### PR TITLE
Add support to set cameras default sort mode

### DIFF
--- a/OgreMain/include/OgreCamera.h
+++ b/OgreMain/include/OgreCamera.h
@@ -236,10 +236,16 @@ namespace Ogre {
         typedef vector<Listener*>::type ListenerList;
         ListenerList mListeners;
 
+        static CameraSortMode msDefaultSortMode;
+
     public:
         /// PUBLIC VARIABLE. This variable can be altered directly.
         /// Changes are reflected immediately.
         CameraSortMode mSortMode;
+
+        /** Sets the default sort mode for all future Camera instances. */
+        static void setDefaultSortMode( CameraSortMode sortMode ) { msDefaultSortMode = sortMode; }
+        static CameraSortMode getDefaultSortMode( void ) { return msDefaultSortMode; }
 
     protected:
         // Internal functions for calcs

--- a/OgreMain/src/OgreCamera.cpp
+++ b/OgreMain/src/OgreCamera.cpp
@@ -39,6 +39,7 @@ THE SOFTWARE.
 namespace Ogre {
 
     String Camera::msMovableType = "Camera";
+    Camera::CameraSortMode Camera::msDefaultSortMode = Camera::SortModeDepth;
     //-----------------------------------------------------------------------
     Camera::Camera( IdType id, ObjectMemoryManager *objectMemoryManager, SceneManager* sm )
         : Frustum( id, objectMemoryManager ),
@@ -60,7 +61,7 @@ namespace Ogre {
         mUseMinPixelSize(false),
         mPixelDisplayRatio(0),
         mConstantBiasScale(1.0f),
-        mSortMode( Camera::SortModeDepth )
+        mSortMode( msDefaultSortMode )
     {
 
         // Reasonable defaults to camera params


### PR DESCRIPTION
Even if commit c2edd71f8ec0c79864e71f4750f3fe3811648ab0 introduced support to change objects sort mode per-camera, there are still cameras which are hard to retrieve (shadows, PCCs, etc.). For these cameras, as well as for other scenarios, being able to change the default sort mode would be very useful.