### PR TITLE
[2.3] Build-fix for x86.

### DIFF
--- a/OgreMain/include/OgreMovableObject.h
+++ b/OgreMain/include/OgreMovableObject.h
@@ -248,8 +248,9 @@ namespace Ogre {
         */
         static void updateAllBounds( const size_t numNodes, ObjectData t );
 
-        static inline ArrayReal calculateCameraDistance( uint32 _cameraSortMode, ArrayVector3 cameraPos,
-                                                         ArrayVector3 cameraDir,
+        static inline ArrayReal calculateCameraDistance( uint32 _cameraSortMode,
+                                                         const ArrayVector3& cameraPos,
+                                                         const ArrayVector3& cameraDir,
                                                          ArrayAabb *RESTRICT_ALIAS worldAabb,
                                                          ArrayReal *RESTRICT_ALIAS worldRadius );
 

--- a/OgreMain/src/OgreMovableObject.cpp
+++ b/OgreMain/src/OgreMovableObject.cpp
@@ -425,8 +425,8 @@ namespace Ogre {
     }
     //-----------------------------------------------------------------------
     inline ArrayReal MovableObject::calculateCameraDistance( uint32 _cameraSortMode,
-                                                             ArrayVector3 cameraPos,
-                                                             ArrayVector3 cameraDir,
+                                                             const ArrayVector3& cameraPos,
+                                                             const ArrayVector3& cameraDir,
                                                              ArrayAabb *RESTRICT_ALIAS worldAabb,
                                                              ArrayReal *RESTRICT_ALIAS worldRadius )
     {


### PR DESCRIPTION
Build-fix: passing ArrayVector3 cameraPos and ArrayVector3 cameraDir as variable caused problems for x86 build with OGRE_SIMD_SSE2 option. 

There were errors:
error C2719: 'cameraPos': formal parameter with requested alignment of 16 won't be aligned
error C2719: 'cameraDir': formal parameter with requested alignment of 16 won't be aligned

Changed to passing those variables as const references solved this problem.