### PR TITLE
[D3D11,Win32] Fixed invalid size of newly created window.

### DIFF
--- a/RenderSystems/Direct3D11/src/Windowing/WIN32/OgreD3D11WindowHwnd.cpp
+++ b/RenderSystems/Direct3D11/src/Windowing/WIN32/OgreD3D11WindowHwnd.cpp
@@ -373,7 +373,7 @@ namespace Ogre
             else
             {
                 RECT rc;
-                SetRect( &rc, mLeft, mTop, mRequestedWidth, mRequestedHeight );
+                SetRect( &rc, mLeft, mTop, mLeft+mRequestedWidth, mTop+mRequestedHeight );
                 if( !outerSize )
                 {
                     //User requested "client resolution", we need to grow the rect


### PR DESCRIPTION
After updating Ogre from 2.1 to 2.2.1 I found dimensions of window to be set incorrectly. Debugger led me to file OgreD3D11WindowHwnd.cpp to line:

`                RECT rc;`
`                SetRect( &rc, mLeft, mTop, mRequestedWidth, mRequestedHeight);`

While in WinUser.h:

`WINUSERAPI`
`BOOL`
`WINAPI`
`SetRect(`
`    _Out_ LPRECT lprc,`
`    _In_ int xLeft,`
`    _In_ int yTop,`
`    _In_ int xRight,`
`    _In_ int yBottom);`
