### PR TITLE
Fix OgreWorkarounds.h encoding

### DIFF
--- a/OgreMain/include/OgreIdString.h
+++ b/OgreMain/include/OgreIdString.h
@@ -42,7 +42,7 @@ THE SOFTWARE.
     #define OGRE_COPY_DEBUG_STRING( _Expression ) ((void)0)
     #define OGRE_APPEND_DEBUG_STRING( _Expression ) ((void)0)
 #else
-    #include "assert.h"
+    #include <assert.h>
 #endif
 
 namespace Ogre

--- a/OgreMain/include/OgreWorkarounds.h
+++ b/OgreMain/include/OgreWorkarounds.h
@@ -41,7 +41,7 @@ THE SOFTWARE.
 //	https://twitter.com/KeepItFoolish/status/472456232738234368
 #define OGRE_GLES2_WORKAROUND_1		1
 
-//For some reason cubemapping in ES, the vector needs to be rotated 90° around the X axis.
+//For some reason cubemapping in ES, the vector needs to be rotated 90Â° around the X axis.
 //May be it's a difference in the ES vs GL spec, or an Ogre bug when uploading the faces.
 //
 //First seen: ???

--- a/OgreMain/include/WIN32/OgreConfigDialogImpWinRT.h
+++ b/OgreMain/include/WIN32/OgreConfigDialogImpWinRT.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
 #if !defined(NOMINMAX) && defined(_MSC_VER)
 #   define NOMINMAX // required to stop windows.h messing up std::min
 #endif
-#include "windows.h"
+#include <windows.h>
 
 namespace Ogre
 {


### PR DESCRIPTION
## Changes
- Fixed OgreWorkarounds.h encoding
- Replaced double quoted includes with angle brackets for system headers for clarity.

I mentioned these in #92.