### PR TITLE
fix RaySceneQuery distance calculation

### DIFF
--- a/OgreMain/src/OgreDefaultSceneQueries.cpp
+++ b/OgreMain/src/OgreDefaultSceneQueries.cpp
@@ -294,10 +294,11 @@ namespace Ogre {
 				//but often is slightly beyond it, causing the test to fail)
                 hitPoint.mChunkBase[j] = objData.mWorldAabb->mCenter.mChunkBase[j];
 
-                //hitMaskR |= t >= 0 && mWorldAabb->contains( hitPoint );
-                //distance = t >= 0 ? min( distance, t ) : t;
-                hitMaskR = Mathlib::Or( hitMaskR, Mathlib::And( mask,
-                                                    objData.mWorldAabb->contains( hitPoint ) ) );
+                //mask = t >= 0 && mWorldAabb->contains( hitPoint ) /* == this hit is correct*/
+                //hitMaskR |= mask;
+                //distance = mask ? min( distance, t ) : distance;
+                mask = Mathlib::And( mask, objData.mWorldAabb->contains( hitPoint ) );
+                hitMaskR = Mathlib::Or( hitMaskR, mask );
                 distance = Mathlib::CmovRobust( Mathlib::Min( distance, t ), distance, mask );
             }
 
@@ -314,10 +315,11 @@ namespace Ogre {
 				//but often is slightly beyond it, causing the test to fail)
                 hitPoint.mChunkBase[j] = objData.mWorldAabb->mCenter.mChunkBase[j];
 
-                //hitMaskR |= t >= 0 && mWorldAabb->contains( hitPoint );
-                //distance = t >= 0 ? min( distance, t ) : t;
-                hitMaskR = Mathlib::Or( hitMaskR, Mathlib::And( mask,
-                                                    objData.mWorldAabb->contains( hitPoint ) ) );
+                //mask = t >= 0 && mWorldAabb->contains( hitPoint ) /* == this hit is correct*/
+                //hitMaskR |= mask;
+                //distance = mask ? min( distance, t ) : distance;
+                mask = Mathlib::And( mask, objData.mWorldAabb->contains( hitPoint ) );
+                hitMaskR = Mathlib::Or( hitMaskR, mask );
                 distance = Mathlib::CmovRobust( Mathlib::Min( distance, t ), distance, mask );
             }
 


### PR DESCRIPTION
Distance shouldn't be replaced with new value when AABB don't contains hit point.

Current calculation can results incorrect hit point – located on infinity plane (at aabb face), but outside aabb.

This patch can fix this issue in default branch, too.