### PR TITLE
Enable clickthrough in Metal OSX

### DIFF
--- a/RenderSystems/Metal/src/Windowing/OSX/OgreMetalView.mm
+++ b/RenderSystems/Metal/src/Windowing/OSX/OgreMetalView.mm
@@ -82,6 +82,15 @@ THE SOFTWARE.
     return self;
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent *)theEvent
+{
+    if(self.superview == nil) {
+        return NO;
+    } else {
+        return [self.superview acceptsFirstMouse:theEvent];
+    }
+}
+
 - (void)setContentScaleFactor:(CGFloat)contentScaleFactor
 {
     self.scaleToNative = false;


### PR DESCRIPTION
Problem:
Click on an unfocused window does not work. For example if you want to
press the button it won't handle mouse down.
With SDL2 you can fix that by setting
`SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH` and it will properly set up
clickthrough for `NSWindow`.

But OGRE adds yet another NSView on top of it which does not handle
clickthrough.

Solution:
Make NSView that contains Metal layer mimic the behaviour of parent
NSView.
This way setting `SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH` starts working as
it should.