### PR TITLE
Workspace multiple listeners

### DIFF
--- a/Components/Hlms/Pbs/src/Cubemaps/OgreCubemapProbe.cpp
+++ b/Components/Hlms/Pbs/src/Cubemaps/OgreCubemapProbe.cpp
@@ -410,7 +410,7 @@ namespace Ogre
         channels.push_back( ibl );
         mWorkspace =
             compositorManager->addWorkspace( sceneManager, channels, mCamera, mWorkspaceDefName, false );
-        mWorkspace->setListener( mCreator );
+        mWorkspace->addListener( mCreator );
 
         if( !mStatic && !mCreator->getAutomaticMode() )
         {

--- a/Components/Hlms/Pbs/src/Cubemaps/OgreParallaxCorrectedCubemap.cpp
+++ b/Components/Hlms/Pbs/src/Cubemaps/OgreParallaxCorrectedCubemap.cpp
@@ -507,7 +507,7 @@ namespace Ogre
                                                            mBlendProxyCamera,
                                                            workspaceName,
                                                            false );
-        mBlendWorkspace->setListener( this );
+        mBlendWorkspace->addListener( this );
 
         workspaceName = "AutoGen_ParallaxCorrectedCubemapCopy_Workspace";
         mCopyWorkspace = compositorManager->addWorkspace( mSceneManager,
@@ -515,12 +515,12 @@ namespace Ogre
                                                           mBlendProxyCamera,
                                                           workspaceName,
                                                           false );
-        mCopyWorkspace->setListener( this );
+        mCopyWorkspace->addListener( this );
     }
     //-----------------------------------------------------------------------------------
     void ParallaxCorrectedCubemap::destroyCompositorData(void)
     {
-        mBlendWorkspace->setListener( 0 );
+        mBlendWorkspace->removeListener( this );
         CompositorManager2 *compositorManager = mDefaultWorkspaceDef->getCompositorManager();
         compositorManager->removeWorkspace( mBlendWorkspace );
         mBlendWorkspace = 0;

--- a/OgreMain/include/Compositor/OgreCompositorCommon.h
+++ b/OgreMain/include/Compositor/OgreCompositorCommon.h
@@ -53,9 +53,10 @@ namespace Ogre
 
     class CompositorManager2;
 
-    typedef vector<CompositorNode*>::type       CompositorNodeVec;
-    typedef vector<CompositorPass*>::type       CompositorPassVec;
-    typedef vector<CompositorShadowNode*>::type CompositorShadowNodeVec;
+    typedef vector<CompositorNode*>::type              CompositorNodeVec;
+    typedef vector<CompositorPass*>::type              CompositorPassVec;
+    typedef vector<CompositorShadowNode*>::type        CompositorShadowNodeVec;
+    typedef vector<CompositorWorkspaceListener*>::type CompositorWorkspaceListenerVec;
 }
 
 #include "OgreHeaderSuffix.h"

--- a/OgreMain/include/Compositor/OgreCompositorManager2.h
+++ b/OgreMain/include/Compositor/OgreCompositorManager2.h
@@ -129,7 +129,6 @@ namespace Ogre
 
         typedef vector<CompositorWorkspace*>::type              WorkspaceVec;
         typedef vector<QueuedWorkspace>::type                   QueuedWorkspaceVec;
-        typedef vector<CompositorWorkspaceListener*>::type      CompositorWorkspaceListenerVec;
         WorkspaceVec            mWorkspaces;
         /// All workspaces created via addWorkspace are first stored in this
         /// container, to prevent corrupting mWorkspaces' iterators in

--- a/OgreMain/include/Compositor/OgreCompositorWorkspace.h
+++ b/OgreMain/include/Compositor/OgreCompositorWorkspace.h
@@ -90,7 +90,7 @@ namespace Ogre
         bool                    mEnabled;
         bool                    mAmalgamatedProfiling;
 
-        CompositorWorkspaceListener *mListener;
+        CompositorWorkspaceListenerVec mListeners;
 
         /// Main sequence in the order they should be executed
         CompositorNodeVec       mNodeSequence;
@@ -181,8 +181,15 @@ namespace Ogre
         void setAmalgamatedProfiling( bool bEnabled )       { mAmalgamatedProfiling = bEnabled; }
         bool getAmalgamatedProfiling(void) const            { return mAmalgamatedProfiling; }
 
