### PR TITLE
Fixed compiler error in sample on macOS

### DIFF
--- a/Samples/2.0/Tutorials/Tutorial00_Basic/Tutorial00_Basic.cpp
+++ b/Samples/2.0/Tutorials/Tutorial00_Basic/Tutorial00_Basic.cpp
@@ -23,6 +23,9 @@
 
 #include "OgreWindowEventUtilities.h"
 
+#if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
+#   include "OSX/macUtils.h"
+#endif
 static void registerHlms( void )
 {
     using namespace Ogre;


### PR DESCRIPTION
Fixes errors:
```
Samples/2.0/Tutorials/Tutorial00_Basic/Tutorial00_Basic.cpp:32:39: error: no member named 'macBundlePath' in namespace 'Ogre'
    const String resourcePath = Ogre::macBundlePath() + "/Contents/Resources/";
                                ~~~~~~^
Samples/2.0/Tutorials/Tutorial00_Basic/Tutorial00_Basic.cpp:43:29: error: use of undeclared identifier 'macBundlePath'
    String rootHlmsFolder = macBundlePath() + '/' + cf.getSetting( "DoNotUseAsResource", "Hlms", "" );
                            ^
2 errors generated.
```

Running XCode 11 and macOS Mojave