### PR TITLE
Fix crash when a dynamic probe is destroyed

### DIFF
--- a/Components/Hlms/Pbs/include/Cubemaps/OgreParallaxCorrectedCubemapAuto.h
+++ b/Components/Hlms/Pbs/include/Cubemaps/OgreParallaxCorrectedCubemapAuto.h
@@ -103,6 +103,8 @@ namespace Ogre
                                       const CompositorWorkspaceDef *probeWorkspaceDef );
         ~ParallaxCorrectedCubemapAuto();
 
+        virtual void destroyProbe( CubemapProbe *probe );
+
         void setListener( ParallaxCorrectedCubemapAutoListener *listener ) { mListener = listener; }
         ParallaxCorrectedCubemapAutoListener *getListener( void ) const { return mListener; }
 

--- a/Components/Hlms/Pbs/include/Cubemaps/OgreParallaxCorrectedCubemapBase.h
+++ b/Components/Hlms/Pbs/include/Cubemaps/OgreParallaxCorrectedCubemapBase.h
@@ -73,7 +73,7 @@ namespace Ogre
 
         /// Adds a cubemap probe.
         CubemapProbe* createProbe(void);
-        void destroyProbe( CubemapProbe *probe );
+        virtual void destroyProbe( CubemapProbe *probe );
         virtual void destroyAllProbes(void);
 
         /// Destroys the Proxy Items. Useful if you need to call sceneManager->clearScene();

--- a/Components/Hlms/Pbs/src/Cubemaps/OgreParallaxCorrectedCubemapAuto.cpp
+++ b/Components/Hlms/Pbs/src/Cubemaps/OgreParallaxCorrectedCubemapAuto.cpp
@@ -96,6 +96,17 @@ namespace Ogre
         destroyAllProbes();
     }
     //-----------------------------------------------------------------------------------
+    void ParallaxCorrectedCubemapAuto::destroyProbe( CubemapProbe *probe )
+    {
+        CubemapProbeVec::iterator itor = std::find( mDirtyProbes.begin(), mDirtyProbes.end(), probe );
+        if( itor != mDirtyProbes.end() )
+        {
+            efficientVectorRemove( mDirtyProbes, itor );
+        }
+
+        ParallaxCorrectedCubemapBase::destroyProbe( probe );
+    }
+    //-----------------------------------------------------------------------------------
     void ParallaxCorrectedCubemapAuto::createCubemapToDpmWorkspaceDef(
             CompositorManager2 *compositorManager, TextureGpu *cubeTexture )
     {


### PR DESCRIPTION
The crash happens during update, after having removed a dynamic probe, because the content of `mDirtyProbes ` _doesn't match_ the content of `mProbes`. And then this cause that a no more existent probe is tried to render.