-        void setListener( CompositorWorkspaceListener *listener )   { mListener = listener; }
-        CompositorWorkspaceListener* getListener(void) const        { return mListener; }
+        /// @deprecated use addListener and removeListener instead
+        void setListener( CompositorWorkspaceListener *listener );
+        /// @deprecated use getListeners instead
+        CompositorWorkspaceListener* getListener(void) const;
+
+        void addListener( CompositorWorkspaceListener *listener );
+        void removeListener( CompositorWorkspaceListener *listener );
+
+        const CompositorWorkspaceListenerVec& getListeners(void) const { return mListeners; }
 
         const ResourceLayoutMap& getResourcesLayout(void) const     { return mResourcesLayout; }
         const ResourceAccessMap& getUavsAccess(void) const          { return mUavsAccess; }

--- a/OgreMain/include/Compositor/OgreCompositorWorkspaceListener.h
+++ b/OgreMain/include/Compositor/OgreCompositorWorkspaceListener.h
@@ -50,6 +50,9 @@ namespace Ogre
             @CompositorWorkspace::_beginUpdate( forceBeginFrame=true )
         */
         virtual void workspacePreUpdate( CompositorWorkspace *workspace ) {}
+        /** Called after all nodes has been updated.
+        */
+        virtual void workspacePosUpdate( CompositorWorkspace *workspace ) {}
         /** Called early on in pass' execution. Happens before passPreExecute,
             before the pass has set anything.
             Warning: calling pass->execute can result in recursive calls.

--- a/OgreMain/include/Compositor/Pass/OgreCompositorPass.h
+++ b/OgreMain/include/Compositor/Pass/OgreCompositorPass.h
@@ -139,6 +139,10 @@ namespace Ogre
 
         void executeResourceTransitions(void);
 
+        void notifyPassEarlyPreExecuteListeners(void);
+        void notifyPassPreExecuteListeners(void);
+        void notifyPassPosExecuteListeners(void);
+
     public:
         CompositorPass( const CompositorPassDef *definition, CompositorNode *parentNode );
         virtual ~CompositorPass();

--- a/OgreMain/include/Compositor/Pass/PassScene/OgreCompositorPassScene.h
+++ b/OgreMain/include/Compositor/Pass/PassScene/OgreCompositorPassScene.h
@@ -74,6 +74,9 @@ namespace Ogre
         TextureGpu      *mDepthTextureNoMsaa;
         TextureGpu      *mRefractionsTexture;
 
+        void notifyPassSceneAfterShadowMapsListeners(void);
+        void notifyPassSceneAfterFrustumCullingListeners(void);
+
     public:
         /** Constructor
         @param definition

--- a/OgreMain/src/Compositor/OgreCompositorWorkspace.cpp
+++ b/OgreMain/src/Compositor/OgreCompositorWorkspace.cpp
@@ -58,7 +58,6 @@ namespace Ogre
             mValid( false ),
             mEnabled( bEnabled ),
             mAmalgamatedProfiling( false ),
-            mListener( 0 ),
             mDefaultCamera( defaultCam ),
             mSceneManager( sceneManager ),
             mRenderSys( renderSys ),
@@ -609,6 +608,36 @@ namespace Ogre
         return mGlobalTextures[index];
     }
     //-----------------------------------------------------------------------------------
+    void CompositorWorkspace::setListener( CompositorWorkspaceListener *listener )
+    {
+        OGRE_EXCEPT( Exception::ERR_NOT_IMPLEMENTED,
+                     "This method has been superseded by CompositorWorkspace::addListener "
+                     "and CompositorWorkspace::removeListener.",
+                     "CompositorWorkspace::setListener" );
+    }
+    //-----------------------------------------------------------------------------------
+    CompositorWorkspaceListener* CompositorWorkspace::getListener(void) const
+    {
+        OGRE_EXCEPT( Exception::ERR_NOT_IMPLEMENTED,
+                     "This method has been superseded by CompositorWorkspace::getListeners.",
+                     "CompositorWorkspace::getListener" );
+    }
+    //-----------------------------------------------------------------------------------
+    void CompositorWorkspace::addListener( CompositorWorkspaceListener *listener )
+    {
+        mListeners.push_back( listener );
+    }
+    //-----------------------------------------------------------------------------------
+    void CompositorWorkspace::removeListener( CompositorWorkspaceListener *listener )
+    {
+        CompositorWorkspaceListenerVec::iterator itor = std::find( mListeners.begin(),
+                                                                   mListeners.end(),
+                                                                   listener );
+
+        if( itor != mListeners.end() )
+            mListeners.erase( itor );
+    }
+    //-----------------------------------------------------------------------------------
     void CompositorWorkspace::recreateAllNodes(void)
     {
         createAllNodes();
@@ -710,8 +739,16 @@ namespace Ogre
             analyzeHazardsAndPlaceBarriers();
         }
 
-        if( mListener )
-            mListener->workspacePreUpdate( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = mListeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = mListeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->workspacePreUpdate( this );
+                ++itor;
+            }
+        }
 
         TextureGpu *finalTarget = getFinalTarget();
         //We need to do this so that D3D9 (and D3D11?) knows which device

--- a/OgreMain/src/Compositor/OgreCompositorWorkspace.cpp
+++ b/OgreMain/src/Compositor/OgreCompositorWorkspace.cpp
@@ -839,6 +839,17 @@ namespace Ogre
             }
             ++itor;
         }
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = mListeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = mListeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->workspacePosUpdate( this );
+                ++itor;
+            }
+        }
     }
     //-----------------------------------------------------------------------------------
     void CompositorWorkspace::_swapFinalTarget( vector<TextureGpu*>::type &swappedTargets )

--- a/OgreMain/src/Compositor/Pass/OgreCompositorPass.cpp
+++ b/OgreMain/src/Compositor/Pass/OgreCompositorPass.cpp
@@ -484,6 +484,48 @@ namespace Ogre
         return retVal;
     }
     //-----------------------------------------------------------------------------------
+    void CompositorPass::notifyPassEarlyPreExecuteListeners(void)
+    {
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+        CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+        while( itor != end )
+        {
+            (*itor)->passEarlyPreExecute( this );
+            ++itor;
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    void CompositorPass::notifyPassPreExecuteListeners(void)
+    {
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+        CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+        while( itor != end )
+        {
+            (*itor)->passPreExecute( this );
+            ++itor;
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    void CompositorPass::notifyPassPosExecuteListeners(void)
+    {
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+        CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+        while( itor != end )
+        {
+            (*itor)->passPosExecute( this );
+            ++itor;
+        }
+    }
+    //-----------------------------------------------------------------------------------
     void CompositorPass::addResourceTransition( ResourceLayoutMap::iterator currentLayout,
                                                 ResourceLayout::Layout newLayout,
                                                 uint32 readBarrierBits )

--- a/OgreMain/src/Compositor/Pass/PassClear/OgreCompositorPassClear.cpp
+++ b/OgreMain/src/Compositor/Pass/PassClear/OgreCompositorPassClear.cpp
@@ -106,32 +106,12 @@ namespace Ogre
 
         profilingBegin();
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         executeResourceTransitions();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         RenderSystem *renderSystem = mParentNode->getRenderSystem();
 
@@ -146,16 +126,7 @@ namespace Ogre
             renderSystem->clearFrameBuffer( mRenderPassDesc, mAnyTargetTexture, mAnyMipLevel );
         }
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassClear/OgreCompositorPassClear.cpp
+++ b/OgreMain/src/Compositor/Pass/PassClear/OgreCompositorPassClear.cpp
@@ -106,15 +106,32 @@ namespace Ogre
 
         profilingBegin();
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         executeResourceTransitions();
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         RenderSystem *renderSystem = mParentNode->getRenderSystem();
 
@@ -129,8 +146,16 @@ namespace Ogre
             renderSystem->clearFrameBuffer( mRenderPassDesc, mAnyTargetTexture, mAnyMipLevel );
         }
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassCompute/OgreCompositorPassCompute.cpp
+++ b/OgreMain/src/Compositor/Pass/PassCompute/OgreCompositorPassCompute.cpp
@@ -270,9 +270,18 @@ namespace Ogre
 
         profilingBegin();
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         RenderSystem *renderSystem = mParentNode->getRenderSystem();
         renderSystem->endRenderPassDescriptor();
@@ -283,8 +292,16 @@ namespace Ogre
         setResourcesToJob();
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         assert( dynamic_cast<HlmsCompute*>( mComputeJob->getCreator() ) );
 
@@ -295,8 +312,16 @@ namespace Ogre
         HlmsCompute *hlmsCompute = static_cast<HlmsCompute*>( mComputeJob->getCreator() );
         hlmsCompute->dispatch( mComputeJob, sceneManager, mCamera );
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassCompute/OgreCompositorPassCompute.cpp
+++ b/OgreMain/src/Compositor/Pass/PassCompute/OgreCompositorPassCompute.cpp
@@ -270,18 +270,7 @@ namespace Ogre
 
         profilingBegin();
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         RenderSystem *renderSystem = mParentNode->getRenderSystem();
         renderSystem->endRenderPassDescriptor();
@@ -292,16 +281,7 @@ namespace Ogre
         setResourcesToJob();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         assert( dynamic_cast<HlmsCompute*>( mComputeJob->getCreator() ) );
 
@@ -312,16 +292,7 @@ namespace Ogre
         HlmsCompute *hlmsCompute = static_cast<HlmsCompute*>( mComputeJob->getCreator() );
         hlmsCompute->dispatch( mComputeJob, sceneManager, mCamera );
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassDepthCopy/OgreCompositorPassDepthCopy.cpp
+++ b/OgreMain/src/Compositor/Pass/PassDepthCopy/OgreCompositorPassDepthCopy.cpp
@@ -80,13 +80,30 @@ namespace Ogre
             --mNumPassesLeft;
         }
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         executeResourceTransitions();
 
@@ -99,8 +116,16 @@ namespace Ogre
         TextureBox dstBox = dstChannel->getEmptyBox( 0 );
         srcChannel->copyTo( dstChannel, dstBox, 0, srcBox, 0, false );
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
     }
     //-----------------------------------------------------------------------------------
     void CompositorPassDepthCopy::_placeBarriersAndEmulateUavExecution( BoundUav boundUavs[64],

--- a/OgreMain/src/Compositor/Pass/PassDepthCopy/OgreCompositorPassDepthCopy.cpp
+++ b/OgreMain/src/Compositor/Pass/PassDepthCopy/OgreCompositorPassDepthCopy.cpp
@@ -80,30 +80,10 @@ namespace Ogre
             --mNumPassesLeft;
         }
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         executeResourceTransitions();
 
@@ -116,16 +96,7 @@ namespace Ogre
         TextureBox dstBox = dstChannel->getEmptyBox( 0 );
         srcChannel->copyTo( dstChannel, dstBox, 0, srcBox, 0, false );
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
     }
     //-----------------------------------------------------------------------------------
     void CompositorPassDepthCopy::_placeBarriersAndEmulateUavExecution( BoundUav boundUavs[64],

--- a/OgreMain/src/Compositor/Pass/PassIblSpecular/OgreCompositorPassIblSpecular.cpp
+++ b/OgreMain/src/Compositor/Pass/PassIblSpecular/OgreCompositorPassIblSpecular.cpp
@@ -298,32 +298,12 @@ namespace Ogre
 
         profilingBegin();
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         executeResourceTransitions();
 
         // Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         const bool usesCompute = !mJobs.empty();
 
@@ -368,16 +348,7 @@ namespace Ogre
             }
         }
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassIblSpecular/OgreCompositorPassIblSpecular.cpp
+++ b/OgreMain/src/Compositor/Pass/PassIblSpecular/OgreCompositorPassIblSpecular.cpp
@@ -298,15 +298,32 @@ namespace Ogre
 
         profilingBegin();
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         executeResourceTransitions();
 
         // Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         const bool usesCompute = !mJobs.empty();
 
@@ -351,8 +368,16 @@ namespace Ogre
             }
         }
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassMipmap/OgreCompositorPassMipmap.cpp
+++ b/OgreMain/src/Compositor/Pass/PassMipmap/OgreCompositorPassMipmap.cpp
@@ -394,32 +394,12 @@ namespace Ogre
 
         profilingBegin();
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         executeResourceTransitions();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         const bool usesCompute = !mJobs.empty();
 
@@ -469,16 +449,7 @@ namespace Ogre
             }
         }
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassMipmap/OgreCompositorPassMipmap.cpp
+++ b/OgreMain/src/Compositor/Pass/PassMipmap/OgreCompositorPassMipmap.cpp
@@ -394,15 +394,32 @@ namespace Ogre
 
         profilingBegin();
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         executeResourceTransitions();
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         const bool usesCompute = !mJobs.empty();
 
@@ -452,8 +469,16 @@ namespace Ogre
             }
         }
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassQuad/OgreCompositorPassQuad.cpp
+++ b/OgreMain/src/Compositor/Pass/PassQuad/OgreCompositorPassQuad.cpp
@@ -150,18 +150,7 @@ namespace Ogre
 
         profilingBegin();
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         if( mPass )
         {
@@ -263,16 +252,7 @@ namespace Ogre
         setRenderPassDescToCurrent();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
 #if TODO_OGRE_2_2
         mTarget->setFsaaResolveDirty();
@@ -301,16 +281,7 @@ namespace Ogre
 
         sceneManager->_setCurrentCompositorPass( 0 );
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassQuad/OgreCompositorPassQuad.cpp
+++ b/OgreMain/src/Compositor/Pass/PassQuad/OgreCompositorPassQuad.cpp
@@ -150,9 +150,18 @@ namespace Ogre
 
         profilingBegin();
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         if( mPass )
         {
@@ -254,8 +263,16 @@ namespace Ogre
         setRenderPassDescToCurrent();
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
 #if TODO_OGRE_2_2
         mTarget->setFsaaResolveDirty();
@@ -284,8 +301,16 @@ namespace Ogre
 
         sceneManager->_setCurrentCompositorPass( 0 );
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassScene/OgreCompositorPassScene.cpp
+++ b/OgreMain/src/Compositor/Pass/PassScene/OgreCompositorPassScene.cpp
@@ -150,9 +150,18 @@ namespace Ogre
 
         profilingBegin();
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         Camera const *usedLodCamera = mLodCamera;
         if( lodCamera && mDefinition->mLodCameraName == IdString() )
@@ -193,8 +202,16 @@ namespace Ogre
         viewport->_setVisibilityMask( mDefinition->mVisibilityMask, mDefinition->mLightVisibilityMask );
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         if( mUpdateShadowNode && shadowNode )
         {
@@ -224,8 +241,16 @@ namespace Ogre
             //We need to restore the previous RT's update
         }
 
-        if( listener )
-            listener->passSceneAfterShadowMaps( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passSceneAfterShadowMaps( this );
+                ++itor;
+            }
+        }
 
         executeResourceTransitions();
         setRenderPassDescToCurrent();
@@ -240,8 +265,16 @@ namespace Ogre
                                       mDefinition->mFirstRQ, mDefinition->mLastRQ,
                                       mDefinition->mReuseCullData );
 
-        if( listener )
-            listener->passSceneAfterFrustumCulling( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passSceneAfterFrustumCulling( this );
+                ++itor;
+            }
+        }
 
 #if TODO_OGRE_2_2
         mTarget->setFsaaResolveDirty();
@@ -269,8 +302,16 @@ namespace Ogre
             sceneManager->_setForwardPlusEnabledInPass( false );
         }
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassScene/OgreCompositorPassScene.cpp
+++ b/OgreMain/src/Compositor/Pass/PassScene/OgreCompositorPassScene.cpp
@@ -138,6 +138,34 @@ namespace Ogre
     {
     }
     //-----------------------------------------------------------------------------------
+    void CompositorPassScene::notifyPassSceneAfterShadowMapsListeners(void)
+    {
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+        CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+        while( itor != end )
+        {
+            (*itor)->passSceneAfterShadowMaps( this );
+            ++itor;
+        }
+    }
+    //-----------------------------------------------------------------------------------
+    void CompositorPassScene::notifyPassSceneAfterFrustumCullingListeners(void)
+    {
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+        CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+        while( itor != end )
+        {
+            (*itor)->passSceneAfterFrustumCulling( this );
+            ++itor;
+        }
+    }
+    //-----------------------------------------------------------------------------------
     void CompositorPassScene::execute( const Camera *lodCamera )
     {
         //Execute a limited number of times?
@@ -150,18 +178,7 @@ namespace Ogre
 
         profilingBegin();
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         Camera const *usedLodCamera = mLodCamera;
         if( lodCamera && mDefinition->mLodCameraName == IdString() )
@@ -202,16 +219,7 @@ namespace Ogre
         viewport->_setVisibilityMask( mDefinition->mVisibilityMask, mDefinition->mLightVisibilityMask );
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         if( mUpdateShadowNode && shadowNode )
         {
@@ -241,16 +249,7 @@ namespace Ogre
             //We need to restore the previous RT's update
         }
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passSceneAfterShadowMaps( this );
-                ++itor;
-            }
-        }
+        notifyPassSceneAfterShadowMapsListeners();
 
         executeResourceTransitions();
         setRenderPassDescToCurrent();
@@ -265,16 +264,7 @@ namespace Ogre
                                       mDefinition->mFirstRQ, mDefinition->mLastRQ,
                                       mDefinition->mReuseCullData );
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passSceneAfterFrustumCulling( this );
-                ++itor;
-            }
-        }
+        notifyPassSceneAfterFrustumCullingListeners();
 
 #if TODO_OGRE_2_2
         mTarget->setFsaaResolveDirty();
@@ -302,16 +292,7 @@ namespace Ogre
             sceneManager->_setForwardPlusEnabledInPass( false );
         }
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
 
         profilingEnd();
     }

--- a/OgreMain/src/Compositor/Pass/PassStencil/OgreCompositorPassStencil.cpp
+++ b/OgreMain/src/Compositor/Pass/PassStencil/OgreCompositorPassStencil.cpp
@@ -74,46 +74,17 @@ namespace Ogre
             --mNumPassesLeft;
         }
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         executeResourceTransitions();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         setRenderPassDescToCurrent();
 
         mRenderSystem->setStencilBufferParams( mDefinition->mStencilRef, mDefinition->mStencilParams );
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
     }
 }

--- a/OgreMain/src/Compositor/Pass/PassStencil/OgreCompositorPassStencil.cpp
+++ b/OgreMain/src/Compositor/Pass/PassStencil/OgreCompositorPassStencil.cpp
@@ -74,21 +74,46 @@ namespace Ogre
             --mNumPassesLeft;
         }
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         executeResourceTransitions();
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         setRenderPassDescToCurrent();
 
         mRenderSystem->setStencilBufferParams( mDefinition->mStencilRef, mDefinition->mStencilParams );
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
     }
 }

--- a/OgreMain/src/Compositor/Pass/PassUav/OgreCompositorPassUav.cpp
+++ b/OgreMain/src/Compositor/Pass/PassUav/OgreCompositorPassUav.cpp
@@ -215,33 +215,13 @@ namespace Ogre
             --mNumPassesLeft;
         }
 
-        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
-
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passEarlyPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassEarlyPreExecuteListeners();
 
         if( !mDescriptorSetUav )
             setupDescriptorSetUav();
 
         //Fire the listener in case it wants to change anything
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPreExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPreExecuteListeners();
 
         //Do not execute resource transitions. This pass shouldn't have them.
         //The transitions are made when the bindings are needed
@@ -256,16 +236,7 @@ namespace Ogre
 
         renderSystem->queueBindUAVs( mDescriptorSetUav );
 
-        {
-            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
-            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
-
-            while( itor != end )
-            {
-                (*itor)->passPosExecute( this );
-                ++itor;
-            }
-        }
+        notifyPassPosExecuteListeners();
     }
     //-----------------------------------------------------------------------------------
     void CompositorPassUav::_placeBarriersAndEmulateUavExecution(

--- a/OgreMain/src/Compositor/Pass/PassUav/OgreCompositorPassUav.cpp
+++ b/OgreMain/src/Compositor/Pass/PassUav/OgreCompositorPassUav.cpp
@@ -215,16 +215,33 @@ namespace Ogre
             --mNumPassesLeft;
         }
 
-        CompositorWorkspaceListener *listener = mParentNode->getWorkspace()->getListener();
-        if( listener )
-            listener->passEarlyPreExecute( this );
+        const CompositorWorkspaceListenerVec& listeners = mParentNode->getWorkspace()->getListeners();
+
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passEarlyPreExecute( this );
+                ++itor;
+            }
+        }
 
         if( !mDescriptorSetUav )
             setupDescriptorSetUav();
 
         //Fire the listener in case it wants to change anything
-        if( listener )
-            listener->passPreExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPreExecute( this );
+                ++itor;
+            }
+        }
 
         //Do not execute resource transitions. This pass shouldn't have them.
         //The transitions are made when the bindings are needed
@@ -239,8 +256,16 @@ namespace Ogre
 
         renderSystem->queueBindUAVs( mDescriptorSetUav );
 
-        if( listener )
-            listener->passPosExecute( this );
+        {
+            CompositorWorkspaceListenerVec::const_iterator itor = listeners.begin();
+            CompositorWorkspaceListenerVec::const_iterator end  = listeners.end();
+
+            while( itor != end )
+            {
+                (*itor)->passPosExecute( this );
+                ++itor;
+            }
+        }
     }
     //-----------------------------------------------------------------------------------
     void CompositorPassUav::_placeBarriersAndEmulateUavExecution(


### PR DESCRIPTION
A single listener per-workspace can be a bit limiting in some advanced scenario. E.g.: set ambient light just during cubemap rendering is impossible at the moment since OGRE internally stoles the listener from end-user availability.