### PR TITLE
[2.1] EMISSIVE texture type is missing in HlmsJsonPbs::loadTexture()

### DIFF
--- a/Components/Hlms/Pbs/src/OgreHlmsJsonPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsJsonPbs.cpp
@@ -203,6 +203,7 @@ namespace Ogre
             HlmsTextureManager::TEXTURE_TYPE_NORMALS,
             HlmsTextureManager::TEXTURE_TYPE_NORMALS,
 #endif
+            HlmsTextureManager::TEXTURE_TYPE_DIFFUSE,
             HlmsTextureManager::TEXTURE_TYPE_ENV_MAP
         };
 


### PR DESCRIPTION
In `HlmsJsonPbs::loadTexture()`, `PBSM_EMISSIVE` is skipped in the texMapTypes array.