### PR TITLE
Shutdown RenderSystemNULL on destruction

### DIFF
--- a/RenderSystems/NULL/include/OgreNULLRenderSystem.h
+++ b/RenderSystems/NULL/include/OgreNULLRenderSystem.h
@@ -63,6 +63,7 @@ namespace Ogre
 
     public:
         NULLRenderSystem();
+        virtual ~NULLRenderSystem(void);
 
         virtual void shutdown(void);
 

--- a/RenderSystems/NULL/src/OgreNULLRenderSystem.cpp
+++ b/RenderSystems/NULL/src/OgreNULLRenderSystem.cpp
@@ -44,6 +44,11 @@ namespace Ogre
     {
     }
     //-------------------------------------------------------------------------
+    NULLRenderSystem::~NULLRenderSystem(void)
+    {
+     shutdown();
+    }
+    //-------------------------------------------------------------------------
     void NULLRenderSystem::shutdown(void)
     {
         OGRE_DELETE mHardwareBufferManager;


### PR DESCRIPTION
RenderSystemNULL wasn't shutting down properly when run in my tests where I create and destroy instances of RenderSystemNULL multiple times.