### PR TITLE
Put API docs under /api/2.2/ when publishing to gh-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ env:
   CMAKE_DOXYGEN_INPUT_LIST: "Components Docs/src OgreMain PlugIns RenderSystems"
   OGRE_SOURCE_DIR: "./"
   OGRE_BINARY_DIR: "./"
+  OGRE_VERSION: "2.2"
+  DOXYGEN_HTML_OUTPUT_DIR: "./2.2"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -35,9 +37,10 @@ jobs:
         with:
           doxyfile-path: './Doxyfile'
 
-#      - name: Publish # Only on master branch
-#        if: github.ref == 'refs/heads/master'
-#        uses: peaceiris/actions-gh-pages@v3
-#        with:
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          publish_dir: ./api
+      - name: Publish # Only on master branch
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          keep_files: true

--- a/CMake/Templates/html.cfg.in
+++ b/CMake/Templates/html.cfg.in
@@ -895,7 +895,7 @@ GENERATE_HTML          = YES
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be
 # put in front of it. If left blank `html' will be used as the default path.
 
-HTML_OUTPUT            = html
+HTML_OUTPUT            = ${DOXYGEN_HTML_OUTPUT_DIR}
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for
 # each generated HTML page (for example: .htm,.php,.asp). If it is left blank


### PR DESCRIPTION
This will publish the html at the same path where the current api docs resides in (i.e. https://ogrecave.github.io/ogre-next/api/2.2/).

I did a build on my own repo's master and made sure it works: https://mimon.github.io/ogre-next/api/2.2/

## Caveat 1
All Ogre files in the the repo will be copied to the published `gh-pages` so the published directory will actually be something like:
```
/
  CmakeFiles/
  Components/
  ...
  api/2.2/...
  ...
```

## Caveat 2
The current main page at https://ogrecave.github.io/ogre-next will disappear. I'm not really sure how to build both doxygen and the main page.

## Conclusion
Due to the simple way gh-pages work and the simple build system I haven't been able to find a perfect clean way to keep both main page and the docs.

However, I'd recommend that you setup a custom subdomain DNS entry (e.g. `docs.ogre3d.org`) for the API docs. This will make it easier to maintain http links in the long-term and is independent of where the docs are hosted.

LMK what you think. Cheers