### PR TITLE
Improve flexibility of cubemap probe internally created workspace

### DIFF
--- a/Components/Hlms/Pbs/include/Cubemaps/OgreCubemapProbe.h
+++ b/Components/Hlms/Pbs/include/Cubemaps/OgreCubemapProbe.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "OgreIdString.h"
 #include "OgreTextureGpu.h"
 #include "OgreHeaderPrefix.h"
+#include "Compositor/OgreCompositorChannel.h"
 
 namespace Ogre
 {
@@ -155,7 +156,9 @@ namespace Ogre
             This value allows you to override it with a different workspace definition.
         */
         void initWorkspace( float cameraNear = 0.5f, float cameraFar = 500.0f,
-                            IdString workspaceDefOverride = IdString() );
+                            IdString workspaceDefOverride = IdString(),
+                            const CompositorChannelVec &additionalChannels = CompositorChannelVec(),
+                            uint8 executionMask = 0xFF );
         bool isInitialized(void) const;
 
         /** Sets cubemap probe's parameters.

--- a/Components/Hlms/Pbs/src/Cubemaps/OgreCubemapProbe.cpp
+++ b/Components/Hlms/Pbs/src/Cubemaps/OgreCubemapProbe.cpp
@@ -348,7 +348,10 @@ namespace Ogre
         }
     }
     //-----------------------------------------------------------------------------------
-    void CubemapProbe::initWorkspace( float cameraNear, float cameraFar, IdString workspaceDefOverride )
+    void CubemapProbe::initWorkspace( float cameraNear, float cameraFar,
+                                      IdString workspaceDefOverride,
+                                      const CompositorChannelVec &additionalChannels,
+                                      uint8 executionMask )
     {
         assert( (mTexture != 0 || mCreator->getAutomaticMode()) && "Call setTextureParams first!" );
 
@@ -404,11 +407,18 @@ namespace Ogre
             mTexture->_transitionTo( GpuResidency::Resident, (uint8*)0 );
 
         CompositorChannelVec channels;
-        channels.reserve( 2u );
+        channels.reserve( 2u + additionalChannels.size() );
         channels.push_back( rtt );
         channels.push_back( ibl );
+        channels.insert( channels.end(), additionalChannels.begin(), additionalChannels.end() );
         mWorkspace =
-            compositorManager->addWorkspace( sceneManager, channels, mCamera, mWorkspaceDefName, false );
+            compositorManager->addWorkspace( sceneManager, channels, mCamera, mWorkspaceDefName, false, -1,
+                                             (UavBufferPackedVec*)0,
+                                             (ResourceLayoutMap*)0,
+                                             (ResourceAccessMap*)0,
+                                             Vector4::ZERO,
+                                             0x00,
+                                             executionMask );
         mWorkspace->addListener( mCreator );
 
         if( !mStatic && !mCreator->getAutomaticMode() )


### PR DESCRIPTION
Add support to set additional compositor channels and/or execution mask to the cubemap probe workspace.
Additional compositor channels are needed to being able to render terrain in cubemap. Terra system requires that its shadow texture is being exposed otherwise an assertion is raised. This is impossible at the moment whitout using this PR.
Execution mask is useful if you have to skip a pass during the cubemap rendering without altering the compositor node (eg: to not render the skybox if it isn't used).