### PR TITLE
WIP: Updating docs to match build scripts

### DIFF
--- a/Docs/src/SettingUpOgre/SettingUpOgreLinux.md
+++ b/Docs/src/SettingUpOgre/SettingUpOgreLinux.md
@@ -22,11 +22,10 @@
 # Building Dependencies {#BuildingDependenciesLinux}
 
 ```sh
-cd Ogre/Dependencies
+cd Ogre/ogredeps
 mkdir build
 cd build
 cmake ../
-cd build
 make
 make install```
 
@@ -36,19 +35,20 @@ make install```
 We'll create both a Release & Debug configuration that match the ones used in Windows.
 This eases portability and cross platform development.
 ```sh
-cd Ogre
+cd Ogre/ogre-next
+ln -s ../ogredeps/build/ogredeps Dependencies
 mkdir build
 cd build
 mkdir Debug
 mkdir Release
 # Build Debug
 cd Debug
-cmake -D OGRE_DEPENDENCIES_DIR=Dependencies/build/ogredeps -D OGRE_BUILD_SAMPLES2=1 -D OGRE_USE_BOOST=0 -D OGRE_CONFIG_THREAD_PROVIDER=0 -D OGRE_CONFIG_THREADS=0 -D CMAKE_BUILD_TYPE=Debug ../../
+cmake -D OGRE_BUILD_SAMPLES2=1 -D OGRE_USE_BOOST=0 -D OGRE_CONFIG_THREAD_PROVIDER=0 -D OGRE_CONFIG_THREADS=0 -D CMAKE_BUILD_TYPE=Debug ../../
 make
 make install
 # Build Release
 cd ../Release
-cmake -D OGRE_DEPENDENCIES_DIR=Dependencies/build/ogredeps -D OGRE_BUILD_SAMPLES2=1 -D OGRE_USE_BOOST=0 -D OGRE_CONFIG_THREAD_PROVIDER=0 -D OGRE_CONFIG_THREADS=0 -D CMAKE_BUILD_TYPE=Release ../../
+cmake -D OGRE_BUILD_SAMPLES2=1 -D OGRE_USE_BOOST=0 -D OGRE_CONFIG_THREAD_PROVIDER=0 -D OGRE_CONFIG_THREADS=0 -D CMAKE_BUILD_TYPE=Release ../../
 make
 make install
 ```

--- a/Docs/src/SettingUpOgre/SettingUpOgreWindows.md
+++ b/Docs/src/SettingUpOgre/SettingUpOgreWindows.md
@@ -96,9 +96,9 @@ Most dependencies are conveniently stored in its own repository called "ogredeps
 **Command line**:
 ```sh
 mkdir Ogre
-hg clone https://bitbucket.org/sinbad/ogre -r v2-1
 cd Ogre
-hg clone https://bitbucket.org/cabalistic/ogredeps Dependencies
+hg clone https://bitbucket.org/cabalistic/ogredeps ogredeps
+git clone https://github.com/OGRECave/ogre-next
 ```
 
 **Graphical**


### PR DESCRIPTION
So far, I've changed `#DownloadingOgreCommon` and `#BuildingOgreLinux` to match the commands from the build script.

GUI directions still need to be updated.

1. Can someone critique my approach and let me know if I need to change anything?
2. The GUI directions are woefully out of date, at least on Linux. Should we nix them? Update them? What's the right path forward?

Thanks,
David