### PR TITLE
Automate deployment of api docs to github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  push:
+    branches:  'master'
+
+  # Run for all pull requests
+  pull_request:
+    branches: '*'
+    types: [opened, closed]
+
+env:
+  CMAKE_DOXYGEN_INPUT_LIST: "Components Docs/src OgreMain PlugIns RenderSystems"
+  OGRE_SOURCE_DIR: "./"
+  OGRE_BINARY_DIR: "./"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  Doxygen:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Generate Doxyfile
+        # Replace CMake's ${ENV_VAR} to Doxygen's $(ENV_VAR) syntax
+        run: cat CMake/Templates/html.cfg.in | sed 's/\${\(.*\)}/$(\1)/' > Doxyfile
+
+      - name: Generate docs with doxygen
+        uses: mattnotmitt/doxygen-action@v1
+        with:
+          doxyfile-path: './Doxyfile'
+
+      - name: Publish # Only on master branch
+        if: github.ref == 'master' || github.event.pull_request.merged
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./api

--- a/CMake/Templates/html.cfg.in
+++ b/CMake/Templates/html.cfg.in
@@ -682,7 +682,7 @@ INPUT_ENCODING         = UTF-8
 # *.hxx *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.dox *.py
 # *.f90 *.f *.for *.vhd *.vhdl
 
-FILE_PATTERNS          = Ogre*.h
+FILE_PATTERNS          = Ogre*.h *.md
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.


### PR DESCRIPTION
This PR will build and deploy the API reference to github pages. Please note:

* It will run the doxygen build for all pull requests
* It will, however, *only publish* to GH pages upon merge or a direct push to `master`

⚠️ It will overwrite the page at https://ogrecave.github.io/ogre-next/

My idea is to replace the GH landing page with the API reference anyway. I think it'll be easier to maintain it in that way.