### PR TITLE
Make sure Ogre::Bone has same debug requirements

### DIFF
--- a/OgreMain/include/Animation/OgreBone.h
+++ b/OgreMain/include/Animation/OgreBone.h
@@ -287,7 +287,7 @@ namespace Ogre {
         */
         FORCEINLINE const SimpleMatrixAf4x3& _getFullTransform(void) const
         {
-#if OGRE_DEBUG_MODE
+#if OGRE_DEBUG_MODE >= OGRE_DEBUG_MEDIUM
             assert( !mCachedTransformOutOfDate &&
                     (!mDebugParentNode || !mDebugParentNode->isCachedTransformOutOfDate()) );
 #endif
@@ -309,7 +309,7 @@ namespace Ogre {
                                          ArrayMatrixAf4x3 const * RESTRICT_ALIAS reverseBind,
                                          size_t numBinds );
 
-#if OGRE_DEBUG_MODE
+#if OGRE_DEBUG_MODE >= OGRE_DEBUG_MEDIUM
         virtual void _setCachedTransformOutOfDate(void);
         bool isCachedTransformOutOfDate(void) const             { return mCachedTransformOutOfDate; }
 #endif

--- a/Samples/2.0/Common/src/GraphicsSystem.cpp
+++ b/Samples/2.0/Common/src/GraphicsSystem.cpp
@@ -35,6 +35,8 @@
 
 #include "OgreLogManager.h"
 
+#include "OgrePlatformInformation.h"
+
 #include "System/Android/AndroidSystems.h"
 
 #include <fstream>


### PR DESCRIPTION

This is to match `Ogre::Node`, otherwise compilation errors can result
from mismatched `OGRE_DEBUG_MODE`. In my case, I was building with `CMAKE_BUILD_TYPE=Debug`.

I don't know how to remove my merge and previous pull request commits, so I would appreciate some help if possible to edit this.