### PR TITLE
Enhance textures memory usage dump functionality

### DIFF
--- a/OgreMain/include/OgreGpuResource.h
+++ b/OgreMain/include/OgreGpuResource.h
@@ -64,6 +64,8 @@ namespace Ogre
             /// (keep everything on Sys. RAM; load to GPU based on scene demands)
             Resident
         };
+
+        const char *toString( GpuResidency value );
     }
 
     namespace GpuPageOutStrategy

--- a/OgreMain/include/OgreTextureGpuManager.h
+++ b/OgreMain/include/OgreTextureGpuManager.h
@@ -917,8 +917,16 @@ namespace Ogre
                              size_t &outUsedStagingTextureBytes,
                              size_t &outAvailableStagingTextureBytes );
 
+        enum MemoryUsageMask
+        {
+            OnStorage = 1 << GpuResidency::OnStorage,
+            OnSystemRam = 1 << GpuResidency::OnSystemRam,
+            Resident = 1 << GpuResidency::Resident,
+            All = OnStorage | OnSystemRam | Resident
+        };
+
         void dumpStats(void) const;
-        void dumpMemoryUsage( Log* log ) const;
+        void dumpMemoryUsage( Log *log, Ogre::uint32 mask = MemoryUsageMask::All ) const;
 
         /// Sets a new listener. The old one will be destroyed with OGRE_DELETE
         /// See TextureGpuManagerListener. Pointer cannot be null.

--- a/OgreMain/src/OgreGpuResource.cpp
+++ b/OgreMain/src/OgreGpuResource.cpp
@@ -32,6 +32,20 @@ THE SOFTWARE.
 
 namespace Ogre
 {
+    namespace GpuResidency
+    {
+        // clang-format off
+        static const char* gpuResidencyTable[] =
+        {
+            "OnStorage",
+            "OnSystemRam",
+            "Resident"
+        };
+        // clang-format on
+
+        const char *toString( GpuResidency value ) { return gpuResidencyTable[value]; }
+    }  // namespace GpuResidency
+
     GpuResource::GpuResource( GpuPageOutStrategy::GpuPageOutStrategy pageOutStrategy,
                               VaoManager *vaoManager, IdString name ) :
         mResidencyStatus( GpuResidency::OnStorage ),

--- a/OgreMain/src/OgreTextureGpu.cpp
+++ b/OgreMain/src/OgreTextureGpu.cpp
@@ -1015,6 +1015,9 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     size_t TextureGpu::getSizeBytes(void) const
     {
+        if( mResidencyStatus == GpuResidency::OnStorage )
+            return 0;
+
         size_t sizeBytes = PixelFormatGpuUtils::calculateSizeBytes( mWidth, mHeight, getDepth(),
                                                                     getNumSlices(),
                                                                     mPixelFormat, mNumMipmaps, 4u );

--- a/OgreMain/src/OgreTextureGpuManager.cpp
+++ b/OgreMain/src/OgreTextureGpuManager.cpp
@@ -1184,7 +1184,7 @@ namespace Ogre
         logMgr.logMessage( text.c_str() );
     }
     //-----------------------------------------------------------------------------------
-    void TextureGpuManager::dumpMemoryUsage( Log* log ) const
+    void TextureGpuManager::dumpMemoryUsage( Log *log, uint32 mask ) const
     {
         Log* logActual = log == NULL ? LogManager::getSingleton().getDefaultLog() : log;
 
@@ -1246,7 +1246,7 @@ namespace Ogre
 
         logActual->logMessage(
                     "|Alias|Resource Name|Width|Height|Depth|Num Slices|Format|Mipmaps|MSAA|Size in bytes|"
-                    "RTT|UAV|Manual|MSAA Explicit|Reinterpretable|AutomaticBatched",
+                    "RTT|UAV|Manual|MSAA Explicit|Reinterpretable|AutomaticBatched|Residency",
                     LML_CRITICAL );
 
         ResourceEntryMap::const_iterator itEntry = mEntries.begin();
@@ -1256,6 +1256,12 @@ namespace Ogre
         {
             const ResourceEntry &entry = itEntry->second;
             text.clear();
+
+            if( !( ( 1 << entry.texture->getResidencyStatus() ) & mask ) )
+            {
+                ++itEntry;
+                continue;
+            }
 
             const size_t bytesTexture = entry.texture->getSizeBytes();
 
@@ -1272,7 +1278,8 @@ namespace Ogre
                     entry.texture->_isManualTextureFlagPresent(), "|" );
             text.a( entry.texture->hasMsaaExplicitResolves(), "|",
                     entry.texture->isReinterpretable(), "|",
-                    entry.texture->hasAutomaticBatching() );
+                    entry.texture->hasAutomaticBatching(), "|",
+                    GpuResidency::toString( entry.texture->getResidencyStatus()) );
 
             if( !entry.texture->hasAutomaticBatching() )
                 bytesOutsidePool += bytesTexture;


### PR DESCRIPTION
This PR adds support to filter (by a mask) memory usage by textures residency as well as it fixes some bugs in the dump itself (e.g. a `Resident` > `OnStorage` transition causes the dump to print a wrong occupation).