### PR TITLE
Fix Terra datablock destroys its sampler blocks twice

### DIFF
--- a/Samples/2.0/Tutorials/Tutorial_Terrain/src/Terra/Hlms/OgreHlmsTerraDatablock.cpp
+++ b/Samples/2.0/Tutorials/Tutorial_Terrain/src/Terra/Hlms/OgreHlmsTerraDatablock.cpp
@@ -81,16 +81,6 @@ namespace Ogre
     {
         if( mAssignedPool )
             static_cast<HlmsTerra*>(mCreator)->releaseSlot( this );
-
-        HlmsManager *hlmsManager = mCreator->getHlmsManager();
-        if( hlmsManager )
-        {
-            for( size_t i=0; i<NUM_TERRA_TEXTURE_TYPES; ++i )
-            {
-                if( mSamplerblocks[i] )
-                    hlmsManager->destroySamplerblock( mSamplerblocks[i] );
-            }
-        }
     }
     //-----------------------------------------------------------------------------------
     void HlmsTerraDatablock::calculateHash()


### PR DESCRIPTION
Sampler blocks destruction is already made in `OGRE_HLMS_TEXTURE_BASE_CLASS::~OGRE_HLMS_TEXTURE_BASE_CLASS`. `HlmsTerraDatablock` do it again in its dtor corrupting the blocks ref count.