### PR TITLE
Implemented Light Buffers

### DIFF
--- a/Components/Hlms/Pbs/include/OgreHlmsPbs.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbs.h
@@ -118,6 +118,9 @@ namespace Ogre
 
         PassData                mPreparedPass;
         ConstBufferPackedVec    mPassBuffers;
+        ConstBufferPackedVec    mLight0Buffers; // lights
+        ConstBufferPackedVec    mLight1Buffers; // areaApproxLights
+        ConstBufferPackedVec    mLight2Buffers; // areaLtcLights
         HlmsSamplerblock const  *mShadowmapSamplerblock;    /// GL3+ only when not using depth textures
         HlmsSamplerblock const  *mShadowmapCmpSamplerblock; /// For depth textures & D3D11
         HlmsSamplerblock const  *mShadowmapEsmSamplerblock; /// For ESM.
@@ -157,7 +160,7 @@ namespace Ogre
 #endif
         TextureGpu              *mAreaLightMasks;
         HlmsSamplerblock const  *mAreaLightMasksSamplerblock;
-        LightArray				mAreaLights;
+        LightArray                mAreaLights;
         bool                    mUsingAreaLightMasks;
 
         bool                    mSkipRequestSlotInChangeRS;
@@ -188,6 +191,8 @@ namespace Ogre
         bool mUseObbRestraintAreaApprox;
         bool mUseObbRestraintAreaLtc;
 #endif
+
+        bool mUseLightBuffers;
 
         ShadowFilter    mShadowFilter;
         uint16          mEsmK; /// K parameter for ESM.
@@ -391,6 +396,9 @@ namespace Ogre
         bool getUseObbRestraintsAreaLtc(void) const         { return mUseObbRestraintAreaLtc; }
 #endif
 
