### PR TITLE
Publish to gh-pages upon push to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
   # Run for all pull requests
   pull_request:
     branches: '*'
-    types: [opened, closed]
+    types: [opened]
 
 env:
   CMAKE_DOXYGEN_INPUT_LIST: "Components Docs/src OgreMain PlugIns RenderSystems"
@@ -36,7 +36,7 @@ jobs:
           doxyfile-path: './Doxyfile'
 
       - name: Publish # Only on master branch
-        if: github.ref == 'master' || github.event.pull_request.merged
+        if: github.ref == 'master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should work if my presumption is correct. I.e. that Github technically pushes a merged PR back to master.