### PR TITLE
Add support to set transparency sort policy per-camera

### DIFF
--- a/OgreMain/include/OgreCamera.h
+++ b/OgreMain/include/OgreCamera.h
@@ -123,6 +123,13 @@ namespace Ogre {
 
         };
     protected:
+        typedef ArrayReal SortFunc( const Camera *camera, ObjectData objData );
+
+        static SortFunc sortby_distance;
+        static SortFunc sortby_distanceConsideringRadius;
+        static SortFunc sortby_projectedZ;
+        static SortFunc sortby_projectedZConsideringRadius;
+
         /// Scene manager responsible for the scene
         SceneManager *mSceneMgr;
 
@@ -205,6 +212,8 @@ namespace Ogre {
         typedef vector<Listener*>::type ListenerList;
         ListenerList mListeners;
 
+        SortMode mSortMode;
+        SortFunc *mSortFunc;
 
         // Internal functions for calcs
         bool isViewOutOfDate(void) const;
@@ -752,6 +761,13 @@ namespace Ogre {
         /// Returns true if the asked render queue has been rendered. False otherwise
         bool isRenderedRq( size_t rqId ) const          { return mRenderedRqs[rqId]; }
         
+        void setSortMode( SortMode mode, bool considerRadius );
+
+        SortMode getSortMode( void ) const         { return mSortMode; }
+        bool isSortConsideringRadius( void ) const { return mSortFunc == sortby_distanceConsideringRadius ||
+                                                            mSortFunc == sortby_projectedZConsideringRadius; }
+
+        ArrayReal getDistanceToCamera( ObjectData objData ) const { return mSortFunc( this, objData ); }
     };
     /** @} */
     /** @} */

--- a/OgreMain/src/OgreCamera.cpp
+++ b/OgreMain/src/OgreCamera.cpp
@@ -1163,7 +1163,7 @@ namespace Ogre {
         ArrayVector3 cameraPos;
         cameraPos.setAll( camera->_getCachedDerivedPosition() );
 
-        return cameraPos.distance( objData.mWorldAabb->mCenter - cameraPos );
+        return cameraPos.distance( objData.mWorldAabb->mCenter );
     }
     //-----------------------------------------------------------------------
     ArrayReal Camera::sortby_distanceConsideringRadius( const Camera *camera, ObjectData objData )

--- a/OgreMain/src/OgreMovableObject.cpp
+++ b/OgreMain/src/OgreMovableObject.cpp
@@ -447,9 +447,7 @@ namespace Ogre {
             ArrayReal       planeNegD;
         };
 
-        ArrayVector3 cameraPos, cameraDir, lodCameraPos;
-        cameraPos.setAll( frustum->_getCachedDerivedPosition() );
-        cameraDir.setAll( -frustum->_getCachedDerivedOrientation().zAxis() );
+        ArrayVector3 lodCameraPos;
         lodCameraPos.setAll( lodCamera->_getCachedDerivedPosition() );
 
         // Flip the bit from shadow caster, and leave only that in "includeNonCasters"
@@ -545,10 +543,7 @@ namespace Ogre {
                                 Mathlib::TestFlags4( Mathlib::Or( *visibilityFlags, includeNonCasters ),
                                                         Mathlib::SetAll( LAYER_SHADOW_CASTER ) ) );
 
-            //Project the vector to the object into the camera's plane. This allows
-            //us to use depth for sorting, rather than euclidean distance
-            *distanceToCamera = cameraDir.dotProduct( objData.mWorldAabb->mCenter -
-                                                      cameraPos ) - *worldRadius;
+            *distanceToCamera = frustum->getDistanceToCamera( objData );
 
             //Fuse result with visibility flag
             // finalMask = ((visible|infinite_aabb) & sceneFlags & visibilityFlags) != 0 ? 0xffffffff : 0


### PR DESCRIPTION
See: https://forums.ogre3d.org/viewtopic.php?p=549934#p549934

I set "sort by euclidean distance, without considering the bounding sphere radius" as a default policy. In my opinion, it's the best sorting policy for 3D scenes with perspective cameras (the main OGRE usage scenario). In fact, the same policy is used as a default by other engines as well. If this choice is too strict or monocratic, I can add a static `Camera::setDefaultSortMode` method to set the default sorting policy for cameras created from now on (similar to what has been done for `MovableObject` and `Renderable`).