### PR TITLE
Fix debug mode in Ogre Node

### DIFF
--- a/OgreMain/include/OgreNode.h
+++ b/OgreMain/include/OgreNode.h
@@ -673,7 +673,7 @@ namespace Ogre {
         */
         virtual_l2 FORCEINLINE const Matrix4& _getFullTransform(void) const
         {
-#if OGRE_DEBUG_MODE
+#if OGRE_DEBUG_MODE >= OGRE_DEBUG_MEDIUM
             assert( !mCachedTransformOutOfDate );
 #endif
             return mTransform.mDerivedTransform[mTransform.mIndex];


### PR DESCRIPTION
Similar to f2739ec, Ogre::Node had debug modes that weren't in sync. I missed this one in my last PR.