### PR TITLE
Add human-readable name to compositor target definition

### DIFF
--- a/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
+++ b/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
@@ -249,6 +249,8 @@ namespace Ogre
     {
         /// Name is local to Node! (unless using 'global_' prefix)
         IdString                mRenderTargetName;
+        String                  mRenderTargetNameStr;
+
         CompositorPassDefVec    mCompositorPasses;
 
         /// Used for cubemaps and 3D textures.
@@ -266,15 +268,18 @@ namespace Ogre
         CompositorNodeDef       *mParentNodeDef;
 
     public:
-        CompositorTargetDef( IdString renderTargetName, uint32 rtIndex,
+        CompositorTargetDef( String renderTargetName, uint32 rtIndex,
                              CompositorNodeDef *parentNodeDef ) :
                 mRenderTargetName( renderTargetName ),
+                mRenderTargetNameStr( renderTargetName ),
                 mRtIndex( rtIndex ),
                 mShadowMapSupportedLightTypes( 0 ),
                 mParentNodeDef( parentNodeDef ) {}
         ~CompositorTargetDef();
 
         IdString getRenderTargetName() const            { return mRenderTargetName; }
+        String getRenderTargetNameStr() const           { return mRenderTargetNameStr; }
+
         uint32 getRtIndex(void) const                   { return mRtIndex; }
 
         void setShadowMapSupportedLightTypes( uint8 types ) { mShadowMapSupportedLightTypes = types; }

--- a/OgreMain/src/Compositor/OgreCompositorNodeDef.cpp
+++ b/OgreMain/src/Compositor/OgreCompositorNodeDef.cpp
@@ -49,11 +49,7 @@ namespace Ogre
         if( renderTargetName.find( "global_" ) == 0 )
             addTextureSourceName( renderTargetName, 0, TEXTURE_GLOBAL );
 
-        IdString targetName;
-        if( !renderTargetName.empty() )
-            targetName = renderTargetName;
-
-        mTargetPasses.push_back( CompositorTargetDef( targetName, rtIndex, this ) );
+        mTargetPasses.push_back( CompositorTargetDef( renderTargetName, rtIndex, this ) );
         return &mTargetPasses.back();
     }
     //-----------------------------------------------------------------------------------


### PR DESCRIPTION
This PR proposes to add a human-readable copy (`Ogre::String`) of the `CompositorTargetDef::mRenderTargetName`.
This change simplifies a lot the process of cloning a compositor node definition by code (which was impossible before since `CompositorNodeDef::addTargetPass` takes `Ogre::String` as input and `CompositorTargetDef::getRenderTargetName` returns `Ogre::IdString` as output). With this PR is in fact possible to do something like::
```
for (auto i = size_t{0}; i < node->getNumTargetPasses(); ++i)
{
	const auto targetI = node->getTargetPass(i);
	const auto targetICloned = nodeCloned->addTargetPass(targetI->getRenderTargetNameStr(), targetI->getRtIndex());

	// Clone passes
	// ...
}
```