+        void setUseLightBuffers(bool b);
+        bool getUseLightBuffers() { return mUseLightBuffers; }
+
 #if !OGRE_NO_JSON
         /// @copydoc Hlms::_loadJson
         virtual void _loadJson( const rapidjson::Value &jsonValue, const HlmsJson::NamedBlocks &blocks,
@@ -409,6 +417,8 @@ namespace Ogre
 
     struct _OgreHlmsPbsExport PbsProperty
     {
+        static const IdString useLightBuffers;
+    
         static const IdString HwGammaRead;
         static const IdString HwGammaWrite;
         static const IdString MaterialsPerBuffer;

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
@@ -270,21 +270,21 @@ INLINE float LTC_Evaluate( float3 N, float3 V, float3 P, float3x3 Minv,
 
 @property( hlms_lights_area_ltc )
 @piece( DoAreaLtcLights )
-for( int i=0; i<floatBitsToInt( passBuf.numAreaLtcLights ); ++i )
+for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 {
-	lightDir = passBuf.areaLtcLights[i].position.xyz - inPs.pos;
+	lightDir = light2Buf.areaLtcLights[i].position.xyz - inPs.pos;
 	fDistance = length( lightDir );
 
 	@property( obb_restraint_ltc )
-		float3 obbFadeFactorLtc = float3( passBuf.areaLtcLights[i].points[1].w,
-										  passBuf.areaLtcLights[i].points[2].w,
-										  passBuf.areaLtcLights[i].points[3].w );
-		float obbRestraintFade = getObbRestraintFade( passBuf.areaLtcLights[i].obbRestraint, inPs.pos,
+		float3 obbFadeFactorLtc = float3( light2Buf.areaLtcLights[i].points[1].w,
+										  light2Buf.areaLtcLights[i].points[2].w,
+										  light2Buf.areaLtcLights[i].points[3].w );
+		float obbRestraintFade = getObbRestraintFade( light2Buf.areaLtcLights[i].obbRestraint, inPs.pos,
 													  obbFadeFactorLtc );
 		@piece( obbRestraintTestLtc )&& obbRestraintFade > 0.0@end
 	@end
 
-	if( fDistance <= passBuf.areaLtcLights[i].diffuse.w
+	if( fDistance <= light2Buf.areaLtcLights[i].diffuse.w
 		@insertpiece( obbRestraintTestLtc )
 		@insertpiece( andObjAreaLtcLightMaskCmp ) )
 	{
@@ -300,17 +300,17 @@ for( int i=0; i<floatBitsToInt( passBuf.numAreaLtcLights ); ++i )
 			float3(ltc0.z, 0, ltc0.w)
 		);
 
-		bool doubleSidedLtc = passBuf.areaLtcLights[i].specular.w != 0.0f;
+		bool doubleSidedLtc = light2Buf.areaLtcLights[i].specular.w != 0.0f;
 
 		@property( !fresnel_scalar )
 			float ltcSpecular = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
-											  passBuf.areaLtcLights[i].points, doubleSidedLtc );
+											  light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 			// BRDF shadowing and Fresnel
 			ltcSpecular *= pixelData.F0 * ltc1.x + (1.0 - pixelData.F0) * ltc1.y;
 		@else
 			float3 ltcSpecular;
 			ltcSpecular.x = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
-										  passBuf.areaLtcLights[i].points, doubleSidedLtc );
+										  light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 			ltcSpecular.yz = ltcSpecular.xx;
 			// BRDF shadowing and Fresnel
 			ltcSpecular.xyz *= pixelData.F0.xyz * ltc1.x + (1.0 - pixelData.F0.xyz) * ltc1.y;
@@ -318,15 +318,15 @@ for( int i=0; i<floatBitsToInt( passBuf.numAreaLtcLights ); ++i )
 
 		float ltcDiffuse = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz,
 										 buildFloat3x3( float3( 1, 0, 0 ), float3( 0, 1, 0 ), float3( 0, 0, 1 ) ),
-										 passBuf.areaLtcLights[i].points, doubleSidedLtc );
+										 light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 
 		@property( obb_restraint_ltc )
 			ltcDiffuse	*= obbRestraintFade;
 			ltcSpecular	*= obbRestraintFade;
 		@end
 
-		finalColour += passBuf.areaLtcLights[i].diffuse.xyz * ltcDiffuse * pixelData.diffuse.xyz;
-		finalColour += passBuf.areaLtcLights[i].specular.xyz * ltcSpecular * pixelData.specular.xyz;
+		finalColour += light2Buf.areaLtcLights[i].diffuse.xyz * ltcDiffuse * pixelData.diffuse.xyz;
+		finalColour += light2Buf.areaLtcLights[i].specular.xyz * ltcSpecular * pixelData.specular.xyz;
 	}
 }
 @end

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
@@ -31,39 +31,39 @@
 
 	float3 projectedPosInPlane;
 
-	for( int i=0; i<floatBitsToInt( passBuf.numAreaApproxLights ); ++i )
+	for( int i=0; i<floatBitsToInt( light1Buf.numAreaApproxLights ); ++i )
 	{
-		lightDir = passBuf.areaApproxLights[i].position.xyz - inPs.pos;
-		projectedPosInPlane.xyz = inPs.pos - dot( -lightDir.xyz, passBuf.areaApproxLights[i].direction.xyz ) *
-											 passBuf.areaApproxLights[i].direction.xyz;
+		lightDir = light1Buf.areaApproxLights[i].position.xyz - inPs.pos;
+		projectedPosInPlane.xyz = inPs.pos - dot( -lightDir.xyz, light1Buf.areaApproxLights[i].direction.xyz ) *
+											 light1Buf.areaApproxLights[i].direction.xyz;
 		fDistance = length( lightDir );
 
 		@property( obb_restraint_approx )
-			float obbRestraintFade = getObbRestraintFade( passBuf.areaApproxLights[i].obbRestraint, inPs.pos,
-														  passBuf.areaApproxLights[i].obbFadeFactorApprox.xyz );
+			float obbRestraintFade = getObbRestraintFade( light1Buf.areaApproxLights[i].obbRestraint, inPs.pos,
+														  light1Buf.areaApproxLights[i].obbFadeFactorApprox.xyz );
 			@piece( obbRestraintTestApprox )&& obbRestraintFade > 0.0@end
 		@end
 
-		if( fDistance <= passBuf.areaApproxLights[i].attenuation.x
+		if( fDistance <= light1Buf.areaApproxLights[i].attenuation.x
 			@insertpiece( obbRestraintTestApprox )
-		/*&& dot( -lightDir, passBuf.areaApproxLights[i].direction.xyz ) > 0*/ @insertpiece( andObjAreaApproxLightMaskCmp ) )
+		/*&& dot( -lightDir, light1Buf.areaApproxLights[i].direction.xyz ) > 0*/ @insertpiece( andObjAreaApproxLightMaskCmp ) )
 		{
-			projectedPosInPlane.xyz -= passBuf.areaApproxLights[i].position.xyz;
-			float3 areaLightBitangent = cross( passBuf.areaApproxLights[i].direction.xyz,
-											   passBuf.areaApproxLights[i].tangent.xyz );
-			float2 invHalfRectSize = float2( passBuf.areaApproxLights[i].direction.w,
-											 passBuf.areaApproxLights[i].tangent.w );
+			projectedPosInPlane.xyz -= light1Buf.areaApproxLights[i].position.xyz;
+			float3 areaLightBitangent = cross( light1Buf.areaApproxLights[i].direction.xyz,
+											   light1Buf.areaApproxLights[i].tangent.xyz );
+			float2 invHalfRectSize = float2( light1Buf.areaApproxLights[i].direction.w,
+											 light1Buf.areaApproxLights[i].tangent.w );
 			//lightUV is in light space, in range [-0.5; 0.5]
 			float2 lightUVForTex;
 			float2 lightUV;
-			lightUV.x = dot( projectedPosInPlane.xyz, passBuf.areaApproxLights[i].tangent.xyz );
+			lightUV.x = dot( projectedPosInPlane.xyz, light1Buf.areaApproxLights[i].tangent.xyz );
 			lightUV.y = dot( projectedPosInPlane.xyz, areaLightBitangent );
 			lightUV.xy *= invHalfRectSize.xy /*/ sqrt( fDistance )*/;
 			//Displace the UV by the normal to account for edge cases when
 			//a surface is close and perpendicular to the light. This is fully a hack and
 			//the values (e.g. 0.25) is completely eye balled.
 			lightUVForTex.xy = lightUV.xy;
-			lightUV.xy += float2( dot( passBuf.areaApproxLights[i].tangent.xyz, pixelData.normal ),
+			lightUV.xy += float2( dot( light1Buf.areaApproxLights[i].tangent.xyz, pixelData.normal ),
 								  dot( areaLightBitangent, pixelData.normal ) ) * 3.75 * invHalfRectSize.xy;
 			lightUV.xy = clamp( lightUV.xy, -0.5f, 0.5f );
 			lightUVForTex = clamp( lightUVForTex.xy, -0.5f, 0.5f );
@@ -77,21 +77,21 @@
 			float3 diffuseMask = float3( 1.0f, 1.0f, 1.0f );
 		@end
 		@property( hlms_lights_area_tex_mask )
-			if( i < floatBitsToInt( passBuf.numAreaApproxLightsWithMask ) )
+			if( i < floatBitsToInt( light1Buf.numAreaApproxLightsWithMask ) )
 			{
 				// 1 / (1 - 0.02) = 1.020408163
-				float diffuseMipsLeft = passBuf.areaLightNumMipmapsSpecFactor * 0.5 -
-										passBuf.areaLightDiffuseMipmapStart * 1.020408163f;
+				float diffuseMipsLeft = light1Buf.areaLightNumMipmapsSpecFactor * 0.5 -
+										light1Buf.areaLightDiffuseMipmapStart * 1.020408163f;
 				diffuseMask = OGRE_SampleArray2DLevel( areaLightMasks, areaLightMasksSampler,
 													   lightUVForTex + 0.5f,
-													   passBuf.areaApproxLights[i].attenuation.w,
-													   passBuf.areaLightDiffuseMipmapStart +
+													   light1Buf.areaApproxLights[i].attenuation.w,
+													   light1Buf.areaLightDiffuseMipmapStart +
 													   (pixelData.roughness - 0.02f) * diffuseMipsLeft ).AREA_LIGHTS_TEX_SWIZZLE;
 			}
 		@end
 
-			float3 closestPoint = passBuf.areaApproxLights[i].position.xyz +
-					passBuf.areaApproxLights[i].tangent.xyz * lightUV.x / invHalfRectSize.x +
+			float3 closestPoint = light1Buf.areaApproxLights[i].position.xyz +
+					light1Buf.areaApproxLights[i].tangent.xyz * lightUV.x / invHalfRectSize.x +
 					areaLightBitangent.xyz * lightUV.y / invHalfRectSize.y;
 
 			float3 lightDir2 = lightDir / fDistance;
@@ -99,21 +99,21 @@
 			fDistance= length( lightDir );
 
 			float3 toShapeLight = reflect( -pixelData.viewDir, pixelData.normal );
-			float denom = dot( toShapeLight, -passBuf.areaApproxLights[i].direction.xyz );
+			float denom = dot( toShapeLight, -light1Buf.areaApproxLights[i].direction.xyz );
 			@property( !hlms_lights_area_tex_mask || !hlms_lights_area_tex_colour )
 				float specCol = 0;
 			@else
 				float3 specCol = float3( 0, 0, 0 );
 			@end
-			if( denom > 1e-6f || passBuf.areaApproxLights[i].doubleSided.x != 0.0f )
+			if( denom > 1e-6f || light1Buf.areaApproxLights[i].doubleSided.x != 0.0f )
 			{
-				float3 p0l0 = passBuf.areaApproxLights[i].position.xyz - inPs.pos;
-				float t = dot( p0l0, -passBuf.areaApproxLights[i].direction.xyz ) / denom;
+				float3 p0l0 = light1Buf.areaApproxLights[i].position.xyz - inPs.pos;
+				float t = dot( p0l0, -light1Buf.areaApproxLights[i].direction.xyz ) / denom;
 				if( t >= 0 )
 				{
-					float3 posInShape = inPs.pos.xyz + toShapeLight.xyz * t - passBuf.areaApproxLights[i].position.xyz;
+					float3 posInShape = inPs.pos.xyz + toShapeLight.xyz * t - light1Buf.areaApproxLights[i].position.xyz;
 					float2 reflClipSpace;
-					reflClipSpace.x = dot( passBuf.areaApproxLights[i].tangent.xyz, posInShape );
+					reflClipSpace.x = dot( light1Buf.areaApproxLights[i].tangent.xyz, posInShape );
 					reflClipSpace.y = dot( areaLightBitangent, posInShape );
 
 					float specVal;
@@ -131,29 +131,29 @@
 					@end
 
 					@property( hlms_lights_area_tex_mask )
-						if( i < floatBitsToInt( passBuf.numAreaApproxLightsWithMask ) )
+						if( i < floatBitsToInt( light1Buf.numAreaApproxLightsWithMask ) )
 						{
 							specCol *= OGRE_SampleArray2DLevel( areaLightMasks, areaLightMasksSampler,
 																reflClipSpace * invHalfRectSize + 0.5f,
-																passBuf.areaApproxLights[i].attenuation.w,
+																light1Buf.areaApproxLights[i].attenuation.w,
 																(pixelData.roughness - 0.02f) *
-																passBuf.areaLightNumMipmapsSpecFactor ).AREA_LIGHTS_TEX_SWIZZLE;
+																light1Buf.areaLightNumMipmapsSpecFactor ).AREA_LIGHTS_TEX_SWIZZLE;
 						}
 					@end
 				}
 			}
 
 			lightDir *= 1.0 / fDistance;
-			//float fAreaW = dot( lightDir, -passBuf.areaApproxLights[i].direction.xyz ) * 0.5f + 0.5f;
-			//lightDir = (-passBuf.areaApproxLights[i].direction.xyz + lightDir) * 0.50f;
+			//float fAreaW = dot( lightDir, -light1Buf.areaApproxLights[i].direction.xyz ) * 0.5f + 0.5f;
+			//lightDir = (-light1Buf.areaApproxLights[i].direction.xyz + lightDir) * 0.50f;
 			//lightDir = lerp( lightDir2, lightDir, fAreaW );
-			float globalDot = saturate( dot( -lightDir, passBuf.areaApproxLights[i].direction.xyz ) );
-			globalDot = passBuf.areaApproxLights[i].doubleSided.x != 0.0f ? 1.0f : globalDot;
+			float globalDot = saturate( dot( -lightDir, light1Buf.areaApproxLights[i].direction.xyz ) );
+			globalDot = light1Buf.areaApproxLights[i].doubleSided.x != 0.0f ? 1.0f : globalDot;
 			tmpColour = BRDF_AreaLightApprox( lightDir,
-											  passBuf.areaApproxLights[i].diffuse.xyz * diffuseMask,
-											  passBuf.areaApproxLights[i].specular.xyz * specCol,
+											  light1Buf.areaApproxLights[i].diffuse.xyz * diffuseMask,
+											  light1Buf.areaApproxLights[i].specular.xyz * specCol,
 											  pixelData ) * ( globalDot * globalDot ) * booster;
-			float atten = 1.0 / (0.5 + (passBuf.areaApproxLights[i].attenuation.y + passBuf.areaApproxLights[i].attenuation.z * fDistance) * fDistance );
+			float atten = 1.0 / (0.5 + (light1Buf.areaApproxLights[i].attenuation.y + light1Buf.areaApproxLights[i].attenuation.z * fDistance) * fDistance );
 
 			@property( obb_restraint_approx )
 				atten *= obbRestraintFade;

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -242,22 +242,22 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
 
 @property( hlms_fine_light_mask )
     @property( syntax != hlsl )
-        @piece( ObjLightMaskCmp )if( (objLightMask & floatBitsToUint( passBuf.lights[@counter(fineMaskLightIdx)].position.w )) != 0u )@end
+        @piece( ObjLightMaskCmp )if( (objLightMask & floatBitsToUint( light0Buf.lights[@counter(fineMaskLightIdx)].position.w )) != 0u )@end
         @property( hlms_static_branch_lights )
-            @piece( ObjLightMaskCmpNonCasterLoop )if( (objLightMask & floatBitsToUint( passBuf.lights[@value(fineMaskLightIdx) + i].position.w )) != 0u )@end
+            @piece( ObjLightMaskCmpNonCasterLoop )if( (objLightMask & floatBitsToUint( light0Buf.lights[@value(fineMaskLightIdx) + i].position.w )) != 0u )@end
             @piece( ObjLightMaskCmpNonCasterLoopEnd )@add( fineMaskLightIdx, hlms_lights_directional_non_caster )@end
         @end
-        @piece( andObjLightMaskCmp )&& ((objLightMask & floatBitsToUint( passBuf.lights[@counter(fineMaskLightIdx)].position.w )) != 0u)@end
-        @piece( andObjAreaApproxLightMaskCmp )&& ((objLightMask & floatBitsToUint( passBuf.areaApproxLights[i].position.w )) != 0u)@end
-        @piece( andObjAreaLtcLightMaskCmp )&& ((objLightMask & floatBitsToUint( passBuf.areaLtcLights[i].position.w )) != 0u)@end
+        @piece( andObjLightMaskCmp )&& ((objLightMask & floatBitsToUint( light0Buf.lights[@counter(fineMaskLightIdx)].position.w )) != 0u)@end
+        @piece( andObjAreaApproxLightMaskCmp )&& ((objLightMask & floatBitsToUint( light1Buf.areaApproxLights[i].position.w )) != 0u)@end
+        @piece( andObjAreaLtcLightMaskCmp )&& ((objLightMask & floatBitsToUint( light2Buf.areaLtcLights[i].position.w )) != 0u)@end
     @else
-        @piece( ObjLightMaskCmp )if( (objLightMask & passBuf.lights[@counter(fineMaskLightIdx)].lightMask) != 0u )@end
+        @piece( ObjLightMaskCmp )if( (objLightMask & light0Buf.lights[@counter(fineMaskLightIdx)].lightMask) != 0u )@end
         @property( hlms_static_branch_lights )
-            @piece( ObjLightMaskCmpNonCasterLoop )if( (objLightMask & passBuf.lights[@value(fineMaskLightIdx) + i].lightMask) != 0u )@end
+            @piece( ObjLightMaskCmpNonCasterLoop )if( (objLightMask & light0Buf.lights[@value(fineMaskLightIdx) + i].lightMask) != 0u )@end
             @piece( ObjLightMaskCmpNonCasterLoopEnd )@add( fineMaskLightIdx, hlms_lights_directional_non_caster )@end
         @end
-        @piece( andObjLightMaskCmp )&& ((objLightMask & passBuf.lights[@counter(fineMaskLightIdx)].lightMask) != 0u)@end
-        @piece( andObjAreaApproxLightMaskCmp )&& ((objLightMask & passBuf.areaApproxLights[i].lightMask) != 0u)@end
-        @piece( andObjAreaLtcLightMaskCmp )&& ((objLightMask & passBuf.areaLtcLights[i].lightMask) != 0u)@end
+        @piece( andObjLightMaskCmp )&& ((objLightMask & light0Buf.lights[@counter(fineMaskLightIdx)].lightMask) != 0u)@end
+        @piece( andObjAreaApproxLightMaskCmp )&& ((objLightMask & light1Buf.areaApproxLights[i].lightMask) != 0u)@end
+        @piece( andObjAreaLtcLightMaskCmp )&& ((objLightMask & light2Buf.areaLtcLights[i].lightMask) != 0u)@end
     @end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
@@ -165,9 +165,13 @@ CONST_BUFFER_STRUCT_BEGIN( PassBuffer, 0 )
 	float pssmBlendPoints@n;@end @end
 @property( hlms_pssm_fade )
 	float pssmFadePoint;@end
+
+@property( !use_light_buffers )
 	@property( hlms_lights_spot )Light lights[@value(hlms_lights_spot)];@end
 	@property( hlms_lights_area_approx )AreaLight areaApproxLights[@value(hlms_lights_area_approx)];@end
 	@property( hlms_lights_area_ltc )AreaLtcLight areaLtcLights[@value(hlms_lights_area_ltc)];@end
+@end // !use_light_buffers
+
 @end @property( hlms_shadowcaster )
 	//Vertex shader
 	@property( exponential_shadow_maps )float4 viewZRow;@end
@@ -215,11 +219,46 @@ CONST_BUFFER_STRUCT_BEGIN( PassBuffer, 0 )
 #define aspectRatio		aspectRatio_unused3.x
 }
 CONST_BUFFER_STRUCT_END( passBuf );
+
+@property( use_light_buffers )
+
+CONST_BUFFER_STRUCT_BEGIN( Light0Buffer, 4 )
+{
+	Light lights[16];
+}
+CONST_BUFFER_STRUCT_END( light0Buf );
+
+CONST_BUFFER_STRUCT_BEGIN( Light1Buffer, 5 )
+{
+	AreaLight areaApproxLights[2];
+}
+CONST_BUFFER_STRUCT_END( light1Buf );
+
+CONST_BUFFER_STRUCT_BEGIN( Light2Buffer, 6 )
+{
+	AreaLtcLight areaLtcLights[2];
+}
+CONST_BUFFER_STRUCT_END( light2Buf );
+
+
+@else
+
+#define light0Buf		passBuf
+#define light1Buf		passBuf
+#define light2Buf		passBuf
+
+@end // use_light_buffers
+
 @end
 
 @property( syntax == metal )
 	@piece( PassDecl )
 	, constant PassBuffer &passBuf [[buffer(CONST_SLOT_START+0)]]
+	@property( use_light_buffers )
+	, constant Light0Buffer &light0Buf [[buffer(CONST_SLOT_START+4)]]
+	, constant Light1Buffer &light1Buf [[buffer(CONST_SLOT_START+5)]]
+	, constant Light2Buffer &light2Buf [[buffer(CONST_SLOT_START+6)]]
+	@end // use_light_buffers
 	@end
 @end
 

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -419,22 +419,22 @@
 @piece( DoDirectionalLights )
 	@property( hlms_lights_directional )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( passBuf.lights[0].position.xyz, passBuf.lights[0].diffuse.xyz, passBuf.lights[0].specular, pixelData ) @insertpiece( DarkenWithShadowFirstLight );
+			finalColour += BRDF( light0Buf.lights[0].position.xyz, light0Buf.lights[0].diffuse.xyz, light0Buf.lights[0].specular, pixelData ) @insertpiece( DarkenWithShadowFirstLight );
 	@end
 	@foreach( hlms_lights_directional, n, 1 )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( passBuf.lights[@n].position.xyz, passBuf.lights[@n].diffuse.xyz, passBuf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadow );@end
+			finalColour += BRDF( light0Buf.lights[@n].position.xyz, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadow );@end
 
 	@property( !hlms_static_branch_lights )
 		@foreach( hlms_lights_directional_non_caster, n, hlms_lights_directional )
 			@insertpiece( ObjLightMaskCmp )
-				finalColour += BRDF( passBuf.lights[@n].position.xyz, passBuf.lights[@n].diffuse.xyz, passBuf.lights[@n].specular, pixelData );@end
+				finalColour += BRDF( light0Buf.lights[@n].position.xyz, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData );@end
 	@else
-		for( int n=0; n<floatBitsToInt( passBuf.numNonCasterDirectionalLights ); ++n )
+		for( int n=0; n<floatBitsToInt( light0Buf.numNonCasterDirectionalLights ); ++n )
 		{
 			int i = @value( hlms_lights_directional ) + n;
 			@insertpiece( ObjLightMaskCmpNonCasterLoop )
-				finalColour += BRDF( passBuf.lights[i].position.xyz, passBuf.lights[i].diffuse.xyz, passBuf.lights[i].specular, pixelData );
+				finalColour += BRDF( light0Buf.lights[i].position.xyz, light0Buf.lights[i].diffuse.xyz, light0Buf.lights[i].specular, pixelData );
 		}
 		/// Increase fineMaskLightIdx to keep it working with spot/point lights
 		@insertpiece( ObjLightMaskCmpNonCasterLoopEnd )
@@ -444,13 +444,13 @@
 //Point lights
 @piece( DoPointLights )
 	@foreach( hlms_lights_point, n, hlms_lights_directional_non_caster )
-		lightDir = passBuf.lights[@n].position.xyz - inPs.pos;
+		lightDir = light0Buf.lights[@n].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
-		if( fDistance <= passBuf.lights[@n].attenuation.x @insertpiece( andObjLightMaskCmp ) )
+		if( fDistance <= light0Buf.lights[@n].attenuation.x @insertpiece( andObjLightMaskCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( lightDir, passBuf.lights[@n].diffuse.xyz, passBuf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadowPoint );
-			float atten = 1.0 / (0.5 + (passBuf.lights[@n].attenuation.y + passBuf.lights[@n].attenuation.z * fDistance) * fDistance );
+			tmpColour = BRDF( lightDir, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadowPoint );
+			float atten = 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance );
 			finalColour += tmpColour * atten;
 		}
 	@end
@@ -462,25 +462,25 @@
 //spotParams[@value(spot_params)].z = falloff
 @piece( DoSpotLights )
 	@foreach( hlms_lights_spot, n, hlms_lights_point )
-		lightDir = passBuf.lights[@n].position.xyz - inPs.pos;
+		lightDir = light0Buf.lights[@n].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
 		@property( !hlms_lights_spot_textured )
-			spotCosAngle = dot( -lightDir, passBuf.lights[@n].spotDirection.xyz );
+			spotCosAngle = dot( -lightDir, light0Buf.lights[@n].spotDirection.xyz );
 		@else
-			spotCosAngle = dot( -lightDir, zAxis( passBuf.lights[@n].spotQuaternion ) );
+			spotCosAngle = dot( -lightDir, zAxis( light0Buf.lights[@n].spotQuaternion ) );
 		@end
-		if( fDistance <= passBuf.lights[@n].attenuation.x && spotCosAngle >= passBuf.lights[@n].spotParams.y @insertpiece( andObjLightMaskCmp ) )
+		if( fDistance <= light0Buf.lights[@n].attenuation.x && spotCosAngle >= light0Buf.lights[@n].spotParams.y @insertpiece( andObjLightMaskCmp ) )
 		{
 			@property( hlms_lights_spot_textured )
 				float3 posInLightSpace = qmul( spotQuaternion[@value(spot_params)], inPs.pos );
 				float spotAtten = texture( texSpotLight, normalize( posInLightSpace ).xy ).x; //TODO
 			@else
-				float spotAtten = saturate( (spotCosAngle - passBuf.lights[@n].spotParams.y) * passBuf.lights[@n].spotParams.x );
-				spotAtten = pow( spotAtten, passBuf.lights[@n].spotParams.z );
+				float spotAtten = saturate( (spotCosAngle - light0Buf.lights[@n].spotParams.y) * light0Buf.lights[@n].spotParams.x );
+				spotAtten = pow( spotAtten, light0Buf.lights[@n].spotParams.z );
 			@end
-			tmpColour = BRDF( lightDir, passBuf.lights[@n].diffuse.xyz, passBuf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadow );
-			float atten = 1.0 / (0.5 + (passBuf.lights[@n].attenuation.y + passBuf.lights[@n].attenuation.z * fDistance) * fDistance );
+			tmpColour = BRDF( lightDir, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadow );
+			float atten = 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 	@end

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -352,7 +352,7 @@
 	@pset( CurrentPointLight, hlms_lights_directional_non_caster )
 	@piece( DarkenWithShadowPoint )
 		* getShadowPoint( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
-						  inPs.pos.xyz, passBuf.lights[@counter(CurrentPointLight)].position.xyz,
+						  inPs.pos.xyz, light0Buf.lights[@counter(CurrentPointLight)].position.xyz,
 						  passBuf.shadowRcv[@value(CurrentShadowMap)].invShadowMapSize,
 						  passBuf.shadowRcv[@value(CurrentShadowMap)].shadowDepthRange.xy
 						  hlms_shadowmap@counter(CurrentShadowMap)_uv_param PASSBUF_ARG )


### PR DESCRIPTION
Moved 3 light arrays out of pass buffer and create 3 separate const buffers), which greatly reduces D3D11 shader compilation times when you have many forward lights. When disabled, the performance hit should be minimal. You need to use setUseLightBuffers() on initialization and don't toggle it at runtime.