### PR TITLE
Pad cubemap probe area and shape in the same way

### DIFF
--- a/Components/Hlms/Pbs/src/Cubemaps/OgreCubemapProbe.cpp
+++ b/Components/Hlms/Pbs/src/Cubemaps/OgreCubemapProbe.cpp
@@ -436,7 +436,11 @@ namespace Ogre
         mOrientation        = orientation;
         mInvOrientation     = mOrientation.Inverse();
         mProbeShape         = probeShape;
-        mProbeShape.mHalfSize *= 1.005; //Add some padding.
+
+        //Add some padding.
+        Real padding = 1.005f;
+        mArea.mHalfSize *= padding;
+        mProbeShape.mHalfSize *= padding;
 
         mAreaInnerRegion.makeCeil( Vector3::ZERO );
         mAreaInnerRegion.makeFloor( Vector3::UNIT_SCALE );


### PR DESCRIPTION
Not doing so, can cause "lit noise" with per-pixel PCC in some scenario. E.g., when the same `Aabb` is used for `area` as well as `probeShabe` in `CubemapProbe::set` method and a pixel to be lit resides on probe shape edges.
![picturemessage_ieqxfddj p2p](https://user-images.githubusercontent.com/7291478/72515341-03c4f500-3850-11ea-8f7d-424c90729a36.png)
