### PR TITLE
fix the Paging Component for v2.2

### DIFF
--- a/Components/Paging/include/OgrePage.h
+++ b/Components/Paging/include/OgrePage.h
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include "OgrePagingPrerequisites.h"
 #include "Threading/OgreThreadHeaders.h"
 #include "OgreWorkQueue.h"
-
+#include "ogrestd/vector.h"
 
 namespace Ogre
 {

--- a/Components/Paging/include/OgrePagedWorld.h
+++ b/Components/Paging/include/OgrePagedWorld.h
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include "OgrePagingPrerequisites.h"
 #include "OgreCommon.h"
 #include "OgreNameGenerator.h"
-
+#include "ogrestd/map.h"
 namespace Ogre
 {
     class PageManager;

--- a/Components/Paging/include/OgrePagedWorldSection.h
+++ b/Components/Paging/include/OgrePagedWorldSection.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 
 #include "OgrePagingPrerequisites.h"
 #include "OgreAxisAlignedBox.h"
-
+#include "ogrestd/map.h"
 namespace Ogre
 {
     /** \addtogroup Optional Components

--- a/Components/Paging/include/OgreSimplePageContentCollection.h
+++ b/Components/Paging/include/OgreSimplePageContentCollection.h
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include "OgrePagingPrerequisites.h"
 #include "OgrePageContentCollection.h"
 #include "OgrePageContentCollectionFactory.h"
-
+#include "ogrestd/vector.h"
 namespace Ogre
 {
     /** \addtogroup Optional Components

--- a/Components/Paging/src/OgreGrid2DPageStrategy.cpp
+++ b/Components/Paging/src/OgreGrid2DPageStrategy.cpp
@@ -33,9 +33,10 @@ THE SOFTWARE.
 #include "OgreSceneNode.h"
 #include "OgreSceneManager.h"
 #include "OgreMaterialManager.h"
-#include "OgreManualObject.h"
+#include "OgreManualObject2.h"
 #include "OgrePageManager.h"
 #include "OgreTechnique.h"
+#include "OgreHlmsDatablock.h"
 
 namespace Ogre
 {
@@ -405,9 +406,10 @@ namespace Ogre
             {
                 mat = MaterialManager::getSingleton().create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
                 Pass* pass = mat->getTechnique(0)->getPass(0);
-                pass->setLightingEnabled(false);
+                HlmsMacroblock macroblock = *pass->getMacroblock();
+                macroblock.mDepthWrite = false;
+                pass->setMacroblock(macroblock);
                 pass->setVertexColourTracking(TVC_AMBIENT);
-                pass->setDepthWriteEnabled(false);
                 mat->load();
             }
 
@@ -416,7 +418,7 @@ namespace Ogre
             if (sn->numAttachedObjects() == 0)
             {
                 mo = p->getParentSection()->getSceneManager()->createManualObject();
-                mo->begin(matName, RenderOperation::OT_LINE_STRIP);
+                mo->begin(matName, OT_LINE_STRIP);
             }
             else
             {

--- a/Components/Paging/src/OgreGrid3DPageStrategy.cpp
+++ b/Components/Paging/src/OgreGrid3DPageStrategy.cpp
@@ -34,9 +34,10 @@ THE SOFTWARE.
 #include "OgreSceneNode.h"
 #include "OgreSceneManager.h"
 #include "OgreMaterialManager.h"
-#include "OgreManualObject.h"
+#include "OgreManualObject2.h"
 #include "OgrePageManager.h"
 #include "OgreTechnique.h"
+#include "OgreHlmsDatablock.h"
 
 namespace Ogre
 {
@@ -367,9 +368,9 @@ namespace Ogre
             {
                 mat = MaterialManager::getSingleton().create(matName, ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
                 Pass* pass = mat->getTechnique(0)->getPass(0);
-                pass->setLightingEnabled(false);
+                HlmsMacroblock macroblock = *pass->getMacroblock();
+                pass->setMacroblock(macroblock);
                 pass->setVertexColourTracking(TVC_AMBIENT);
-                pass->setDepthWriteEnabled(false);
                 mat->load();
             }
 
@@ -383,7 +384,7 @@ namespace Ogre
             else
             {
                 mo = p->getParentSection()->getSceneManager()->createManualObject();
-                mo->begin(matName, RenderOperation::OT_LINE_STRIP);
+                mo->begin(matName, OT_LINE_STRIP);
             }
 
             ColourValue vcol = ColourValue::Green;

--- a/Components/Paging/src/OgrePagedWorldSection.cpp
+++ b/Components/Paging/src/OgrePagedWorldSection.cpp
@@ -127,16 +127,13 @@ namespace Ogre
         ser.read(&smType);
         ser.read(&smInstanceName);
         Root& root = Root::getSingleton();
-
-        InstancingThreadedCullingMethod threadedCullingMethod = INSTANCING_CULLING_SINGLETHREAD;
-        const size_t numThreads = std::max<size_t>( 1, PlatformInformation::getNumLogicalCores() );
-        if( numThreads > 1 )
-            threadedCullingMethod = Ogre::INSTANCING_CULLING_THREADED;
+		
+        const size_t numThreads = std::max<size_t>(1, PlatformInformation::getNumLogicalCores());
 
         if (root.hasSceneManager(smInstanceName))
             sm = root.getSceneManager(smInstanceName);
         else
-            sm = root.createSceneManager(smType, numThreads, threadedCullingMethod, smInstanceName);
+            sm = root.createSceneManager(smType, numThreads, smInstanceName);
         setSceneManager(sm);
         // Page Strategy Name
         String stratname;


### PR DESCRIPTION
I have created a small patch to fix the OgrePaging Component for v2.2, because i am currently using it myself. It is currently a WIP but it seems to work ok for my use case: a custom, procedural implementation of PageStrategy, PageContent and PageProvider.
I would be thankful for any hints as to what might still be missing or wrong. The Grid2D/3DPageStrategy.cpp files are currently missing the `pass->setLightingEnabled(false);` and i don't really know what the best/correct way is to achieve this in v2.2.