### PR TITLE
Export MetalPlugin and GL3PlusPlugin classes

### DIFF
--- a/RenderSystems/GL3Plus/include/OgreGL3PlusPlugin.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusPlugin.h
@@ -35,7 +35,7 @@ namespace Ogre
 {
 
     /** Plugin instance for GL3Plus Manager */
-    class GL3PlusPlugin : public Plugin
+    class _OgreGL3PlusExport GL3PlusPlugin : public Plugin
     {
     public:
         GL3PlusPlugin();

--- a/RenderSystems/Metal/include/OgreMetalPlugin.h
+++ b/RenderSystems/Metal/include/OgreMetalPlugin.h
@@ -29,13 +29,14 @@ THE SOFTWARE.
 #define _OgreMetalPlugin_H_
 
 #include "OgrePlugin.h"
+#include "OgreMetalPrerequisites.h"
 
 namespace Ogre
 {
     class MetalRenderSystem;
 
     /** Plugin instance for Metal Manager */
-    class MetalPlugin : public Plugin
+    class _OgreMetalExport MetalPlugin : public Plugin
     {
     public:
         MetalPlugin();


### PR DESCRIPTION
On clang, macOS mojave, unless MetalPlugin is exported, dynamic linking yields

```
Undefined symbols for architecture x86_64:
  "Ogre::MetalPlugin::MetalPlugin()", referenced from:
      flexbox::application::application() in application.cpp.2.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Note: The plugin is not loaded at run-time in this case.

Perhaps I should set the other render system plugins to be exported as well?