### PR TITLE
Clear coat

### DIFF
--- a/Components/Hlms/Pbs/include/OgreHlmsPbs.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbs.h
@@ -601,6 +601,7 @@ namespace Ogre
         static const IdString BrdfBlinnPhong;
         static const IdString FresnelSeparateDiffuse;
         static const IdString GgxHeightCorrelated;
+        static const IdString ClearCoat;
         static const IdString LegacyMathBrdf;
         static const IdString RoughnessIsShininess;
 

--- a/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
@@ -236,7 +236,9 @@ namespace Ogre
         float   mEmissive[3];
         float   mNormalMapWeight;
         float   mRefractionStrength;
-        float   _padding1[3];
+        float   mClearCoat;
+        float   mClearCoatRoughness;
+        float   _padding1;
         float   mUserValue[3][4]; //can be used in custom pieces
         //uint16  mTexIndices[NUM_PBSM_TEXTURE_TYPES];
 
@@ -610,6 +612,17 @@ namespace Ogre
         */
         void setRefractionStrength( float strength );
         float getRefractionStrength( void ) const                   { return mRefractionStrength; }
+
+        /** Sets the strength of the of the clear coat layer and its roughness.
+        @param strength
+            This should be treated as a binary value, set to either 0 or 1. Intermediate values are
+            useful to control transitions between parts of the surface that have a clear coat layers and
+            parts that don't.
+        */
+        void setClearCoat( float clearCoat );
+        void setClearCoatRoughness( float roughness );
+        float getClearCoat( void ) const               { return mClearCoat; }
+        float getClearCoatRoughness( void ) const      { return mClearCoatRoughness; }
 
         /** When false, objects with this material will not receive shadows (independent of
             whether they case shadows or not)

--- a/Components/Hlms/Pbs/src/OgreHlmsJsonPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsJsonPbs.cpp
@@ -336,6 +336,20 @@ namespace Ogre
                                            useAlphaFromTextures, changeBlendblock );
         }
 
+        itor = json.FindMember( "clear_coat" );
+        if( itor != json.MemberEnd() && itor->value.IsObject() )
+        {
+            const rapidjson::Value &subobj = itor->value;
+
+            itor = subobj.FindMember( "value" );
+            if( itor != subobj.MemberEnd() && itor->value.IsNumber() )
+                pbsDatablock->setClearCoat( static_cast<float>( itor->value.GetDouble() ) );
+
+            itor = subobj.FindMember( "roughness" );
+            if( itor != subobj.MemberEnd() && itor->value.IsNumber() )
+                pbsDatablock->setClearCoatRoughness( static_cast<float>( itor->value.GetDouble() ) );
+        }
+
         itor = json.FindMember("diffuse");
         if( itor != json.MemberEnd() && itor->value.IsObject() )
         {
@@ -761,6 +775,16 @@ namespace Ogre
             toQuotedStr( pbsDatablock->getTransparencyMode(), outString );
             outString += ",\n\t\t\t\t\"use_alpha_from_textures\" : ";
             outString += pbsDatablock->getUseAlphaFromTextures() ? "true" : "false";
+            outString += "\n\t\t\t}";
+        }
+
+        if( pbsDatablock->getClearCoat() != 0.0f )
+        {
+            outString += ",\n\t\t\t\"clear_coat\" :\n\t\t\t{";
+            outString += "\n\t\t\t\t\"value\" : ";
+            outString += StringConverter::toString( pbsDatablock->getClearCoat() );
+            outString += ",\n\t\t\t\t\"roughness\" : ";
+            outString += StringConverter::toString( pbsDatablock->getClearCoatRoughness() );
             outString += "\n\t\t\t}";
         }
 

--- a/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
@@ -203,6 +203,7 @@ namespace Ogre
     const IdString PbsProperty::BrdfBlinnPhong    = IdString( "BRDF_BlinnPhong" );
     const IdString PbsProperty::FresnelSeparateDiffuse  = IdString( "fresnel_separate_diffuse" );
     const IdString PbsProperty::GgxHeightCorrelated     = IdString( "GGX_height_correlated" );
+    const IdString PbsProperty::ClearCoat               = IdString( "clear_coat" );
     const IdString PbsProperty::LegacyMathBrdf          = IdString( "legacy_math_brdf" );
     const IdString PbsProperty::RoughnessIsShininess    = IdString( "roughness_is_shininess" );
 
@@ -748,6 +749,8 @@ namespace Ogre
 
             if( !(brdf & PbsBrdf::FLAG_UNCORRELATED) )
                 setProperty( PbsProperty::GgxHeightCorrelated, 1 );
+
+            setProperty( PbsProperty::ClearCoat, datablock->mClearCoat != 0.0f );
         }
         else if( (brdf & PbsBrdf::BRDF_MASK) == PbsBrdf::CookTorrance )
             setProperty( PbsProperty::BrdfCookTorrance, 1 );

--- a/Components/Hlms/Pbs/src/OgreHlmsPbsDatablock.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbsDatablock.cpp
@@ -90,12 +90,14 @@ namespace Ogre
         mTransparencyValue( 1.0f ),
         mNormalMapWeight( 1.0f ),
         mRefractionStrength( 0.075f ),
+        mClearCoat( 0.0f ),
+        mClearCoatRoughness( 0.0f ),
+        _padding1( 0 ),
         mCubemapProbe( 0 ),
         mBrdf( PbsBrdf::Default )
     {
         memset( mUvSource, 0, sizeof( mUvSource ) );
         memset( mBlendModes, 0, sizeof( mBlendModes ) );
-        memset( _padding1, 0, sizeof( _padding1 ) );
         memset( mUserValue, 0, sizeof( mUserValue ) );
 
         mBgDiffuse[0] = mBgDiffuse[1] = mBgDiffuse[2] = mBgDiffuse[3] = 1.0f;
@@ -898,6 +900,35 @@ namespace Ogre
     void HlmsPbsDatablock::setRefractionStrength( float strength )
     {
         mRefractionStrength = strength;
+        scheduleConstBufferUpdate();
+    }
+    //-----------------------------------------------------------------------------------
+    void HlmsPbsDatablock::setClearCoat( float clearCoat )
+    {
+        assert( ( mBrdf & PbsBrdf::BRDF_MASK ) == PbsBrdf::Default );
+
+        bool wasZero = mClearCoat == 0.0f;
+        mClearCoat = clearCoat;
+
+        if( wasZero && clearCoat != 0.0f || !wasZero && clearCoat == 0.0f )
+        {
+            flushRenderables();
+        }
+
+        scheduleConstBufferUpdate();
+    }
+    //-----------------------------------------------------------------------------------
+    void HlmsPbsDatablock::setClearCoatRoughness( float roughness )
+    {
+        mClearCoatRoughness = roughness;
+
+        if( mClearCoatRoughness <= 1e-6f )
+        {
+            LogManager::getSingleton().logMessage( "WARNING: PBS Datablock '" + mName.getFriendlyText() +
+                                                   "' Very low clear coat roughness values can "
+                                                   "cause NaNs in the pixel shader!" );
+        }
+
         scheduleConstBufferUpdate();
     }
     //-----------------------------------------------------------------------------------

--- a/Samples/Media/Hlms/Pbs/Any/ClearCoat_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ClearCoat_piece_ps.any
@@ -1,0 +1,63 @@
+@property( clear_coat )
+@piece( DeclClearCoatFuncs )
+float D_GGX(float roughness, float NoH) {
+    // Walter et al. 2007, "Microfacet Models for Refraction through Rough Surfaces"
+
+    // In mediump, there are two problems computing 1.0 - NoH^2
+    // 1) 1.0 - NoH^2 suffers floating point cancellation when NoH^2 is close to 1 (highlights)
+    // 2) NoH doesn't have enough precision around 1.0
+    // Both problem can be fixed by computing 1-NoH^2 in highp and providing NoH in highp as well
+
+    // However, we can do better using Lagrange's identity:
+    //      ||a x b||^2 = ||a||^2 ||b||^2 - (a . b)^2
+    // since N and H are unit vectors: ||N x H||^2 = 1.0 - NoH^2
+    // This computes 1.0 - NoH^2 directly (which is close to zero in the highlights and has
+    // enough precision).
+    // Overall this yields better performance, keeping all computations in mediump
+    float oneMinusNoHSquared = 1.0 - NoH * NoH;
+
+    float a = NoH * roughness;
+    float k = roughness / (oneMinusNoHSquared + a * a);
+    float d = k * k * (1.0 / 3.14159265359);
+    return d;
+}
+
+float V_Kelemen(float LoH) {
+    // Kelemen 2001, "A Microfacet Based Coupled Specular-Matte BRDF Model with Importance Sampling"
+    return 0.25 / (LoH * LoH);
+}
+
+float F_Schlick(float f0, float f90, float VoH) {
+    return f0 + (f90 - f0) * pow(1.0 - VoH, 5.0);
+}
+
+float clearCoatLobe(const PixelData pixel, const float3 h, float NoH, float LoH, out float Fcc) {
+@property( normal_map )
+    // If the material has a normal map, we want to use the geometric normal
+    // instead to avoid applying the normal map details to the clear coat layer
+    float clearCoatNoH = saturate(dot(pixel.geomNormal, h));
+@else
+    float clearCoatNoH = NoH;
+@end
+
+    // clear coat specular lobe
+    float D = D_GGX(pixel.clearCoatRoughness, clearCoatNoH);
+    float V = V_Kelemen(LoH);
+    float F = F_Schlick(0.04, 1.0, LoH) * pixel.clearCoat; // fix IOR to 1.5
+
+    Fcc = F;
+    return D * V * F;
+}
+@end
+
+@piece( LoadClearCoat )
+    pixelData.clearCoat = material.clearCoat;
+    pixelData.clearCoatPerceptualRoughness = material.clearCoatRoughness;
+
+	@property( perceptual_roughness )
+		pixelData.clearCoatRoughness = max( pixelData.clearCoatPerceptualRoughness * pixelData.clearCoatPerceptualRoughness, 0.001f );
+	@else
+		pixelData.clearCoatRoughness = max( pixelData.clearCoatPerceptualRoughness, 0.001f );
+	@end
+@end
+@end

--- a/Samples/Media/Hlms/Pbs/Any/ClearCoat_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ClearCoat_piece_ps.any
@@ -1,58 +1,58 @@
 @property( clear_coat )
 @piece( DeclClearCoatFuncs )
 float D_GGX(float roughness, float NoH) {
-    // Walter et al. 2007, "Microfacet Models for Refraction through Rough Surfaces"
+	// Walter et al. 2007, "Microfacet Models for Refraction through Rough Surfaces"
 
-    // In mediump, there are two problems computing 1.0 - NoH^2
-    // 1) 1.0 - NoH^2 suffers floating point cancellation when NoH^2 is close to 1 (highlights)
-    // 2) NoH doesn't have enough precision around 1.0
-    // Both problem can be fixed by computing 1-NoH^2 in highp and providing NoH in highp as well
+	// In mediump, there are two problems computing 1.0 - NoH^2
+	// 1) 1.0 - NoH^2 suffers floating point cancellation when NoH^2 is close to 1 (highlights)
+	// 2) NoH doesn't have enough precision around 1.0
+	// Both problem can be fixed by computing 1-NoH^2 in highp and providing NoH in highp as well
 
-    // However, we can do better using Lagrange's identity:
-    //      ||a x b||^2 = ||a||^2 ||b||^2 - (a . b)^2
-    // since N and H are unit vectors: ||N x H||^2 = 1.0 - NoH^2
-    // This computes 1.0 - NoH^2 directly (which is close to zero in the highlights and has
-    // enough precision).
-    // Overall this yields better performance, keeping all computations in mediump
-    float oneMinusNoHSquared = 1.0 - NoH * NoH;
+	// However, we can do better using Lagrange's identity:
+	//      ||a x b||^2 = ||a||^2 ||b||^2 - (a . b)^2
+	// since N and H are unit vectors: ||N x H||^2 = 1.0 - NoH^2
+	// This computes 1.0 - NoH^2 directly (which is close to zero in the highlights and has
+	// enough precision).
+	// Overall this yields better performance, keeping all computations in mediump
+	float oneMinusNoHSquared = 1.0 - NoH * NoH;
 
-    float a = NoH * roughness;
-    float k = roughness / (oneMinusNoHSquared + a * a);
-    float d = k * k * (1.0 / 3.14159265359);
-    return d;
+	float a = NoH * roughness;
+	float k = roughness / (oneMinusNoHSquared + a * a);
+	float d = k * k * (1.0 / 3.14159265359);
+	return d;
 }
 
 float V_Kelemen(float LoH) {
-    // Kelemen 2001, "A Microfacet Based Coupled Specular-Matte BRDF Model with Importance Sampling"
-    return 0.25 / (LoH * LoH);
+	// Kelemen 2001, "A Microfacet Based Coupled Specular-Matte BRDF Model with Importance Sampling"
+	return 0.25 / (LoH * LoH);
 }
 
 float F_Schlick(float f0, float f90, float VoH) {
-    return f0 + (f90 - f0) * pow(1.0 - VoH, 5.0);
+	return f0 + (f90 - f0) * pow(1.0 - VoH, 5.0);
 }
 
 float clearCoatLobe(const PixelData pixel, const float3 h, float NoH, float LoH, OGRE_OUT_REF(float, Fcc)) {
 @property( normal_map )
-    // If the material has a normal map, we want to use the geometric normal
-    // instead to avoid applying the normal map details to the clear coat layer
-    float clearCoatNoH = saturate(dot(pixel.geomNormal, h));
+	// If the material has a normal map, we want to use the geometric normal
+	// instead to avoid applying the normal map details to the clear coat layer
+	float clearCoatNoH = saturate(dot(pixel.geomNormal, h));
 @else
-    float clearCoatNoH = NoH;
+	float clearCoatNoH = NoH;
 @end
 
-    // clear coat specular lobe
-    float D = D_GGX(pixel.clearCoatRoughness, clearCoatNoH);
-    float V = V_Kelemen(LoH);
-    float F = F_Schlick(0.04, 1.0, LoH) * pixel.clearCoat; // fix IOR to 1.5
+	// clear coat specular lobe
+	float D = D_GGX(pixel.clearCoatRoughness, clearCoatNoH);
+	float V = V_Kelemen(LoH);
+	float F = F_Schlick(0.04, 1.0, LoH) * pixel.clearCoat; // fix IOR to 1.5
 
-    Fcc = F;
-    return D * V * F;
+	Fcc = F;
+	return D * V * F;
 }
 @end
 
 @piece( LoadClearCoat )
-    pixelData.clearCoat = material.clearCoat;
-    pixelData.clearCoatPerceptualRoughness = material.clearCoatRoughness;
+	pixelData.clearCoat = material.clearCoat;
+	pixelData.clearCoatPerceptualRoughness = material.clearCoatRoughness;
 
 	@property( perceptual_roughness )
 		pixelData.clearCoatRoughness = max( pixelData.clearCoatPerceptualRoughness * pixelData.clearCoatPerceptualRoughness, 0.001f );

--- a/Samples/Media/Hlms/Pbs/Any/ClearCoat_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ClearCoat_piece_ps.any
@@ -31,7 +31,7 @@ float F_Schlick(float f0, float f90, float VoH) {
     return f0 + (f90 - f0) * pow(1.0 - VoH, 5.0);
 }
 
-float clearCoatLobe(const PixelData pixel, const float3 h, float NoH, float LoH, out float Fcc) {
+float clearCoatLobe(const PixelData pixel, const float3 h, float NoH, float LoH, OGRE_OUT_REF(float, Fcc)) {
 @property( normal_map )
     // If the material has a normal map, we want to use the geometric normal
     // instead to avoid applying the normal map details to the clear coat layer

--- a/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
@@ -145,6 +145,10 @@
 	float3 pccEnvS = float3( 0, 0, 0 );
 	float3 pccEnvD = float3( 0, 0, 0 );
 
+	@property( clear_coat )
+		float3 clearCoatPccEnvS = float3( 0, 0, 0 );
+	@end
+
 	@property( vct_num_probes )
 	if( pixelData.roughness < 1.0f || vctSpecular.w == 0 )
 	{
@@ -196,6 +200,11 @@
 			float3 normalLS = localCorrect( pixelData.normal, posInProbSpace, probe ).xyz;
 
 			float4 pccSingleEnvS;
+
+			@property( clear_coat )
+				float3 clearCoatPccSingleEnvS;
+			@end
+
 			@property( !hlms_cubemaps_use_dpm )
 				pccSingleEnvS = OGRE_SampleArrayCubeLevel(
 					texEnvProbeMap, samplerState@value(envMapRegSampler), reflDirLS,
@@ -206,6 +215,14 @@
 						probeCubemapIdx, 11.0 ).xyz
 						@insertpiece( ApplyEnvMapScale ) * probeFade;
 				@end
+
+				@property( clear_coat )
+					clearCoatPccSingleEnvS = OGRE_SampleArrayCubeLevel( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+																		reflDirLS,
+																		probeCubemapIdx,
+																		@insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
+					clearCoatPccSingleEnvS *= probeFade;
+				@end
 			@else
 				pccSingleEnvS = OGRE_SampleArray2DLevel(
 					texEnvProbeMap, samplerState@value(envMapRegSampler), mapCubemapToDpm( reflDirLS ),
@@ -215,6 +232,14 @@
 						texEnvProbeMap, samplerState@value(envMapRegSampler), mapCubemapToDpm( normalLS ),
 						probeCubemapIdx, 11.0 ).xyz
 						@insertpiece( ApplyEnvMapScale ) * probeFade;
+				@end
+
+				@property( clear_coat )
+					clearCoatPccSingleEnvS = OGRE_SampleArray2DLevel( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+																	  mapCubemapToDpm( reflDirLS ),
+																	  probeCubemapIdx,
+																	  @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
+					clearCoatPccSingleEnvS *= probeFade;
 				@end
 			@end
 
@@ -233,11 +258,20 @@
 													  pccSingleEnvS.w );
 
 				pccSingleEnvS *= 1.0f - vctLerp;
+
+				@property( clear_coat )
+					clearCoatPccSingleEnvS *= 1.0f - vctLerp;
+				@end
+
 				accumVctLerp += 1.0f - vctLerp;
 				numProbesVctLerp += 1.0f;
 			@end
 
 			pccEnvS	+= pccSingleEnvS.xyz;
+
+			@property( clear_coat )
+				clearCoatPccEnvS += clearCoatPccSingleEnvS;
+			@end
 
 			cubemapAccumWeight += probeFade;
 		}
@@ -248,6 +282,10 @@
 	@end
 	pccEnvS.xyz *= cubemapAccumWeight == 0.0f ? 1.0f : (1.0f / cubemapAccumWeight);
 
+	@property( clear_coat )
+		clearCoatPccEnvS *= cubemapAccumWeight == 0.0f ? 1.0f : ( 1.0f / cubemapAccumWeight );
+	@end
+
 	@property( vct_num_probes )
 		numProbesVctLerp = numProbesVctLerp == 0.0f ? 1.0f : numProbesVctLerp;
 		pixelData.envColourS.xyz = ( pccEnvS +
@@ -256,10 +294,20 @@
 		@property( cubemaps_as_diffuse_gi )
 			pixelData.envColourD += vctSpecular.w > 0 ? float3( 0, 0, 0 ) : pccEnvD;
 		@end
+
+		@property( clear_coat )
+			pixelData.clearCoatEnvColourS = ( clearCoatPccEnvS +
+											  pixelData.clearCoatEnvColourS * ( numProbesVctLerp - accumVctLerp ) )
+											/ numProbesVctLerp;
+		@end
 	@else
 		pixelData.envColourS.xyz = pccEnvS;
 		@property( cubemaps_as_diffuse_gi )
 			pixelData.envColourD.xyz = pccEnvD;
+		@end
+
+		@property( clear_coat )
+			pixelData.clearCoatEnvColourS = clearCoatPccEnvS;
 		@end
 	@end
 

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -173,31 +173,31 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
 	//We should divide Rd by PI, but it is already included in kD
     float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz;
 
-    @property( clear_coat )
-        float3 color = Rd + Rs;
+	@property( clear_coat )
+		float3 color = Rd + Rs;
 
-        float Fcc;
-        float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
-        float attenuation = 1.0 - Fcc;
+		float Fcc;
+		float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
+		float attenuation = 1.0 - Fcc;
 
-        @property( normal_map )
-            color *= attenuation * NdotL;
+		@property( normal_map )
+			color *= attenuation * NdotL;
 
-            // If the material has a normal map, we want to use the geometric normal
-            // instead to avoid applying the normal map details to the clear coat layer
-            float clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
-            color += clearCoat * clearCoatNoL;
+			// If the material has a normal map, we want to use the geometric normal
+			// instead to avoid applying the normal map details to the clear coat layer
+			float clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
+			color += clearCoat * clearCoatNoL;
 
-            return color * lightSpecular;
-        @else
-            color *= attenuation;
-            color += clearCoat;
+			return color * lightSpecular;
+		@else
+			color *= attenuation;
+			color += clearCoat;
 
-            return color * lightSpecular * NdotL;
-        @end
-    @else
+			return color * lightSpecular * NdotL;
+		@end
+	@else
 	return NdotL * (Rs * lightSpecular + Rd * lightDiffuse);
-    @end
+	@end
 }
 @end
 @end
@@ -256,20 +256,20 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
 	float3 Rd = pixelData.envColourD * pixelData.diffuse.xyz * fresnelD;
 	float3 Rs = pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
 
-    @property( clear_coat )
-        @property( normal_map )
-            // We want to use the geometric normal for the clear coat layer
-            float clearCoatNoV = saturate(dot(pixelData.geomNormal, pixelData.viewDir));
-        @else
-            float clearCoatNoV = pixelData.NdotV;
-        @end
-        // The clear coat layer assumes an IOR of 1.5 (4% reflectance)
-        float Fc = F_Schlick(0.04, 1.0, clearCoatNoV) * pixelData.clearCoat;
-        float attenuation = 1.0 - Fc;
-        Rd *= attenuation;
-        Rs *= attenuation;
-        Rs += pixelData.clearCoatEnvColourS * Fc;
-    @end
+	@property( clear_coat )
+		@property( normal_map )
+			// We want to use the geometric normal for the clear coat layer
+			float clearCoatNoV = saturate(dot(pixelData.geomNormal, pixelData.viewDir));
+		@else
+			float clearCoatNoV = pixelData.NdotV;
+		@end
+		// The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+		float Fc = F_Schlick(0.04, 1.0, clearCoatNoV) * pixelData.clearCoat;
+		float attenuation = 1.0 - Fc;
+		Rd *= attenuation;
+		Rs *= attenuation;
+		Rs += pixelData.clearCoatEnvColourS * Fc;
+	@end
 
 	finalColour += Rd + Rs;
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -173,7 +173,31 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
 	//We should divide Rd by PI, but it is already included in kD
     float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
 
-	return NdotL * (Rs + Rd);
+    @property( clear_coat )
+        float LoH = saturate(dot(lightDir, halfWay));
+
+        float3 color = Rs + Rd;
+
+        float Fcc;
+        float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, LoH, Fcc);
+        float attenuation = 1.0 - Fcc;
+
+        @property( normal_map )
+            color *= attenuation * NdotL;
+
+            // If the material has a normal map, we want to use the geometric normal
+            // instead to avoid applying the normal map details to the clear coat layer
+            float clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
+            color += clearCoat * clearCoatNoL;
+        @else
+            color *= attenuation;
+            color += clearCoat;
+        @end
+
+		return NdotL * color;
+    @else
+		return NdotL * (Rs + Rd);
+    @end
 }
 @end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -174,12 +174,10 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
     float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
 
     @property( clear_coat )
-        float LoH = saturate(dot(lightDir, halfWay));
-
         float3 color = Rs + Rd;
 
         float Fcc;
-        float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, LoH, Fcc);
+        float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
         float attenuation = 1.0 - Fcc;
 
         @property( normal_map )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -154,7 +154,7 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
     float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 
 	//We should divide Rs by PI, but it was done inside G for performance
-    float3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz * lightSpecular;
+    float3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz;
 
 	//Diffuse BRDF (*Normalized* Disney, see course_notes_moving_frostbite_to_pbr.pdf
 	//"Moving Frostbite to Physically Based Rendering" Sebastien Lagarde & Charles de Rousiers)
@@ -171,10 +171,10 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
     @end
 
 	//We should divide Rd by PI, but it is already included in kD
-    float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
+    float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz;
 
     @property( clear_coat )
-        float3 color = Rs + Rd;
+        float3 color = Rd + Rs;
 
         float Fcc;
         float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
@@ -187,14 +187,16 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
             // instead to avoid applying the normal map details to the clear coat layer
             float clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
             color += clearCoat * clearCoatNoL;
+
+            return color * lightSpecular;
         @else
             color *= attenuation;
             color += clearCoat;
-        @end
 
-		return NdotL * color;
+            return color * lightSpecular * NdotL;
+        @end
     @else
-		return NdotL * (Rs + Rd);
+	return NdotL * (Rs * lightSpecular + Rd * lightDiffuse);
     @end
 }
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -253,8 +253,25 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
 		float fresnelD = 1.0f - @insertpiece( getMaxFresnelS );
 	@end
 
-	finalColour += pixelData.envColourD * pixelData.diffuse.xyz * fresnelD +
-				   pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
+	float3 Rd = pixelData.envColourD * pixelData.diffuse.xyz * fresnelD;
+	float3 Rs = pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
+
+    @property( clear_coat )
+        @property( normal_map )
+            // We want to use the geometric normal for the clear coat layer
+            float clearCoatNoV = saturate(dot(pixelData.geomNormal, pixelData.viewDir));
+        @else
+            float clearCoatNoV = pixelData.NdotV;
+        @end
+        // The clear coat layer assumes an IOR of 1.5 (4% reflectance)
+        float Fc = F_Schlick(0.04, 1.0, clearCoatNoV) * pixelData.clearCoat;
+        float attenuation = 1.0 - Fc;
+        Rd *= attenuation;
+        Rs *= attenuation;
+        Rs += pixelData.clearCoatEnvColourS * Fc;
+    @end
+
+	finalColour += Rd + Rs;
 @end
 
 @property( hlms_fine_light_mask || hlms_forwardplus_fine_light_mask )

--- a/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
@@ -290,9 +290,9 @@ struct Material
 	float4 detailOffsetScale[4];
 	float4 emissive;		//emissive.w contains mNormalMapWeight.
 	float refractionStrength;
-	float _padding10;
-	float _padding11;
-	float _padding12;
+	float clearCoat;
+	float clearCoatRoughness;
+	float _padding1;
 	float4 userValue[3];
 
 	@property( syntax != metal )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -334,12 +334,12 @@
 	@end
 
 @property( clear_coat )
-    // This is a hack but it will do: the base layer must be at least as rough
-    // as the clear coat layer to take into account possible diffusion by the
-    // top layer
-    pixelData.perceptualRoughness = lerp(pixelData.perceptualRoughness,
-                                         max(pixelData.perceptualRoughness, pixelData.clearCoatPerceptualRoughness),
-                                         pixelData.clearCoat);
+	// This is a hack but it will do: the base layer must be at least as rough
+	// as the clear coat layer to take into account possible diffusion by the
+	// top layer
+	pixelData.perceptualRoughness = lerp(pixelData.perceptualRoughness,
+										 max(pixelData.perceptualRoughness, pixelData.clearCoatPerceptualRoughness),
+										 pixelData.clearCoat);
 @end
 
 	@property( perceptual_roughness )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -45,6 +45,13 @@
 			@end
 			float4	diffuse;
 			float3	specular;
+
+			@property( clear_coat )
+				float clearCoat;
+				float clearCoatPerceptualRoughness;
+				float clearCoatRoughness;
+			@end
+
 			float	perceptualRoughness;
 			float	roughness;
 			float_fresnel	F0;
@@ -140,6 +147,8 @@
 	@end
 
 	@property( (hlms_normal || hlms_qtangent) && !hlms_prepass && needs_view_dir )
+		@insertpiece( DeclClearCoatFuncs )
+
 		@insertpiece( DeclareBRDF )
 		@insertpiece( DeclareBRDF_InstantRadiosity )
 		@insertpiece( DeclareBRDF_AreaLightApprox )
@@ -318,6 +327,16 @@
 							 UV_ROUGHNESS( inPs.uv@value(uv_roughness).xy ),
 							 texIndex_roughnessIdx ).x;
 	@end
+
+@property( clear_coat )
+    // This is a hack but it will do: the base layer must be at least as rough
+    // as the clear coat layer to take into account possible diffusion by the
+    // top layer
+    pixelData.perceptualRoughness = lerp(pixelData.perceptualRoughness,
+                                         max(pixelData.perceptualRoughness, pixelData.clearCoatPerceptualRoughness),
+                                         pixelData.clearCoat);
+@end
+
 	@property( perceptual_roughness )
 		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, 0.001f );
 	@else
@@ -629,6 +648,7 @@
 		@end
 
 		@insertpiece( SampleSpecularMap )
+		@insertpiece( LoadClearCoat )
 		@insertpiece( SampleRoughnessMap )
 
 @property( hlms_bake_lighting_only )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -1,4 +1,5 @@
 @piece( envSpecularRoughness ) pixelData.perceptualRoughness * passBuf.envMapNumMipmaps @end
+@piece( envSpecularRoughnessClearCoat ) pixelData.clearCoatPerceptualRoughness * passBuf.envMapNumMipmaps @end
 
 @piece( DefaultHeaderPS )
 	// START UNIFORM DECLARATION
@@ -66,6 +67,10 @@
 				@property( needs_env_brdf )
 					float3 envColourS;
 					float3 envColourD;
+
+					@property( clear_coat )
+						float3 clearCoatEnvColourS;
+					@end
 				@end
 			@end
 		@else
@@ -585,6 +590,13 @@
 
 		envS.xyz *= probeFade;
 
+		@property( clear_coat )
+			float3 clearCoatEnvS = SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+												   reflDirLS,
+												   @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
+			clearCoatEnvS *= probeFade;
+		@end
+
 		@property( vct_num_probes )
 			float vctLerp = getPccVctBlendWeight( inPs.pos, pixelData.reflDir, reflDirLS_dist.w,
 												  pixelData.roughness,
@@ -598,10 +610,18 @@
 			@property( cubemaps_as_diffuse_gi )
 				pixelData.envColourD += vctSpecular.w > 0 ? float3( 0, 0, 0 ) : envD;
 			@end
+
+			@property( clear_coat )
+				pixelData.clearCoatEnvColourS = lerp( clearCoatEnvS, pixelData.clearCoatEnvColourS, vctLerp );
+			@end
 		@else
 			pixelData.envColourS += envS.xyz;
 			@property( cubemaps_as_diffuse_gi )
 				pixelData.envColourD += envD;
+			@end
+
+			@property( clear_coat )
+				pixelData.clearCoatEnvColourS += clearCoatEnvS;
 			@end
 		@end
 	}
@@ -615,6 +635,12 @@
 		pixelData.envColourD += SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
 												mul( pixelData.normal, passBuf.invViewMatCubemap ),
 												11.0 ).xyz @insertpiece( ApplyEnvMapScale );
+	@end
+
+	@property( clear_coat )
+		pixelData.clearCoatEnvColourS += SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+														 mul( pixelData.reflDir, passBuf.invViewMatCubemap ),
+														 @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 	@end
 @end
 
@@ -740,6 +766,10 @@
 			@property( needs_env_brdf )
 				pixelData.envColourS = float3( 0, 0, 0 );
 				pixelData.envColourD = float3( 0, 0, 0 );
+
+				@property( clear_coat )
+					pixelData.clearCoatEnvColourS = float3( 0, 0, 0 );
+				@end
 			@end
 
 			@insertpiece( applyVoxelConeTracing )


### PR DESCRIPTION
The implementation is based on [Filament](https://google.github.io/filament/Filament.md.html#materialsystem/clearcoatmodel), taking inspiration from @rujialiu [preliminary work](https://forums.ogre3d.org/viewtopic.php?p=542452#p542452).
![image](https://user-images.githubusercontent.com/7291478/113418580-103a5c80-93c6-11eb-93c4-061e46154b97.png)
![image](https://user-images.githubusercontent.com/7291478/113418588-14667a00-93c6-11eb-881b-00704900c822.png)
Differently from what Filament allows, I didn't add support neither for a clear coat layer [dedicated normal map](https://google.github.io/filament/Materials.html#materialmodels/litmodel/clearcoatnormal) nor for [base layer specular color alteration](https://google.github.io/filament/Materials.html#materialdefinitions/materialblock/lighting:clearcoatiorchange). Those two features weren't in my needs, but should be quite straightforward to add.
Another _subtle_ thing that I didn't take in account is to discriminate the clear coat lighting contribution among [standard scene rendering pass](https://github.com/google/filament/blob/main/shaders/src/light_indirect.fs#L347) and [IBL rendering pass](https://github.com/google/filament/blob/main/shaders/src/light_indirect.fs#L343).
For having a look at Filament implementation I suggest starting from [here](https://github.com/google/filament/blob/main/shaders/src/shading_model_standard.fs#L126) for direct light contribution and from [here](https://github.com/google/filament/blob/main/shaders/src/light_indirect.fs#L543) for indirect lighting contribution.