### PR TITLE
Fix MaterialBuf isn't binded to vertex shader in HLMS Unlit

### DIFF
--- a/Components/Hlms/Unlit/src/OgreHlmsUnlit.cpp
+++ b/Components/Hlms/Unlit/src/OgreHlmsUnlit.cpp
@@ -912,6 +912,10 @@ namespace Ogre
         {
             //layout(binding = 1) uniform MaterialBuf {} materialArray
             const ConstBufferPool::BufferPool *newPool = datablock->getAssignedPool();
+            *commandBuffer->addCommand<CbShaderBuffer>() = CbShaderBuffer( VertexShader,
+                                                                           1, newPool->materialBuffer, 0,
+                                                                           newPool->materialBuffer->
+                                                                           getTotalSizeBytes() );
             *commandBuffer->addCommand<CbShaderBuffer>() = CbShaderBuffer( PixelShader,
                                                                            1, newPool->materialBuffer, 0,
                                                                            newPool->materialBuffer->


### PR DESCRIPTION
This cause visual artifacts using a mesh with vertex colour.