### PR TITLE
Optionally prefix plugin libraries with `lib` on Unix

### DIFF
--- a/CMake/Utils/OgreConfigTargets.cmake
+++ b/CMake/Utils/OgreConfigTargets.cmake
@@ -271,7 +271,7 @@ function(ogre_config_plugin PLUGINNAME)
   else (OGRE_STATIC)
     if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       # disable "lib" prefix on Unix
-      set_target_properties(${PLUGINNAME} PROPERTIES PREFIX "")
+      set_target_properties(${PLUGINNAME} PROPERTIES PREFIX "${OGRE_PLUGIN_LIB_PREFIX}")
     endif (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif (OGRE_STATIC)
   # export only if static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,6 +450,9 @@ option(OGRE_BUILD_TESTS "Build the unit tests & PlayPen" FALSE)
 option(OGRE_CONFIG_DOUBLE "Use doubles instead of floats in Ogre" FALSE)
 option(OGRE_CONFIG_NODE_INHERIT_TRANSFORM "Tells the node whether it should inherit full transform from it's parent node or derived position, orientation and scale" FALSE)
 
+
+set(OGRE_PLUGIN_LIB_PREFIX "" CACHE STRING "Prefix dynamically linked plugins, e.g. 'lib' (GCC and Clang only)")
+
 if (WINDOWS_STORE OR WINDOWS_PHONE)
 # WinRT can only use the standard allocator
 set(OGRE_CONFIG_ALLOCATOR 1 CACHE STRING "Forcing Standard Allocator for WinRT" FORCE)
@@ -575,6 +578,7 @@ mark_as_advanced(
   OGRE_USE_BOOST
   OGRE_INSTALL_SAMPLES_SOURCE
   OGRE_FULL_RPATH
+  OGRE_PLUGIN_LIB_PREFIX
   OGRE_PROFILING_PROVIDER
   OGRE_CONFIG_STATIC_LINK_CRT
   OGRE_LIB_DIRECTORY


### PR DESCRIPTION
Prior to this commit, building e.g. `RenderSystem_Metal` would output
`RenderSystem_Metal.dylib` on macOS. Normally when using the linker
tool `ld` (which is used by `clang++`)  you'd link using the following command:

```bash
clang++ [...] -lRenderSystem_Metal
```

Then you will get the error:
```
ld: library not found for -lRenderSystem_Metal
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Because `ld` is looking for a library named `libRenderSystem_Metal.dylib` (Note that
`ld` is adding the prefix `lib` to the name of the library.

The 'lib' prefix was originally removed back in 2009 (a9f80807ad9db98bb97fd959587367cdb67fdeff) and not sure why.