### PR TITLE
Build v2-1 docs and publish to gh-pages /api/2.1/

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  push:
+    branches:  'v2-1'
+
+  # Run for all pull requests
+  pull_request:
+    branches: '*'
+    types: [opened]
+
+env:
+  CMAKE_DOXYGEN_INPUT_LIST: "Components Docs/src OgreMain PlugIns RenderSystems"
+  OGRE_SOURCE_DIR: "./"
+  OGRE_BINARY_DIR: "./"
+  OGRE_VERSION: "2.1"
+  DOXYGEN_HTML_OUTPUT_DIR: "./2.1"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  Doxygen:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Generate Doxyfile
+        # Replace CMake's ${ENV_VAR} to Doxygen's $(ENV_VAR) syntax
+        run: cat CMake/Templates/html.cfg.in | sed 's/\${\(.*\)}/$(\1)/' > Doxyfile
+
+      - name: Generate docs with doxygen
+        uses: mattnotmitt/doxygen-action@v1
+        with:
+          doxyfile-path: './Doxyfile'
+
+      - name: Publish # Only on master branch
+        if: github.ref == 'refs/heads/v2-1'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          keep_files: true

--- a/CMake/Templates/html.cfg.in
+++ b/CMake/Templates/html.cfg.in
@@ -682,7 +682,7 @@ INPUT_ENCODING         = UTF-8
 # *.hxx *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.dox *.py
 # *.f90 *.f *.for *.vhd *.vhdl
 
-FILE_PATTERNS          = Ogre*.h
+FILE_PATTERNS          = Ogre*.h *.md
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.
@@ -895,7 +895,7 @@ GENERATE_HTML          = YES
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be
 # put in front of it. If left blank `html' will be used as the default path.
 
-HTML_OUTPUT            = html
+HTML_OUTPUT            = ${DOXYGEN_HTML_OUTPUT_DIR}
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for
 # each generated HTML page (for example: .htm,.php,.asp). If it is left blank


### PR DESCRIPTION
Complementing #95 by building 2.1 docs aside to 2.2.

This works by setting the `keep_files: true` in the publish step in `main.yml`. Hence, docs built on `master` and `v2-1` branch can both push to `gh-pages` without overwriting each others files.