### PR TITLE
Fixed Skybox rendering for OpenVR

### DIFF
--- a/OgreMain/include/OgreCamera.h
+++ b/OgreMain/include/OgreCamera.h
@@ -45,17 +45,22 @@ namespace Ogre {
     struct VrData
     {
         Matrix4 mHeadToEye[2];
+        Matrix4 mEyeToHead[2];
         Matrix4 mProjectionMatrix[2];
-        //Matrix4 mLeftToRight;
+        Matrix4 mProjectionMatrixInverse[2];
         Vector3 mLeftToRight;
 
+        // The corners are ordered as follows: top-right far, top-left far, bottom-left far, bottom-right far.
+        Vector3 mWorldSpaceFarCorners[2][4];
+        
         void set( const Matrix4 eyeToHead[2], const Matrix4 projectionMatrix[2] )
         {
             for( int i=0; i<2; ++i )
             {
-                mHeadToEye[i] = eyeToHead[i];
+                mEyeToHead[i] = eyeToHead[i];
                 mProjectionMatrix[i] = projectionMatrix[i];
-                mHeadToEye[i] = mHeadToEye[i].inverseAffine();
+                mProjectionMatrixInverse[i] = projectionMatrix[i].inverse();
+                mHeadToEye[i] = mEyeToHead[i].inverseAffine();
             }
             mLeftToRight = (mHeadToEye[0] * eyeToHead[1]).getTrans();
         }
@@ -244,6 +249,8 @@ namespace Ogre {
         static void setDefaultSortMode( CameraSortMode sortMode ) { msDefaultSortMode = sortMode; }
         static CameraSortMode getDefaultSortMode( void ) { return msDefaultSortMode; }
 
+        /// Recalculate Vr world space corners for Sky rendering
+        void updateVrWorldSpaceFarCorners();
     protected:
         // Internal functions for calcs
         bool isViewOutOfDate(void) const;
@@ -700,6 +707,11 @@ namespace Ogre {
         bool isVisible(const Vector3& vert, FrustumPlane* culledBy = 0) const;
         /// @copydoc Frustum::getWorldSpaceCorners
         const Vector3* getWorldSpaceCorners(void) const;
+        /** Gets the 4 far world space corners of the frustum.
+		@remarks
+			The corners are ordered as follows: top-right far, top-left far, bottom-left far, bottom-right far.
+		*/
+        const Vector3* getVrWorldSpaceFarCorners(size_t eyeIdx) const;
         /// @copydoc Frustum::getFrustumPlane
         const Plane& getFrustumPlane( unsigned short plane ) const;
         /// @copydoc Frustum::projectSphere

--- a/OgreMain/include/OgreRectangle2D2.h
+++ b/OgreMain/include/OgreRectangle2D2.h
@@ -68,8 +68,7 @@ namespace Ogre
 
         bool mChanged;
         uint32 mGeometryFlags;
-        Vector3 mNormals[NumCorners];
-
+        Vector3 mNormals[NumCorners*2];
         Vector2 mPosition;
         Vector2 mSize;
 
@@ -93,6 +92,8 @@ namespace Ogre
 
         void setNormals( const Vector3 &upperLeft, const Vector3 &bottomLeft,  //
                          const Vector3 &upperRight, const Vector3 &bottomRight );
+        void setStereoNormals( const Vector3 &upperLeft, const Vector3 &bottomLeft,  //
+                               const Vector3 &upperRight, const Vector3 &bottomRight );
 
         void setHollowRectRadius( Real radius );
         Real getHollowRectRadius( void ) const { return mNormals[0].x; }

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -522,6 +522,8 @@ namespace Ogre {
         /// For VR optimization
         RadialDensityMask *mRadialDensityMask;
 
+        bool mSkyStereo{false};
+
         // Fog
         FogMode mFogMode;
         ColourValue mFogColour;
@@ -1177,6 +1179,14 @@ namespace Ogre {
         */
         void setRadialDensityMask( bool bEnabled, const float radius[3] );
         RadialDensityMask* getRadialDensityMask(void) const     { return mRadialDensityMask; }
+
+        /**
+         * Must be used before setSky. Activates instanced stereo mode for OpenVR applications
+         */
+        void setSkyStereoMode (bool bEnabled)
+        {
+        	mSkyStereo = bEnabled;
+        }
 
         /** Gets the SceneNode at the root of the scene hierarchy.
             @remarks

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -888,7 +888,7 @@ namespace Ogre {
         // Treat infinite fardist as some arbitrary far value
         Real farDist = (mFarDist == 0) ? 100000 : mFarDist;
 
-        // Calc far palne corners
+        // Calc far plane corners
         Real radio = mProjType == PT_PERSPECTIVE ? farDist / mNearDist : 1;
         Real farLeft = nearLeft * radio;
         Real farRight = nearRight * radio;
@@ -940,7 +940,7 @@ namespace Ogre {
         // Treat infinite fardist as some arbitrary far value
         Real farDist = (customFarPlane == 0) ? 100000 : customFarPlane;
 
-        // Calc far palne corners
+        // Calc far plane corners
         Real radio = mProjType == PT_PERSPECTIVE ? farDist / mNearDist : 1;
         Real farLeft = nearLeft * radio;
         Real farRight = nearRight * radio;

--- a/OgreMain/src/OgreRectangle2D2.cpp
+++ b/OgreMain/src/OgreRectangle2D2.cpp
@@ -239,7 +239,7 @@ namespace Ogre
             if( bHasNormals )
             {
                 for( size_t j = 0u; j < 3u; ++j )
-                    *vertexData++ = mNormals[0][j];
+                    *vertexData++ = mNormals[0 + 4 * i][j];
             }
 
             // Top left
@@ -250,7 +250,7 @@ namespace Ogre
             if( bHasNormals )
             {
                 for( size_t j = 0u; j < 3u; ++j )
-                    *vertexData++ = mNormals[1][j];
+                    *vertexData++ = mNormals[1 + 4 * i][j];
             }
 
             // Bottom right
@@ -261,7 +261,7 @@ namespace Ogre
             if( bHasNormals )
             {
                 for( size_t j = 0u; j < 3u; ++j )
-                    *vertexData++ = mNormals[2][j];
+                    *vertexData++ = mNormals[2 + 4 * i][j];
             }
 
             if( isQuad() )
@@ -274,7 +274,7 @@ namespace Ogre
                 if( bHasNormals )
                 {
                     for( size_t j = 0u; j < 3u; ++j )
-                        *vertexData++ = mNormals[3][j];
+                        *vertexData++ = mNormals[3 + 4 * i][j];
                 }
             }
         }
@@ -300,6 +300,18 @@ namespace Ogre
         mNormals[CornerUpperLeft] = upperLeft;
         mNormals[CornerBottomRight] = bottomRight;
         mNormals[CornerUpperRight] = upperRight;
+        mChanged = true;
+    }
+
+    void Rectangle2D::setStereoNormals( const Vector3 &upperLeft, const Vector3 &bottomLeft,
+                                  const Vector3 &upperRight, const Vector3 &bottomRight )
+    {
+        OGRE_ASSERT_MEDIUM( getBufferType() != BT_IMMUTABLE || mVaoPerLod[0].empty() );
+        OGRE_ASSERT_MEDIUM( hasNormals() || mVaoPerLod[0].empty() );
+        mNormals[4 + CornerBottomLeft] = bottomLeft;
+        mNormals[4 + CornerUpperLeft] = upperLeft;
+        mNormals[4 + CornerBottomRight] = bottomRight;
+        mNormals[4 + CornerUpperRight] = upperRight;
         mChanged = true;
     }
     //-----------------------------------------------------------------------------------

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -1005,8 +1005,13 @@ void SceneManager::setSky( bool bEnabled, SkyMethod skyMethod, TextureGpu *textu
                                          &mEntityMemoryManager[SCENE_STATIC], this );
             // We can't use BT_DYNAMIC_* because the scene may be rendered from multiple cameras
             // in the same frame, and dynamic supports only one set of values per frame
-            mSky->initialize( BT_DEFAULT,
-                              Rectangle2D::GeometryFlagQuad | Rectangle2D::GeometryFlagNormals );
+
+			uint32 skyGeometryFlags=Rectangle2D::GeometryFlagQuad | Rectangle2D::GeometryFlagNormals;
+
+			if (mSkyStereo)
+				skyGeometryFlags|=Rectangle2D::GeometryFlagStereo;
+
+            mSky->initialize( BT_DEFAULT,skyGeometryFlags);
             mSky->setGeometry( -Ogre::Vector2::UNIT_SCALE, Ogre::Vector2( 2.0f ) );
             mSky->setRenderQueueGroup( 212u ); // Render after most stuff
             mSceneRoot[SCENE_STATIC]->attachObject( mSky );
@@ -1064,6 +1069,13 @@ void SceneManager::setSky( bool bEnabled, SkyMethod skyMethod, TextureGpu *textu
         tu->setTexture( texture );
 
         mSky->setMaterial( mSkyMaterial );
+
+        GpuProgramParametersSharedPtr vsParams = pass->getVertexProgramParameters();
+        vsParams->setNamedConstant( "ogreBaseVertex", (float)mSky->getVaos( VpNormal )
+                                                          .back()
+                                                          ->getBaseVertexBuffer()
+                                                          ->_getFinalBufferStart() );
+
     }
     else
     {
@@ -1381,18 +1393,43 @@ void SceneManager::_renderPhase02(Camera* camera, const Camera *lodCamera,
 
         if( mSky && mIlluminationStage != IRS_RENDER_TO_TEXTURE )
         {
-            const Vector3 *corners = camera->getWorldSpaceCorners();
+            const Vector3 *corners;
             const Vector3 &cameraPos = camera->getDerivedPosition();
-
             const Real invFarPlane = 1.0f / camera->getFarClipDistance();
             Vector3 cameraDirs[4];
-            cameraDirs[0] = ( corners[5] - cameraPos ) * invFarPlane;
-            cameraDirs[1] = ( corners[6] - cameraPos ) * invFarPlane;
-            cameraDirs[2] = ( corners[4] - cameraPos ) * invFarPlane;
-            cameraDirs[3] = ( corners[7] - cameraPos ) * invFarPlane;
 
-            mSky->setNormals( cameraDirs[0], cameraDirs[1], cameraDirs[2], cameraDirs[3] );
+            if (!mSky->isStereo())
+            {
+				corners = camera->getWorldSpaceCorners();
+				cameraDirs[0] = ( corners[5] - cameraPos ) * invFarPlane;
+				cameraDirs[1] = ( corners[6] - cameraPos ) * invFarPlane;
+				cameraDirs[2] = ( corners[4] - cameraPos ) * invFarPlane;
+				cameraDirs[3] = ( corners[7] - cameraPos ) * invFarPlane;
+
+				mSky->setNormals( cameraDirs[0], cameraDirs[1], cameraDirs[2], cameraDirs[3] );
+				mSky->setStereoNormals( cameraDirs[0], cameraDirs[1], cameraDirs[2], cameraDirs[3] );
+            }
+            else
+            {
+            	camera->updateVrWorldSpaceFarCorners();
+
+				corners = camera->getVrWorldSpaceFarCorners(0);
+				cameraDirs[0] = ( corners[1] - cameraPos ) * invFarPlane;
+				cameraDirs[1] = ( corners[2] - cameraPos ) * invFarPlane;
+				cameraDirs[2] = ( corners[0] - cameraPos ) * invFarPlane;
+				cameraDirs[3] = ( corners[3] - cameraPos ) * invFarPlane;
+				mSky->setNormals( cameraDirs[0], cameraDirs[1], cameraDirs[2], cameraDirs[3] );
+
+				corners = camera->getVrWorldSpaceFarCorners(1);
+				cameraDirs[0] = ( corners[1] - cameraPos ) * invFarPlane;
+				cameraDirs[1] = ( corners[2] - cameraPos ) * invFarPlane;
+				cameraDirs[2] = ( corners[0] - cameraPos ) * invFarPlane;
+				cameraDirs[3] = ( corners[3] - cameraPos ) * invFarPlane;
+				mSky->setStereoNormals( cameraDirs[0], cameraDirs[1], cameraDirs[2], cameraDirs[3] );
+            }
+
             mSky->update();
+
         }
 
         if( mRadialDensityMask && mIlluminationStage != IRS_RENDER_TO_TEXTURE &&

--- a/Samples/2.0/Tutorials/Tutorial_OpenVR/OpenVRCompositorListener.h
+++ b/Samples/2.0/Tutorials/Tutorial_OpenVR/OpenVRCompositorListener.h
@@ -15,7 +15,15 @@
         #define nullptr (0)
     #endif
 #endif
+
+#ifdef __MINGW32__
+// For compilation on Windows with MinGW a special header must be used
+#include "openvr_mingw.hpp"
+#else
 #include "openvr.h"
+#endif
+
+
 #if __cplusplus <= 199711L
     #ifdef OgreDemoNullptrDefined
         #undef OgreDemoNullptrDefined

--- a/Samples/2.0/Tutorials/Tutorial_OpenVR/Tutorial_OpenVR.cpp
+++ b/Samples/2.0/Tutorials/Tutorial_OpenVR/Tutorial_OpenVR.cpp
@@ -39,7 +39,7 @@ extern const bool c_useRDM;
 //
 // The main reason we allow this setting to be disabled is because it is
 // causing glitches in NVIDIA GPUs in Linux, see https://github.com/OGRECave/ogre-next/issues/53
-const bool c_useRDM = true;
+const bool c_useRDM = false;
 
 namespace Demo
 {

--- a/Samples/2.0/Tutorials/Tutorial_OpenVR/Tutorial_OpenVR.h
+++ b/Samples/2.0/Tutorials/Tutorial_OpenVR/Tutorial_OpenVR.h
@@ -10,7 +10,14 @@
         #define nullptr (0)
     #endif
 #endif
+
+#ifdef __MINGW32__
+// For compilation on Windows with MinGW a special header must be used
+#include "openvr_mingw.hpp"
+#else
 #include "openvr.h"
+#endif
+
 #if __cplusplus <= 199711L
     #ifdef OgreDemoNullptrDefined
         #undef OgreDemoNullptrDefined

--- a/Samples/2.0/Tutorials/Tutorial_OpenVR/Tutorial_OpenVRGameState.cpp
+++ b/Samples/2.0/Tutorials/Tutorial_OpenVR/Tutorial_OpenVRGameState.cpp
@@ -253,6 +253,10 @@ namespace Demo
         mCameraController = new CameraController( mGraphicsSystem, false );
 
         TutorialGameState::createScene01();
+
+        sceneManager->setSkyStereoMode(true);
+        sceneManager->setSky(true, Ogre::SceneManager::SkyCubemap, "SaintPetersBasilica.dds",
+						 Ogre::ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME);
     }
     //-----------------------------------------------------------------------------------
     void Tutorial_OpenVRGameState::update( float timeSinceLast )

--- a/Samples/Media/2.0/scripts/materials/Common/GLSL/QuadCameraDirNoUV_vs.glsl
+++ b/Samples/Media/2.0/scripts/materials/Common/GLSL/QuadCameraDirNoUV_vs.glsl
@@ -1,9 +1,13 @@
 #version ogre_glsl_ver_330
+#extension GL_ARB_shader_viewport_layer_array : require
 
 vulkan_layout( OGRE_POSITION )	in vec2 vertex;
 vulkan_layout( OGRE_NORMAL )	in vec3 normal;
 
+in int gl_InstanceID;
+
 vulkan( layout( ogre_P0 ) uniform Params { )
+	uniform float ogreBaseVertex;
 	uniform vec2 rsDepthRange;
 	uniform mat4 worldViewProj;
 vulkan( }; )
@@ -22,7 +26,13 @@ out block
 void main()
 {
 	gl_Position.xy = (worldViewProj * vec4( vertex.xy, 0, 1.0f )).xy;
+
+	// TODO Move the second instance aside. There must be a way to make this more clean. But how?
+    gl_Position.x += 3.5f*gl_InstanceID;
+    
 	gl_Position.z = rsDepthRange.y;
 	gl_Position.w = 1.0f;
 	outVs.cameraDir.xyz	= normal.xyz;
+	
+	gl_ViewportIndex = (gl_VertexID - ogreBaseVertex) >= 2 ? 1 : 0;
 }


### PR DESCRIPTION
Rectangle2D supports a second set of normals.
Fixed world space corner calculation for head to eye matrices.

Also tested without instancing. Still works without OpenVR projects.
One thing: There is a TODO in the shader code which must still be fixed. But currently I have the feeling that you do know more about this.