### PR TITLE
Default light mask for all movable objects

### DIFF
--- a/Components/SceneFormat/src/OgreSceneFormatExporter.cpp
+++ b/Components/SceneFormat/src/OgreSceneFormatExporter.cpp
@@ -978,6 +978,8 @@ namespace Ogre
         jsonStr.a( ",\n\t\"use_binary_floating_point\" : ", toQuotedStr( mUseBinaryFloatingPoint ) );
         jsonStr.a( ",\n\t\"MovableObject_msDefaultVisibilityFlags\" : ",
                    MovableObject::getDefaultVisibilityFlags() );
+        jsonStr.a( ",\n\t\"MovableObject_msDefaultLightMask\" : ",
+                   MovableObject::getDefaultLightMask() );
 
         if( exportFlags & SceneFlags::TexturesOitd )
             jsonStr.a( ",\n\t\"saved_oitd_textures\" : true" );

--- a/Components/SceneFormat/src/OgreSceneFormatExporter.cpp
+++ b/Components/SceneFormat/src/OgreSceneFormatExporter.cpp
@@ -978,6 +978,8 @@ namespace Ogre
         jsonStr.a( ",\n\t\"use_binary_floating_point\" : ", toQuotedStr( mUseBinaryFloatingPoint ) );
         jsonStr.a( ",\n\t\"MovableObject_msDefaultVisibilityFlags\" : ",
                    MovableObject::getDefaultVisibilityFlags() );
+        jsonStr.a( ",\n\t\"MovableObject_msDefaultQueryFlags\" : ",
+                   MovableObject::getDefaultQueryFlags() );
         jsonStr.a( ",\n\t\"MovableObject_msDefaultLightMask\" : ",
                    MovableObject::getDefaultLightMask() );
 

--- a/Components/SceneFormat/src/OgreSceneFormatImporter.cpp
+++ b/Components/SceneFormat/src/OgreSceneFormatImporter.cpp
@@ -1411,6 +1411,16 @@ namespace Ogre
         if( itor != d.MemberEnd() && itor->value.IsBool() )
             mUseBinaryFloatingPoint = itor->value.GetBool();
 
+        itor = d.FindMember( "MovableObject_msDefaultVisibilityFlags" );
+        if( itor != d.MemberEnd() && itor->value.IsUint() )
+            MovableObject::setDefaultVisibilityFlags( itor->value.GetUint() );
+        itor = d.FindMember( "MovableObject_msDefaultQueryFlags" );
+        if( itor != d.MemberEnd() && itor->value.IsUint() )
+            MovableObject::setDefaultQueryFlags( itor->value.GetUint() );
+        itor = d.FindMember( "MovableObject_msDefaultLightMask" );
+        if( itor != d.MemberEnd() && itor->value.IsUint() )
+            MovableObject::setDefaultLightMask( itor->value.GetUint() );
+
         if( importFlags & SceneFlags::SceneNodes )
         {
             itor = d.FindMember( "scene_nodes" );

--- a/OgreMain/include/OgreMovableObject.h
+++ b/OgreMain/include/OgreMovableObject.h
@@ -126,6 +126,8 @@ namespace Ogre {
         static uint32 msDefaultQueryFlags;
         /// Default visibility flags
         static uint32 msDefaultVisibilityFlags;
+        /// Default light mask
+        static uint32 msDefaultLightMask;
 
     protected:
         Aabb updateSingleWorldAabb();
@@ -553,6 +555,14 @@ namespace Ogre {
             By default, this mask is fully set meaning all lights will affect this object
         */
         inline void setLightMask(uint32 lightMask);
+
+        /** Set the default light mask for all future MovableObject instances.
+        */
+        static void setDefaultLightMask(uint32 mask) { msDefaultLightMask = mask; }
+
+        /** Get the default light mask for all future MovableObject instances.
+        */
+        static uint32 getDefaultLightMask() { return msDefaultLightMask; }
 
         /** Returns a pointer to the current list of lights for this object.
         @remarks

--- a/OgreMain/src/Math/Array/OgreObjectDataArrayMemoryManager.cpp
+++ b/OgreMain/src/Math/Array/OgreObjectDataArrayMemoryManager.cpp
@@ -138,7 +138,7 @@ namespace Ogre
         outData.mUpperDistance[1][nextSlotIdx]      = std::numeric_limits<Real>::max();
         outData.mVisibilityFlags[nextSlotIdx]       = MovableObject::getDefaultVisibilityFlags();
         outData.mQueryFlags[nextSlotIdx]            = MovableObject::getDefaultQueryFlags();
-        outData.mLightMask[nextSlotIdx]             = 0xFFFFFFFF;
+        outData.mLightMask[nextSlotIdx]             = MovableObject::getDefaultLightMask();
     }
     //-----------------------------------------------------------------------------------
     void ObjectDataArrayMemoryManager::destroyNode( ObjectData &inOutData )

--- a/OgreMain/src/OgreMovableObject.cpp
+++ b/OgreMain/src/OgreMovableObject.cpp
@@ -53,6 +53,7 @@ namespace Ogre {
     const uint32 VisibilityFlags::RESERVED_VISIBILITY_FLAGS = ~(LAYER_SHADOW_CASTER|LAYER_VISIBILITY);
     uint32 MovableObject::msDefaultQueryFlags = 0xFFFFFFFF;
     uint32 MovableObject::msDefaultVisibilityFlags = 0xFFFFFFFF & (~LAYER_VISIBILITY);
+    uint32 MovableObject::msDefaultLightMask = 0xFFFFFFFF;
     //-----------------------------------------------------------------------
     MovableObject::MovableObject( IdType id, ObjectMemoryManager *objectMemoryManager,
                                   SceneManager *manager, uint8 renderQueueId )


### PR DESCRIPTION
As the title says, this PR aims to provide a way  to set a default light mask for all the movable objects (which is impossible at the moment).