### PR TITLE
Do XSync right after calling XDestroyWindow

### DIFF
--- a/RenderSystems/GL3Plus/src/windowing/GLX/OgreGLXWindow.cpp
+++ b/RenderSystems/GL3Plus/src/windowing/GLX/OgreGLXWindow.cpp
@@ -96,6 +96,7 @@ namespace Ogre
         if (mWindow)
         {
             XDestroyWindow(xDisplay, mWindow);
+            XSync(xDisplay, false);
         }
 
         if (mContext)


### PR DESCRIPTION
I've hit the following corner case:
- create SDL2 window.
- create Ogre render window and specify `parentWindowHandle`.
- close and destroy Ogre render window.
- close SDL2 parent window.

Get `BadWindow` error due to async XLib nature.
Adding `XSync` makes window destructor more predictable.

Again: would be great to get this PR merged into 2.1 as well.