### PR TITLE
Vulkan needs to be the last loaded render system.

### DIFF
--- a/CMake/Templates/plugins.cfg.in
+++ b/CMake/Templates/plugins.cfg.in
@@ -4,10 +4,11 @@
 PluginFolder=@OGRE_PLUGIN_DIR_REL@
 
 # Define plugins
-@OGRE_COMMENT_RENDERSYSTEM_VULKAN@ Plugin=RenderSystem_Vulkan
 @OGRE_COMMENT_RENDERSYSTEM_D3D11@ Plugin=RenderSystem_Direct3D11
 @OGRE_COMMENT_RENDERSYSTEM_GL3PLUS@ Plugin=RenderSystem_GL3Plus
 @OGRE_COMMENT_RENDERSYSTEM_GLES@ Plugin=RenderSystem_GLES
 @OGRE_COMMENT_RENDERSYSTEM_GLES2@ Plugin=RenderSystem_GLES2
 @OGRE_COMMENT_RENDERSYSTEM_METAL@ Plugin=RenderSystem_Metal
+# If you add another RenderSystem make sure Vulkan is the last one or you might encounter issues on nVidia cards.
+@OGRE_COMMENT_RENDERSYSTEM_VULKAN@ Plugin=RenderSystem_Vulkan_d
 @OGRE_COMMENT_PLUGIN_PARTICLEFX@ Plugin=Plugin_ParticleFX

--- a/CMake/Templates/plugins_d.cfg.in
+++ b/CMake/Templates/plugins_d.cfg.in
@@ -4,10 +4,11 @@
 PluginFolder=@OGRE_PLUGIN_DIR_DBG@
 
 # Define plugins
-@OGRE_COMMENT_RENDERSYSTEM_VULKAN@ Plugin=RenderSystem_Vulkan_d
 @OGRE_COMMENT_RENDERSYSTEM_D3D11@ Plugin=RenderSystem_Direct3D11_d
 @OGRE_COMMENT_RENDERSYSTEM_GL3PLUS@ Plugin=RenderSystem_GL3Plus_d
 @OGRE_COMMENT_RENDERSYSTEM_GLES@ Plugin=RenderSystem_GLES_d
 @OGRE_COMMENT_RENDERSYSTEM_GLES2@ Plugin=RenderSystem_GLES2_d
 @OGRE_COMMENT_RENDERSYSTEM_METAL@ Plugin=RenderSystem_Metal_d
+# If you add another RenderSystem make sure Vulkan is the last one or you might encounter issues on nVidia cards.
+@OGRE_COMMENT_RENDERSYSTEM_VULKAN@ Plugin=RenderSystem_Vulkan_d
 @OGRE_COMMENT_PLUGIN_PARTICLEFX@ Plugin=Plugin_ParticleFX_d


### PR DESCRIPTION
On nVidia graphics cards you get a crash if you try to use render APIs after calls to Vulkan API.