### PR TITLE
Add support to set renderables default render queue sub-group

### DIFF
--- a/OgreMain/include/OgreRenderable.h
+++ b/OgreMain/include/OgreRenderable.h
@@ -431,7 +431,15 @@ namespace Ogre {
         void setRenderQueueSubGroup( uint8 subGroup )   { mRenderQueueSubGroup = subGroup; }
         uint8 getRenderQueueSubGroup(void) const        { return mRenderQueueSubGroup; }
 
+        /** Sets the default render queue sub group for all future Renderable instances.
+        */
+        static void setDefaultRenderQueueSubGroup( uint8 subGroup ) { msDefaultRenderQueueSubGroup = subGroup; }
+        static uint8 getDefaultRenderQueueSubGroup() { return msDefaultRenderQueueSubGroup; }
+
     protected:
+        /// Default query flags
+        static uint8 msDefaultRenderQueueSubGroup;
+
         CustomParameterMap mCustomParameters;
         /// VAO to render the submesh. One per LOD level. Each LOD may or
         /// may not share the vertex and index buffers the other levels

--- a/OgreMain/src/OgreRenderable.cpp
+++ b/OgreMain/src/OgreRenderable.cpp
@@ -39,12 +39,14 @@ THE SOFTWARE.
 
 namespace Ogre
 {
+    uint8 Renderable::msDefaultRenderQueueSubGroup = 0;
+    //-----------------------------------------------------------------------------------
     Renderable::Renderable() :
         mHlmsHash( 0 ),
         mHlmsCasterHash( 0 ),
         mHlmsDatablock( 0 ),
         mCustomParameter( 0 ),
-        mRenderQueueSubGroup( 0 ),
+        mRenderQueueSubGroup( msDefaultRenderQueueSubGroup ),
         mHasSkeletonAnimation( false ),
         mCurrentMaterialLod( 0 ),
         mLodMaterial( &MovableObject::c_DefaultLodMesh ),


### PR DESCRIPTION
There's no way to do this right now and a fixed value of 0 can be a bit limiting/impractical in certain situation (e.g. having to lower the rendering priority of just few renderables at runtime). I mimicked what is done for `MovableObject::msDefault*`.