### PR TITLE
Add support to remove a skeleton definition from its memory manager

### DIFF
--- a/OgreMain/include/Animation/OgreSkeletonAnimManager.h
+++ b/OgreMain/include/Animation/OgreSkeletonAnimManager.h
@@ -110,6 +110,7 @@ namespace Ogre
         SkeletonInstance* createSkeletonInstance( const SkeletonDef *skeletonDef,
                                                     size_t numWorkerThreads );
         void destroySkeletonInstance( SkeletonInstance *skeletonInstance );
+        void removeSkeletonDef( const SkeletonDef *skeletonDef );
     };
 
     /** @} */

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -1501,6 +1501,8 @@ namespace Ogre {
         SkeletonInstance* createSkeletonInstance( const SkeletonDef *skeletonDef );
         /// Destroys an instance of a skeleton created with @createSkeletonInstance.
         void destroySkeletonInstance( SkeletonInstance *skeletonInstance );
+        /// Removes a skeleton definition from its memory manager.
+        void _removeSkeletonDef( const SkeletonDef *skeletonDef );
 
         /** Create a ManualObject, an object which you populate with geometry
             manually through a GL immediate-mode style interface.

--- a/OgreMain/src/Animation/OgreSkeletonAnimManager.cpp
+++ b/OgreMain/src/Animation/OgreSkeletonAnimManager.cpp
@@ -182,4 +182,30 @@ namespace Ogre
         //Update the thread starts, they have changed.
         bySkelDef.updateThreadStarts();
     }
+    //-----------------------------------------------------------------------
+    void SkeletonAnimManager::removeSkeletonDef( const SkeletonDef *skeletonDef )
+    {
+        IdString defName( skeletonDef->getNameStr() );
+        BySkeletonDefList::iterator itor = std::find( bySkeletonDefs.begin(), bySkeletonDefs.end(),
+                                                        defName );
+
+        if( itor == bySkeletonDefs.end() )
+        {
+            OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
+                         "Trying to remove a SkeletonDef we don't have. Have you already removed it?",
+                         "SceneManager::destroySkeletonDef" );
+        }
+
+        BySkeletonDef &bySkelDef = *itor;
+        FastArray<SkeletonInstance*> &skeletonsArray = bySkelDef.skeletons;
+
+        if( !skeletonsArray.empty() )
+        {
+            OGRE_EXCEPT( Exception::ERR_INVALID_STATE,
+                         "Trying to remove a SkeletonDef for which instances are still in use. Destroy all SkeletonInstances first.",
+                         "SceneManager::destroySkeletonDef" );
+        }
+
+        bySkeletonDefs.erase( itor );
+    }
 }

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -671,6 +671,11 @@ void SceneManager::destroySkeletonInstance( SkeletonInstance *skeletonInstance )
     mSkeletonAnimationManager.destroySkeletonInstance( skeletonInstance );
 }
 //-----------------------------------------------------------------------
+void SceneManager::_removeSkeletonDef( const SkeletonDef *skeletonDef )
+{
+    mSkeletonAnimationManager.removeSkeletonDef( skeletonDef );
+}
+//-----------------------------------------------------------------------
 void SceneManager::destroyAllBillboardSets(void)
 {
     destroyAllMovableObjectsByType(v1::BillboardSetFactory::FACTORY_TYPE_NAME);


### PR DESCRIPTION
At the moment, it's impossible to remove a `SkeletonDefinition` if you don't want to use it anymore or if you want to update it (e.g. in an editor).