### PR TITLE
Detect failure to create Dependency directory symlink

### DIFF
--- a/Scripts/BuildScripts/build_ogre.bat
+++ b/Scripts/BuildScripts/build_ogre.bat
@@ -50,6 +50,10 @@ IF NOT EXIST ogre-next (
 cd ogre-next
 IF NOT EXIST Dependencies (
 	mklink /D Dependencies ..\ogre-next-deps\build\ogredeps
+	IF ERRORLEVEL 1 (
+		echo Failed to create Dependency directory symlink. Run the script as Administrator.
+		EXIT /B 1
+	)
 )
 mkdir build
 cd build


### PR DESCRIPTION
If the symlink couldn't be created, show a useful error messages indicating how to solve the problem and exit.

(prevents OGRECave#117)