### PR TITLE
make resource path in sample GraphicsSystem set in initializer

### DIFF
--- a/Samples/2.0/Common/include/GraphicsSystem.h
+++ b/Samples/2.0/Common/include/GraphicsSystem.h
@@ -96,6 +96,7 @@ namespace Demo
         void gameEntityRemoved( GameEntity *toRemove );
     public:
         GraphicsSystem( GameState *gameState,
+                        Ogre::String resourcePath = Ogre::String(""),
                         Ogre::ColourValue backgroundColour = Ogre::ColourValue( 0.2f, 0.4f, 0.6f ) );
         virtual ~GraphicsSystem();
 

--- a/Samples/2.0/Common/src/GraphicsSystem.cpp
+++ b/Samples/2.0/Common/src/GraphicsSystem.cpp
@@ -51,6 +51,7 @@
 namespace Demo
 {
     GraphicsSystem::GraphicsSystem( GameState *gameState,
+                                    Ogre::String resourcePath ,
                                     Ogre::ColourValue backgroundColour ) :
         BaseSystem( gameState ),
         mLogicSystem( 0 ),
@@ -64,6 +65,7 @@ namespace Demo
         mCamera( 0 ),
         mWorkspace( 0 ),
         mPluginsFolder( "./" ),
+        mResourcePath( resourcePath ),
         mOverlaySystem( 0 ),
         mAccumTimeSinceLastLogicFrame( 0 ),
         mCurrentTransformIdx( 0 ),


### PR DESCRIPTION
Tiny change in GraphicsSystem so that new Projects can set custom resource folder.