### PR TITLE
Fixing compile errors, when OGRE_CONFIG_DOUBLE is TRUE

### DIFF
--- a/Components/Hlms/Pbs/src/Vct/OgreVctLighting.cpp
+++ b/Components/Hlms/Pbs/src/Vct/OgreVctLighting.cpp
@@ -595,7 +595,7 @@ namespace Ogre
         mBounceVoxelCellSize->setManualValue( mVoxelizer->getVoxelCellSize() );
         mBounceInvVoxelResolution->setManualValue( 1.0f / mVoxelizer->getVoxelResolution() );
         //mBounceIterationDampening->setManualValue( 1.0f / (Math::PI * (bounceIteration * 0.5f + 1.0f)) );
-        mBounceIterationDampening->setManualValue( 1.0f / Math::PI );
+        mBounceIterationDampening->setManualValue( 1.0f / (float)Math::PI );
         mBounceStartBiasInvBias->setManualValue( Vector2( invSmallestRes, smallestRes ) );
         mBounceShaderParams->setDirty();
 

--- a/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
+++ b/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
@@ -125,7 +125,7 @@ namespace Ogre
         uint32              mIdentifier;
 
         ColourValue mClearColour[OGRE_MAX_MULTIPLE_RENDER_TARGETS];
-        float       mClearDepth;
+        Real        mClearDepth;
         uint32      mClearStencil;
         LoadAction::LoadAction mLoadActionColour[OGRE_MAX_MULTIPLE_RENDER_TARGETS];
         LoadAction::LoadAction mLoadActionDepth;


### PR DESCRIPTION
Fixed such compile errors:
- OgreScriptTranslator.cpp:8980:60: error: cannot initialize a parameter of type 'Ogre::Real *' (aka 'double *') with an rvalue of type 'float *': `if( !getReal(prop->values.front(), &passClear->mClearDepth) )`
- Components/Hlms/Pbs/src/Vct/OgreVctLighting.cpp:598:36: error: call to member function 'setManualValue' is ambiguous: `mBounceIterationDampening->setManualValue( 1.0f / Math::PI )`