### PR TITLE
[v2.0 samples] SDL "keycodes" with "scancodes"

### DIFF
--- a/Samples/2.0/ApiUsage/InstantRadiosity/InstantRadiosityGameState.cpp
+++ b/Samples/2.0/ApiUsage/InstantRadiosity/InstantRadiosityGameState.cpp
@@ -231,38 +231,38 @@ namespace Demo
             const SDL_Keysym &keySym = itor->second;
             const bool reverse = (keySym.mod & (KMOD_LSHIFT|KMOD_RSHIFT)) != 0;
             const float modPerFrame = reverse ? -timeSinceLast : timeSinceLast;
-            if( keySym.sym == SDLK_h )
+            if( keySym.scancode == SDL_SCANCODE_H )
             {
                 mInstantRadiosity->mCellSize += modPerFrame;
                 mInstantRadiosity->mCellSize = Ogre::max( mInstantRadiosity->mCellSize,
                                                           Ogre::Real(0.001f) );
                 needsRebuild = true;
             }
-            if( keySym.sym == SDLK_j )
+            if( keySym.scancode == SDL_SCANCODE_J )
             {
                 mInstantRadiosity->mBias += modPerFrame;
                 mInstantRadiosity->mBias = Ogre::Math::Clamp( mInstantRadiosity->mBias,
                                                               Ogre::Real(0.0f), Ogre::Real(1.0f) );
                 needsRebuild = true;
             }
-            if( keySym.sym == SDLK_u )
+            if( keySym.scancode == SDL_SCANCODE_U )
             {
                 mInstantRadiosity->mVplMaxRange += modPerFrame * 4.0f;
                 changedVplSetting = true;
                 needsIrradianceVolumeRebuild = true;
             }
-            if( keySym.sym == SDLK_i )
+            if( keySym.scancode == SDL_SCANCODE_I )
             {
                 mInstantRadiosity->mVplPowerBoost += modPerFrame * 2.0f;
                 changedVplSetting = true;
                 needsIrradianceVolumeRebuild = true;
             }
-            if( keySym.sym == SDLK_o )
+            if( keySym.scancode == SDL_SCANCODE_O )
             {
                 mInstantRadiosity->mVplThreshold += modPerFrame * 0.05f;
                 changedVplSetting = true;
             }
-            if( keySym.sym == SDLK_p )
+            if( keySym.scancode == SDL_SCANCODE_P )
             {
                 mInstantRadiosity->mVplIntensityRangeMultiplier += modPerFrame * 10.0;
                 mInstantRadiosity->mVplIntensityRangeMultiplier =
@@ -270,7 +270,7 @@ namespace Demo
                 changedVplSetting = true;
                 needsIrradianceVolumeRebuild = true;
             }
