### PR TITLE
Make Terra system working with Forward3D and/or PCC (with DirectX and Metal render systems)

### DIFF
--- a/Samples/2.0/Tutorials/Tutorial_Terrain/src/Terra/Hlms/OgreHlmsTerra.cpp
+++ b/Samples/2.0/Tutorials/Tutorial_Terrain/src/Terra/Hlms/OgreHlmsTerra.cpp
@@ -491,9 +491,9 @@ namespace Ogre
                 if( mGridBuffer )
                 {
                     *commandBuffer->addCommand<CbShaderBuffer>() =
-                            CbShaderBuffer( PixelShader, texUnit++, mGridBuffer, 0, 0 );
-                    *commandBuffer->addCommand<CbShaderBuffer>() =
                             CbShaderBuffer( PixelShader, texUnit++, mGlobalLightListBuffer, 0, 0 );
+                    *commandBuffer->addCommand<CbShaderBuffer>() =
+                            CbShaderBuffer( PixelShader, texUnit++, mGridBuffer, 0, 0 );
                 }
 
                 texUnit += mReservedTexSlots;

--- a/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
@@ -144,11 +144,15 @@
 		@end
 	@end
 
-	pixelData.roughness =	(roughness0 * detailWeights.x * material.roughness.x +
-							 roughness1 * detailWeights.y * material.roughness.y) +
-							(roughness2 * detailWeights.z * material.roughness.z +
-							 roughness3 * detailWeights.w * material.roughness.w);
-	pixelData.roughness = max( pixelData.roughness, 0.001f );
+	pixelData.perceptualRoughness =	(roughness0 * detailWeights.x * material.roughness.x +
+									 roughness1 * detailWeights.y * material.roughness.y) +
+									(roughness2 * detailWeights.z * material.roughness.z +
+									 roughness3 * detailWeights.w * material.roughness.w);
+	@property( perceptual_roughness )
+		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, 0.001f );
+	@else
+		pixelData.roughness = max( pixelData.perceptualRoughness, 0.001f );
+	@end
 @end
 
 @undefpiece( LoadNormalData )

--- a/Samples/Media/Hlms/Terra/HLSL/PixelShader_ps.hlsl
+++ b/Samples/Media/Hlms/Terra/HLSL/PixelShader_ps.hlsl
@@ -15,6 +15,8 @@ struct PS_INPUT
 	@insertpiece( Terra_VStoPS_block )
 };
 
+@pset( currSampler, samplerStateStart )
+
 @property( !hlms_render_depth_only )
 	@property( hlms_gen_normals_gbuffer )
 		#define outPs_normals outPs.normals
@@ -66,7 +68,7 @@ SamplerState samplerStateTerra		: register(s@value(terrainNormals));
 		@property( !hlms_cubemaps_use_dpm )
 			TextureCubeArray	texEnvProbeMap : register(t@value(texEnvProbeMap));
 		@else
-			@property( use_envprobe_map )Texture2DArray	texEnvProbeMap : register(t@value(texEnvProbeMap));@end
+			Texture2DArray	texEnvProbeMap : register(t@value(texEnvProbeMap));
 			@insertpiece( DeclDualParaboloidFunc )
 		@end
 	@end
@@ -76,7 +78,7 @@ SamplerState samplerStateTerra		: register(s@value(terrainNormals));
 @end
 
 @foreach( num_samplers, n )
-	SamplerState samplerState@value(samplerStateStart) : register(s@counter(samplerStateStart));@end
+	SamplerState samplerState@value(currSampler) : register(s@counter(currSampler));@end
 
 @property( use_parallax_correct_cubemaps )
 	@insertpiece( DeclParallaxLocalCorrect )
@@ -92,6 +94,7 @@ SamplerState samplerStateTerra		: register(s@value(terrainNormals));
 @insertpiece( DeclAreaLtcLightFuncs )
 
 @insertpiece( DeclVctTextures )
+@insertpiece( DeclIrradianceFieldTextures )
 
 @insertpiece( DeclOutputType )
 

