### PR TITLE
Check for directory and symbolic links in build scripts.

### DIFF
--- a/Scripts/BuildScripts/build_ogre_linux.sh
+++ b/Scripts/BuildScripts/build_ogre_linux.sh
@@ -4,7 +4,7 @@ OGRE_BRANCH_NAME="{0}"
 
 mkdir Ogre
 cd Ogre
-if test ! -f ogre-next-deps; then
+if test ! -d ogre-next-deps; then
 	mkdir ogre-next-deps
 	echo "--- Cloning ogre-next-deps ---"
 	git clone --recurse-submodules --shallow-submodules https://github.com/OGRECave/ogre-next-deps || exit $?
@@ -20,13 +20,13 @@ ninja || exit $?
 ninja install || exit $?
 
 cd ../../
-if test ! -f ogre-next; then
+if test ! -d ogre-next; then
 	mkdir ogre-next
 	echo "--- Cloning Ogre {0} ---"
 	git clone --branch ${{OGRE_BRANCH_NAME}} https://github.com/OGRECave/ogre-next || exit $?
 fi
 cd ogre-next
-if test ! -f Dependencies; then
+if test ! -L Dependencies; then
 	ln -s ../ogre-next-deps/build/ogredeps Dependencies
 fi
 mkdir -p build/Debug

--- a/Scripts/BuildScripts/output/build_ogre_linux_c++11.sh
+++ b/Scripts/BuildScripts/output/build_ogre_linux_c++11.sh
@@ -4,7 +4,7 @@ OGRE_BRANCH_NAME="master"
 
 mkdir Ogre
 cd Ogre
-if test ! -f ogre-next-deps; then
+if test ! -d ogre-next-deps; then
 	mkdir ogre-next-deps
 	echo "--- Cloning ogre-next-deps ---"
 	git clone --recurse-submodules --shallow-submodules https://github.com/OGRECave/ogre-next-deps || exit $?
@@ -20,13 +20,13 @@ ninja || exit $?
 ninja install || exit $?
 
 cd ../../
-if test ! -f ogre-next; then
+if test ! -d ogre-next; then
 	mkdir ogre-next
 	echo "--- Cloning Ogre master ---"
 	git clone --branch ${OGRE_BRANCH_NAME} https://github.com/OGRECave/ogre-next || exit $?
 fi
 cd ogre-next
-if test ! -f Dependencies; then
+if test ! -L Dependencies; then
 	ln -s ../ogre-next-deps/build/ogredeps Dependencies
 fi
 mkdir -p build/Debug

--- a/Scripts/BuildScripts/output/build_ogre_linux_c++98.sh
+++ b/Scripts/BuildScripts/output/build_ogre_linux_c++98.sh
@@ -4,7 +4,7 @@ OGRE_BRANCH_NAME="master"
 
 mkdir Ogre
 cd Ogre
-if test ! -f ogre-next-deps; then
+if test ! -d ogre-next-deps; then
 	mkdir ogre-next-deps
 	echo "--- Cloning ogre-next-deps ---"
 	git clone --recurse-submodules --shallow-submodules https://github.com/OGRECave/ogre-next-deps || exit $?
@@ -20,13 +20,13 @@ ninja || exit $?
 ninja install || exit $?
 
 cd ../../
-if test ! -f ogre-next; then
+if test ! -d ogre-next; then
 	mkdir ogre-next
 	echo "--- Cloning Ogre master ---"
 	git clone --branch ${OGRE_BRANCH_NAME} https://github.com/OGRECave/ogre-next || exit $?
 fi
 cd ogre-next
-if test ! -f Dependencies; then
+if test ! -L Dependencies; then
 	ln -s ../ogre-next-deps/build/ogredeps Dependencies
 fi
 mkdir -p build/Debug

--- a/Scripts/BuildScripts/output/build_ogre_linux_c++latest.sh
+++ b/Scripts/BuildScripts/output/build_ogre_linux_c++latest.sh
@@ -4,7 +4,7 @@ OGRE_BRANCH_NAME="master"
 
 mkdir Ogre
 cd Ogre
-if test ! -f ogre-next-deps; then
+if test ! -d ogre-next-deps; then
 	mkdir ogre-next-deps
 	echo "--- Cloning ogre-next-deps ---"
 	git clone --recurse-submodules --shallow-submodules https://github.com/OGRECave/ogre-next-deps || exit $?
@@ -20,13 +20,13 @@ ninja || exit $?
 ninja install || exit $?
 
 cd ../../
-if test ! -f ogre-next; then
+if test ! -d ogre-next; then
 	mkdir ogre-next
 	echo "--- Cloning Ogre master ---"
 	git clone --branch ${OGRE_BRANCH_NAME} https://github.com/OGRECave/ogre-next || exit $?
 fi
 cd ogre-next
-if test ! -f Dependencies; then
+if test ! -L Dependencies; then
 	ln -s ../ogre-next-deps/build/ogredeps Dependencies
 fi
 mkdir -p build/Debug


### PR DESCRIPTION
Rebuilds with build script for Linux fails since it checks for regular files instead of directories and symbolic link.