-            if( keySym.sym == SDLK_m )
+            if( keySym.scancode == SDL_SCANCODE_M )
             {
                 mIrradianceCellSize += modPerFrame * 10.0f;
                 mIrradianceCellSize = std::max( mIrradianceCellSize, Ogre::Real(0.1f) );
@@ -363,13 +363,13 @@ namespace Demo
     //-----------------------------------------------------------------------------------
     void InstantRadiosityGameState::keyPressed( const SDL_KeyboardEvent &arg )
     {
-        mKeysHold[arg.keysym.sym] = arg.keysym;
+        mKeysHold[arg.keySym.scancode] = arg.keysym;
         TutorialGameState::keyPressed( arg );
     }
     //-----------------------------------------------------------------------------------
     void InstantRadiosityGameState::keyReleased( const SDL_KeyboardEvent &arg )
     {
-        mKeysHold.erase( arg.keysym.sym );
+        mKeysHold.erase( arg.keySym.scancode );
 
         if( (arg.keysym.mod & ~(KMOD_NUM|KMOD_CAPS|KMOD_LSHIFT|KMOD_RSHIFT)) != 0 )
         {
@@ -377,25 +377,25 @@ namespace Demo
             return;
         }
 
-        if( arg.keysym.sym == SDLK_F2 )
+        if( arg.keySym.scancode == SDL_SCANCODE_F2 )
         {
             mInstantRadiosity->setEnableDebugMarkers( !mInstantRadiosity->getEnableDebugMarkers() );
         }
-        else if( arg.keysym.sym == SDLK_F3 )
+        else if( arg.keySym.scancode == SDL_SCANCODE_F3 )
         {
             mCurrentType = static_cast<Ogre::Light::LightTypes>( (mCurrentType + 1) %
                                                                  Ogre::Light::LT_VPL );
             createLight();
             updateIrradianceVolume();
         }
-        else if( arg.keysym.sym == SDLK_F4 )
+        else if( arg.keySym.scancode == SDL_SCANCODE_F4 )
         {
             mInstantRadiosity->mVplUseIntensityForMaxRange =
                     !mInstantRadiosity->mVplUseIntensityForMaxRange;
             mInstantRadiosity->updateExistingVpls();
             updateIrradianceVolume();
         }
-        else if( arg.keysym.sym == SDLK_F5 )
+        else if( arg.keySym.scancode == SDL_SCANCODE_F5 )
         {
             Ogre::HlmsManager *hlmsManager = mGraphicsSystem->getRoot()->getHlmsManager();
             assert( dynamic_cast<Ogre::HlmsPbs*>( hlmsManager->getHlms( Ogre::HLMS_PBS ) ) );
@@ -413,7 +413,7 @@ namespace Demo
                 mInstantRadiosity->setUseIrradianceVolume(false);
             }
         }
-        else if( arg.keysym.sym == SDLK_g )
+        else if( arg.keySym.scancode == SDL_SCANCODE_G )
         {
             const bool reverse = (arg.keysym.mod & (KMOD_LSHIFT|KMOD_RSHIFT)) != 0;
             if( reverse )
@@ -428,7 +428,7 @@ namespace Demo
             mInstantRadiosity->build();
             updateIrradianceVolume();
         }
-        else if( arg.keysym.sym == SDLK_k )
+        else if( arg.keySym.scancode == SDL_SCANCODE_K )
         {
             const bool reverse = (arg.keysym.mod & (KMOD_LSHIFT|KMOD_RSHIFT)) != 0;
             if( reverse )
@@ -445,7 +445,7 @@ namespace Demo
             mInstantRadiosity->build();
             updateIrradianceVolume();
         }
-        else if( arg.keysym.sym == SDLK_l )
+        else if( arg.keySym.scancode == SDL_SCANCODE_L )
         {
             const bool reverse = (arg.keysym.mod & (KMOD_LSHIFT|KMOD_RSHIFT)) != 0;
             if( reverse )

--- a/Samples/2.0/Common/src/CameraController.cpp
+++ b/Samples/2.0/Common/src/CameraController.cpp
@@ -72,20 +72,20 @@ namespace Demo
     //-----------------------------------------------------------------------------------
     bool CameraController::keyPressed( const SDL_KeyboardEvent &arg )
     {
-        if( arg.keysym.sym == SDLK_LSHIFT )
+        if( arg.keysym.scancode == SDL_SCANCODE_LSHIFT )
             mSpeedMofifier = true;
 
-        if( arg.keysym.sym == SDLK_w )
+        if( arg.keysym.scancode == SDL_SCANCODE_W )
             mWASD[0] = true;
-        else if( arg.keysym.sym == SDLK_a )
+        else if( arg.keysym.scancode == SDL_SCANCODE_A )
             mWASD[1] = true;
-        else if( arg.keysym.sym == SDLK_s )
+        else if( arg.keysym.scancode == SDL_SCANCODE_S )
             mWASD[2] = true;
-        else if( arg.keysym.sym == SDLK_d )
+        else if( arg.keysym.scancode == SDL_SCANCODE_D )
             mWASD[3] = true;
-        else if( arg.keysym.sym == SDLK_PAGEUP )
+        else if( arg.keysym.scancode == SDL_SCANCODE_PAGEUP )
             mSlideUpDown[0] = true;
-        else if( arg.keysym.sym == SDLK_PAGEDOWN )
+        else if( arg.keysym.scancode == SDL_SCANCODE_PAGEDOWN )
             mSlideUpDown[1] = true;
         else
             return false;
@@ -95,20 +95,20 @@ namespace Demo
     //-----------------------------------------------------------------------------------
     bool CameraController::keyReleased( const SDL_KeyboardEvent &arg )
     {
-        if( arg.keysym.sym == SDLK_LSHIFT )
+        if( arg.keysym.scancode == SDL_SCANCODE_LSHIFT )
             mSpeedMofifier = false;
 
-        if( arg.keysym.sym == SDLK_w )
+        if( arg.keysym.scancode == SDL_SCANCODE_W )
             mWASD[0] = false;
-        else if( arg.keysym.sym == SDLK_a )
+        else if( arg.keysym.scancode == SDL_SCANCODE_A )
             mWASD[1] = false;
-        else if( arg.keysym.sym == SDLK_s )
+        else if( arg.keysym.scancode == SDL_SCANCODE_S )
             mWASD[2] = false;
-        else if( arg.keysym.sym == SDLK_d )
+        else if( arg.keysym.scancode == SDL_SCANCODE_D )
             mWASD[3] = false;
-        else if( arg.keysym.sym == SDLK_PAGEUP )
+        else if( arg.keysym.scancode == SDL_SCANCODE_PAGEUP )
             mSlideUpDown[0] = false;
-        else if( arg.keysym.sym == SDLK_PAGEDOWN )
+        else if( arg.keysym.scancode == SDL_SCANCODE_PAGEDOWN )
             mSlideUpDown[1] = false;
         else
             return false;

--- a/Samples/2.0/Common/src/TutorialGameState.cpp
+++ b/Samples/2.0/Common/src/TutorialGameState.cpp
@@ -137,7 +137,7 @@ namespace Demo
     //-----------------------------------------------------------------------------------
     void TutorialGameState::keyReleased( const SDL_KeyboardEvent &arg )
     {
-        if( arg.keysym.sym == SDLK_F1 && (arg.keysym.mod & ~(KMOD_NUM|KMOD_CAPS)) == 0 )
+        if( arg.keysym.scancode == SDL_SCANCODE_F1 && (arg.keysym.mod & ~(KMOD_NUM|KMOD_CAPS)) == 0 )
         {
             mDisplayHelpMode = (mDisplayHelpMode + 1) % mNumDisplayHelpModes;
 
@@ -146,7 +146,7 @@ namespace Demo
             mDebugText->setCaption( finalText );
             mDebugTextShadow->setCaption( finalText );
         }
-        else if( arg.keysym.sym == SDLK_F1 && (arg.keysym.mod & (KMOD_LCTRL|KMOD_RCTRL)) )
+        else if( arg.keysym.scancode == SDL_SCANCODE_F1 && (arg.keysym.mod & (KMOD_LCTRL|KMOD_RCTRL)) )
         {
             //Hot reload of PBS shaders. We need to clear the microcode cache
             //to prevent using old compiled versions.
@@ -157,7 +157,7 @@ namespace Demo
             Ogre::GpuProgramManager::getSingleton().clearMicrocodeCache();
             hlms->reloadFrom( hlms->getDataFolder() );
         }
-        else if( arg.keysym.sym == SDLK_F2 && (arg.keysym.mod & (KMOD_LCTRL|KMOD_RCTRL)) )
+        else if( arg.keysym.scancode == SDL_SCANCODE_F2  && (arg.keysym.mod & (KMOD_LCTRL|KMOD_RCTRL)) )
         {
             //Hot reload of Unlit shaders.
             Ogre::Root *root = mGraphicsSystem->getRoot();
@@ -167,7 +167,7 @@ namespace Demo
             Ogre::GpuProgramManager::getSingleton().clearMicrocodeCache();
             hlms->reloadFrom( hlms->getDataFolder() );
         }
-        else if( arg.keysym.sym == SDLK_F3 && (arg.keysym.mod & (KMOD_LCTRL|KMOD_RCTRL)) )
+        else if( arg.keysym.scancode == SDL_SCANCODE_F3 && (arg.keysym.mod & (KMOD_LCTRL|KMOD_RCTRL)) )
         {
             //Hot reload of Unlit shaders.
             Ogre::Root *root = mGraphicsSystem->getRoot();
@@ -177,7 +177,7 @@ namespace Demo
             Ogre::GpuProgramManager::getSingleton().clearMicrocodeCache();
             hlms->reloadFrom( hlms->getDataFolder() );
         }
-        else if( arg.keysym.sym == SDLK_ESCAPE )
+        else if(arg.keysym.scancode == SDL_SCANCODE_ESCAPE)
         {
             mGraphicsSystem->setQuit();
         }


### PR DESCRIPTION
In SDL2, Scancodes were introduced. This keyboard representation does not move around with the keyboard layout and makes everything consistant.

When you use a non-qwerty keyboard, the alpha keys tend to be moved around. Scancodes makes so that, for example, the WASD keys will allways be placed at the right place.

This is a non issue on Windows as it always behaved that way, but on linux, Keycodes respect the current keyboard layout, so international users will have the samples running with the wrong keyboard mapping.

All of the alphabetical keys in the samples source code have been changed to scancodes. I did not change all the function key and other special characters as this will not change anything for theses keys and I wanted to keep the diff short.