--- a/Samples/Media/Hlms/Terra/HLSL/PixelShader_ps.hlsl
+++ b/Samples/Media/Hlms/Terra/HLSL/PixelShader_ps.hlsl
@@ -48,7 +48,7 @@ SamplerState samplerStateTerra		: register(s@value(terrainNormals));
 
 @property( hlms_forwardplus )
 	Buffer<uint> f3dGrid : register(t@value(f3dGrid));
-	Buffer<float4> f3dLightList : register(t@value(f3dLightList));
+	ReadOnlyBuffer( @value(f3dLightList), float4, f3dLightList );
 @end
 
 @property( irradiance_volumes )

--- a/Samples/Media/Hlms/Terra/HLSL/VertexShader_vs.hlsl
+++ b/Samples/Media/Hlms/Terra/HLSL/VertexShader_vs.hlsl
@@ -30,7 +30,11 @@ struct PS_INPUT
 @insertpiece( custom_vs_uniformDeclaration )
 
 // START UNIFORM DECLARATION
-Texture2D<float> heightMap: register(t0);
+@property( !terra_use_uint )
+	Texture2D<float> heightMap: register(t@value(heightMap));
+@else
+	Texture2D<uint> heightMap: register(t@value(heightMap));
+@end
 // END UNIFORM DECLARATION
 
 PS_INPUT main( VS_INPUT input )

--- a/Samples/Media/Hlms/Terra/Metal/PixelShader_ps.metal
+++ b/Samples/Media/Hlms/Terra/Metal/PixelShader_ps.metal
@@ -17,6 +17,8 @@ struct PS_INPUT
 	@insertpiece( Terra_VStoPS_block )
 };
 
+@pset( currSampler, samplerStateStart )
+
 @property( !hlms_render_depth_only )
 	@property( hlms_gen_normals_gbuffer )
 		#define outPs_normals outPs.normals
@@ -111,12 +113,10 @@ fragment @insertpiece( output_type ) main_metal
 	@property( use_envprobe_map )
 		@property( !hlms_enable_cubemaps_auto )
 			, texturecube<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
-		@end
-		@property( hlms_enable_cubemaps_auto )
+		@else
 			@property( !hlms_cubemaps_use_dpm )
 				, texturecube_array<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
-			@end
-			@property( hlms_cubemaps_use_dpm )
+			@else
 				, texture2d_array<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 			@end
 		@end
@@ -125,11 +125,12 @@ fragment @insertpiece( output_type ) main_metal
 		@end
 	@end
 	@foreach( num_samplers, n )
-		, sampler samplerState@value(samplerStateStart) [[sampler(@counter(samplerStateStart))]]@end
+		, sampler samplerState@value(currSampler) [[sampler(@counter(currSampler))]]@end
 	@insertpiece( DeclDecalsSamplers )
 	@insertpiece( DeclShadowSamplers )
 	@insertpiece( DeclAreaLtcTextures )
 	@insertpiece( DeclVctTextures )
+	@insertpiece( DeclIrradianceFieldTextures )
 )
 {
 	PS_OUTPUT outPs;

--- a/Samples/Media/Hlms/Terra/Metal/VertexShader_vs.metal
+++ b/Samples/Media/Hlms/Terra/Metal/VertexShader_vs.metal
@@ -34,7 +34,11 @@ vertex PS_INPUT main_metal
 	// START UNIFORM DECLARATION
 	@insertpiece( PassDecl )
 	@insertpiece( TerraInstanceDecl )
-	, texture2d<float, access::read> heightMap [[texture(0)]]
+	@property( !terra_use_uint )
+		, texture2d<float, access::read> heightMap [[texture(@value(heightMap))]]
+	@else
+		, texture2d<uint, access::read> heightMap [[texture(@value(heightMap))]]
+	@end
 	@insertpiece( custom_vs_uniformDeclaration )
 	// END UNIFORM DECLARATION
 )


### PR DESCRIPTION
As the title explains, creating a terrain in a scene with Forward3D and/or PCC enabled ends with some shader build errors (at least using DirectX 11 render system). This PR aims to solve this.
Please note that I've changed Metal shaders "blindly" since I'm unable to test that render system.