### PR TITLE
E2K: added initial support of MCST Elbrus 2000 CPU architecture

### DIFF
--- a/OgreMain/include/OgrePlatform.h
+++ b/OgreMain/include/OgrePlatform.h
@@ -61,9 +61,10 @@ namespace Ogre {
 #define OGRE_CPU_PPC        2
 #define OGRE_CPU_ARM        3
 #define OGRE_CPU_MIPS       4
+#define OGRE_CPU_E2K        5
 
 /* Find CPU type */
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64)
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64) || defined(_M_AMD64) || defined(__e2k__)
 #   define OGRE_CPU OGRE_CPU_X86
 #elif defined(__ppc__) || defined(__ppc64__) || defined(_M_PPC)
 #   define OGRE_CPU OGRE_CPU_PPC
@@ -80,7 +81,7 @@ namespace Ogre {
  || defined(__ppc64__) \
  || defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64) \
  || defined(__mips64) || defined(__mips64_) \
- || defined(__alpha__) || defined(__ia64__) || defined(__s390__) || defined(__s390x__)
+ || defined(__alpha__) || defined(__ia64__) || defined(__e2k__) || defined(__s390__) || defined(__s390x__)
 #   define OGRE_ARCH_TYPE OGRE_ARCHITECTURE_64
 #else
 #   define OGRE_ARCH_TYPE OGRE_ARCHITECTURE_32
@@ -124,7 +125,7 @@ namespace Ogre {
 #elif defined( __BORLANDC__ )
 #   define OGRE_COMPILER OGRE_COMPILER_BORL
 #   define OGRE_COMP_VER __BCPLUSPLUS__
-#   define __FUNCTION__ __FUNC__ 
+#   define __FUNCTION__ __FUNC__
 #else
 #   pragma error "No known compiler. Abort! Abort!"
 

--- a/OgreMain/include/OgrePlatformInformation.h
+++ b/OgreMain/include/OgrePlatformInformation.h
@@ -51,7 +51,6 @@ namespace Ogre {
 */
 #if OGRE_CPU == OGRE_CPU_X86
 #   define OGRE_SIMD_ALIGNMENT  16
-
 #else
 #   define OGRE_SIMD_ALIGNMENT  16
 #endif

--- a/OgreMain/src/OgrePlatformInformation.cpp
+++ b/OgreMain/src/OgrePlatformInformation.cpp
@@ -71,7 +71,7 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-#if OGRE_CPU == OGRE_CPU_X86
+#if OGRE_CPU == OGRE_CPU_X86 && !defined(__e2k__)
 
     //---------------------------------------------------------------------
     // Struct for store CPUID instruction result, compiler-independent
@@ -620,7 +620,55 @@ namespace Ogre {
         return cpuID;
     }
 
-#else   // OGRE_CPU == OGRE_CPU_MIPS
+#elif OGRE_CPU == OGRE_CPU_X86 && defined(__e2k__)  // OGRE_CPU == OGRE_CPU_E2K
+
+    //---------------------------------------------------------------------
+    static uint _detectCpuFeatures(void)
+    {
+        // Use preprocessor definitions to determine architecture and CPU features
+        uint features = 0;
+        // MCST e2k (Elbrus 2000) architecture has half native / half software support of most Intel/AMD SIMD
+        // e.g. MMX/SSE/SSE2/SSE3/SSSE3/SSE4.1/SSE4.2/AES/AVX/AVX2 & 3DNow!/SSE4a/XOP/FMA4
+        features |= PlatformInformation::CPU_FEATURE_PRO;
+        features |= PlatformInformation::CPU_FEATURE_TSC;
+        features |= PlatformInformation::CPU_FEATURE_FPU;
+        features |= PlatformInformation::CPU_FEATURE_CMOV;
+#       if defined(__MMX__)
+            features |= PlatformInformation::CPU_FEATURE_MMX;
+#       endif
+#       if defined(__SSE__)
+            features |= PlatformInformation::CPU_FEATURE_MMXEXT;
+            features |= PlatformInformation::CPU_FEATURE_SSE;
+#       endif
+#       if defined(__SSE2__)
+            features |= PlatformInformation::CPU_FEATURE_SSE2;
+#       endif
+#       if defined(__SSE3__)
+            features |= PlatformInformation::CPU_FEATURE_SSE3;
+#       endif
+#       if defined(__3dNOW__)
+            features |= PlatformInformation::CPU_FEATURE_3DNOW;
+#       endif
+#       if defined(__3dNOW_A__)
+            features |= PlatformInformation::CPU_FEATURE_3DNOWEXT;
+#       endif
+        return features;
+    }
+    //---------------------------------------------------------------------
+    static String _detectCpuIdentifier(void)
+    {
+        String cpuID = __builtin_cpu_name();
+
+        return cpuID;
+    }
+    //---------------------------------------------------------------------
+    // Added for compatibility with x86 architecture in void PlatformInformation::log(Log* pLog) section
+    static int _isSupportCpuid(void)
+    {
+        return true;
+    }
+
+#else  // OGRE_CPU == OGRE_CPU_E2K
 
     //---------------------------------------------------------------------
     static uint _detectCpuFeatures(void)
@@ -731,6 +779,5 @@ namespace Ogre {
         pLog->logMessage("-------------------------");
 
     }
-
 
 }

--- a/RenderSystems/GL3Plus/include/Deprecated/OgreGL3PlusTexture.h
+++ b/RenderSystems/GL3Plus/include/Deprecated/OgreGL3PlusTexture.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
   -----------------------------------------------------------------------------
   This source file is part of OGRE
   (Object-oriented Graphics Rendering Engine)

--- a/RenderSystems/GL3Plus/src/Deprecated/OgreGL3PlusNullTexture.cpp
+++ b/RenderSystems/GL3Plus/src/Deprecated/OgreGL3PlusNullTexture.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
   -----------------------------------------------------------------------------
   This source file is part of OGRE
   (Object-oriented Graphics Rendering Engine)


### PR DESCRIPTION
e2k (Elbrus 2000) - this is VLIW/EPIC architecture, like Intel Itanium (IA-64) architecture.

- https://en.wikipedia.org/wiki/Elbrus_2000