### PR TITLE
Fix incorrect window texture resolution in windowed mode in OpenGl

### DIFF
--- a/RenderSystems/GL3Plus/src/windowing/win32/OgreWin32Window.cpp
+++ b/RenderSystems/GL3Plus/src/windowing/win32/OgreWin32Window.cpp
@@ -671,7 +671,9 @@ namespace Ogre
         mTexture->setSampleDescription( mSampleDescription );
         mDepthBuffer->setSampleDescription( mSampleDescription );
 
-        setFinalResolution( mRequestedWidth, mRequestedHeight );
+        RECT rc;
+        GetClientRect( mHwnd, &rc );  // width and height represent interior drawable area
+        setFinalResolution( rc.right - rc.left, rc.bottom - rc.top );
 
         if( mDepthBuffer )
         {


### PR DESCRIPTION
This fixes the issue  I described in the forum:
https://forums.ogre3d.org/viewtopic.php?f=25&t=95899