### PR TITLE
Update CSS the style in API Reference page

### DIFF
--- a/Docs/ogre_style.css
+++ b/Docs/ogre_style.css
@@ -1,31 +1,361 @@
-h1.glow, h2.glow, h3.glow, h4.glow, h5.glow, h6.glow {
-	text-shadow: 0 0 15px #F5BA4E;
+/*
+ *  GitHub Markdown style CSS for doxygen 1.8.14
+ *  Source:  https://github.com/sindresorhus/github-markdown-css
+ *  License: MIT © Sindre Sorhus
+ */
+
+* {
+  box-sizing: border-box;
+}
+
+body, table, div, p, dl {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  line-height: 1.5;
+  color: #24292e;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+b {
+  font-weight: 600;
+}
+
+/* @group Heading Levels */
+
+h1, h2, h3, h4, h5, h6, .headertitle {
+  font-weight: 600;
+  line-height: 1.25;
+  margin-top: 24px;
+  margin-bottom: 16px;  
+}
+
+.headertitle {
+  margin-top: 0px;
+}
+
+h1 {
+  font-size: 2em;
+  padding-bottom: 0.3em;
+}
+
+h2 {
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+}
+
+h3 {
+  font-size: 1.25em;
+}
+
+h4 {
+  font-size: 1em;
+}
+
+h5 {
+  font-size: 0.875em;
+}
+
+h6 {
+  font-size: 0.85em;
+  color: #6a737d;
+}
+
+a {
+  background-color: transparent;
+  color: #628768;
+  text-decoration: none;
+  font-weight: normal;
+}
+
+.contents a:visited {
+  color: #628768;
+}
+
+a:active, a:hover {
+  outline-width: 0;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+a.el {
+    font-weight: normal;
+}
+
+.image {
+    text-align: left;
+}
+
+.tip {
+    background-image: url(tip.png);
+    background-position: left center;
+    background-repeat: no-repeat;
+    padding-left: 30px;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    min-height: 31px;
+    display: block;
+    font-style:italic;
+}
+
+.warn {
+    background-image: url(warn.png);
+    background-position: left center;
+    background-repeat: no-repeat;
+    padding-left: 48px;
+    margin-top: 1em;
+    margin-bottom: 1em;    
+    min-height: 31px;
+    display: block;
+    font-style:italic;
+}
+
+#projectname
+{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 2em;
+    font-weight: bold;
+}
+    
+#projectbrief
+{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 0.8em;
+}
+
+#projectnumber
+{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-size: 1em;
+}
+
+div.contents {
+  width: 980px;
+  padding: 0px;
+  margin-top: -1px;
+  margin-bottom: 10px;
+}
+
+div.toc {
+  border: 0px none;
+  border-radius: 7px 7px 7px 7px;        
+}
+
+div.header
+{
+  width: 980px;
+  padding: 00px;
+  margin-top: 10px;
+  background-image: none;
+  background-repeat: none;
+  background-color: transparent;
+  border: medium none;
+}
+
+.PageDoc div.header .title {
+  font-size: 2em;
+}
+
+.PageDoc code {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: rgba(27,31,35,.05);
+  border-radius: 3px;
+  font-family: inherit;
+}
+
+.PageDoc blockquote.doxtable {
+  padding: 0 1em;
+  color: #6a737d;
+  border-left: .25em solid #dfe2e5;
+  background-color: white;
+}
+
+.PageDoc blockquote.doxtable p {
+  color: #6a737d;
+  background-color: white;
+}
+
+table.markdownTable tr {
+  background-color: #fff;
+  border-top: 1px solid #c6cbd1;
+}
+
+table.markdownTable td,
+table.markdownTable tr {
+  padding: 6px 13px;
+  border: 1px solid #dfe2e5;
+}
+
+table.markdownTable tr:nth-child(2n) {
+    background-color: #f6f8fa;
+}
+
+.title ol {
+    margin: 0px;
+}
+
+.title ol li {
+    list-style-type: none;
+}
+
+.ui-resizable .ui-resizable-handle {
+}
+
+.ui-resizable-e {
+  background: none;
+  background-color: #E6E6E6;
+}
+
+.ui-resizable-handle {
+}
+
+div.fragment {
+  padding: 16px;
+  background-color: #f3f3f3;
+  border: 0px solid;
+}
+
+div.line,
+.PageDoc code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 85%;
+  line-height: 1.45;
+  -webkit-transition-duration: 0;
+  -moz-transition-duration: 0;
+  -ms-transition-duration: 0;
+  -o-transition-duration: 0;
+  transition-duration: 0;
 }
 
 div.line.glow {
-	background-color: #F5BA4E;
-	box-shadow: 0 0 10px #F5BA4E;
+  background-color: auto;
+  box-shadow: none;
 }
 
-.memberdecls td.glow, .fieldtable tr.glow {
-	background-color: #F5BA4E;
-	box-shadow: 0 0 15px #F5BA4E;
+pre.fragment {
+  border: 0px solid #C4CFE5;
+  padding: 16px;
+  background-color: #f3f3f3;
+  font-size: 85%;
+  line-height: 1.45;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 85%;
 }
 
-.memitem.glow {
-    box-shadow: 0 0 15px #F5BA4E;
+/* @group Code Colorization */
+span.keyword {
+  color: #808000
 }
 
-.image
-{
-   text-align: left;
+span.keywordtype {
+  color: #808000
 }
 
-h1, h2
-{
-    margin-top: 50px;
+span.keywordflow {
+  color: #808000
 }
-h3, h4
-{
-    margin-top: 25px;
+
+span.comment {
+  color: #008000
+}
+
+span.preprocessor {
+  color: #800000
+}
+
+span.stringliteral {
+  color: #000080
+}
+
+span.charliteral {
+  color: #000080
+}
+
+blockquote {
+        background-color: #EEEEEE;
+        border-left: 2px solid #606060;
+        margin: 0 24px 0 4px;
+        padding: 0 12px 0 16px;
+}
+
+/* @end */
+
+.arrow {
+  box-sizing: content-box;
+  display: inline-block;
+}
+
+img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+#nav-tree {
+    background-image: none;
+}
+
+#nav-tree .label {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+}
+
+#side-nav {
+    width: 25%;
+    max-width: 50%;
+}
+
+.memtitle {
+    background-image: none;
+}
+
+.memproto {
+  text-shadow: none;
+  /* opera specific markup */
+  box-shadow: none;
+  /* firefox specific markup */
+  -moz-box-shadow: none;
+  -moz-border-radius-topright: 4px;
+  /* webkit specific markup */
+  -webkit-box-shadow: none;
+  -webkit-border-top-right-radius: 4px;
+}
+
+.memdoc {
+  background-image:none;
+  background-repeat:repeat-x;
+  background-color: #FFFFFF;
+  /* opera specific markup */
+  box-shadow: none;
+  /* firefox specific markup */
+  -moz-box-shadow: none;
+  /* webkit specific markup */
+  -webkit-box-shadow: none;
+}
+
+#projectlogo {
+  display: none;
+}
+
+#projectalign {
+  padding: 4px 0;
+}
+
+.sm-dox,
+.sm-dox a {
+  background-image: none;
+}
+
+#nav-tree {
+  background-color: #fff;
 }


### PR DESCRIPTION
Changes in the API docs CSS style:
* Use Github-like markdown style
* More padding in code blocks
* Removed noisy logo (more focus on the content)

Live preview at: https://mimon.github.io/ogre-next/api/2.2/
![Screenshot 2020-04-12 at 00 57 17](https://user-images.githubusercontent.com/4318967/79056740-ad523180-7c59-11ea-9d68-c471ab8af6b9.jpg)
