### PR TITLE
Enable wireframe in Metal

### DIFF
--- a/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
+++ b/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
@@ -2059,6 +2059,11 @@ namespace Ogre
             [mActiveRenderEncoder setRenderPipelineState:metalPso->pso];
             mPso = metalPso;
         }
+
+        MTLTriangleFillMode fillMode = (
+            pso->macroblock->mPolygonMode == PM_SOLID
+        ) ? MTLTriangleFillModeFill : MTLTriangleFillModeLines;
+        [mActiveRenderEncoder setTriangleFillMode:fillMode];
     }
     //-------------------------------------------------------------------------
     void MetalRenderSystem::_setComputePso( const HlmsComputePso *pso )


### PR DESCRIPTION
Macroblocks with wireframe wasn't rendered as wireframes on Metal render system.

For reference: https://forums.ogre3d.org/viewtopic.php?f=25&t=95089&p=545434#p545434