### PR TITLE
Fix bug with compositor texture referenced from TextureUnitState

### DIFF
--- a/OgreMain/src/OgreTextureUnitState.cpp
+++ b/OgreMain/src/OgreTextureUnitState.cpp
@@ -1064,7 +1064,18 @@ namespace Ogre {
     void TextureUnitState::_setTexturePtr( TextureGpu *texptr, size_t frame )
     {
         assert(frame < mFramePtrs.size());
-        mFramePtrs[frame] = texptr;
+
+        if (mFramePtrs[frame] != texptr)
+        {
+            if (mFramePtrs[frame])
+            {
+                mFramePtrs[frame]->removeListener(this);
+            }
+
+            mFramePtrs[frame] = texptr;
+
+            mFramePtrs[frame]->addListener(this);
+        }
     }
     //-----------------------------------------------------------------------
     void TextureUnitState::ensurePrepared(size_t frame) const

--- a/OgreMain/src/OgreTextureUnitState.cpp
+++ b/OgreMain/src/OgreTextureUnitState.cpp
@@ -1439,7 +1439,6 @@ namespace Ogre {
         cleanFramePtrs();
         mFrames.resize(1);
         mFramePtrs.resize(1);
-        mFrames[0] = textureName;
         mCompositorRefTexName = textureName;
     }
     //-----------------------------------------------------------------------


### PR DESCRIPTION
When setting the reference to the compositor texture, mFrames[0] was set to the texture name.
However, this caused the TextureUnitState to try and read the file from disk when the
TextureUnitState was loaded.

Instead, mFrames[0] should not be set to anything. mFramePtrs[0] will be correctly set
when the corresponding compositor is updated.