### PR TITLE
Add appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: 2.2.{build}
+
+environment:
+  matrix:
+#    - PLATFORM: x86
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      BUILD_SCRIPT: build_ogre_Visual_Studio_15_2017_Win32.bat
+#    - PLATFORM: x86
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      BUILD_SCRIPT: build_ogre_Visual_Studio_14_2015_Win32.bat
+#    - PLATFORM: x86
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+#      BUILD_SCRIPT: build_ogre_Visual_Studio_12_2013_Win32.bat
+#    - PLATFORM: x64
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#      BUILD_SCRIPT: build_ogre_Visual_Studio_15_2017_x64.bat
+#    - PLATFORM: x64
+#      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+#      BUILD_SCRIPT: build_ogre_Visual_Studio_14_2015_x64.bat
+    - PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      BUILD_SCRIPT: build_ogre_Visual_Studio_12_2013_x64.bat
+
+build_script:
+  - cmd: Scripts\BuildScripts\output\%BUILD_SCRIPT%
+


### PR DESCRIPTION
This adds an appveyor.yml file that configure a CI build for MSVC (x64 2013, we can activate more versions by un-commenting the matrix blocks in the yml file) on the AppVeyor service.

AppVeyor needs to be linked from somebody's account with access to OGRECave organization 

After merging this, just create an account on AppVeyor (https://www.appveyor.com/ - you can use GitHub OAuth), link your GitHub to it, and add the OGRECave/ogre-next repo to AppVeyor.

It will build all commits and pull requests on this repo. It's slow but it works...

OpenSouce projects have free unlimited builds on AppVeyor :wink: