### PR TITLE
Fix readers-writer lock is wrongly handled in STD thread provider

### DIFF
--- a/OgreMain/include/Threading/OgreThreadDefinesSTD.h
+++ b/OgreMain/include/Threading/OgreThreadDefinesSTD.h
@@ -110,9 +110,9 @@ namespace Ogre
 #define OGRE_THREAD_NOTIFY_ALL(sync) sync.notify_all()
 
 // Read-write mutex
-#define OGRE_RW_MUTEX(name) mutable std::recursive_mutex name
-#define OGRE_LOCK_RW_MUTEX_READ(name) std::unique_lock<std::recursive_mutex> OGRE_TOKEN_PASTE_EXTRA(ogrenameLock, __LINE__) (name)
-#define OGRE_LOCK_RW_MUTEX_WRITE(name) std::unique_lock<std::recursive_mutex> OGRE_TOKEN_PASTE_EXTRA(ogrenameLock, __LINE__) (name)
+#define OGRE_RW_MUTEX(name) mutable std::shared_mutex name
+#define OGRE_LOCK_RW_MUTEX_READ(name) std::shared_lock<std::shared_mutex> OGRE_TOKEN_PASTE_EXTRA(ogrenameLock, __LINE__) (name)
+#define OGRE_LOCK_RW_MUTEX_WRITE(name) std::unique_lock<std::shared_mutex> OGRE_TOKEN_PASTE_EXTRA(ogrenameLock, __LINE__) (name)
 
 // Thread-local pointer
 #define OGRE_THREAD_POINTER(T, var) Ogre::ThreadLocalPtr<T> var

--- a/OgreMain/include/Threading/OgreThreadHeadersSTD.h
+++ b/OgreMain/include/Threading/OgreThreadHeadersSTD.h
@@ -30,5 +30,6 @@ THE SOFTWARE
 #include <thread>
 #include <mutex>
 #include <condition_variable>
+#include <shared_mutex>
 
 #endif


### PR DESCRIPTION
[Readers-writer lock](https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock) is handled with `std::recursive_mutex` and `std::unique_lock` (instead of `std::shared_mutex` and `std::shared_lock`) in STD thread provider. This is probably a (wrong) "approximation" of the synchronization primitive because, when STD thread provider (which mimics Boost thread provider [has been added](https://github.com/OGRECave/ogre-next/commit/e0e1a0f088f64d05ea4f62b217aa7feb36d53e08#diff-e441ae30ba228c05c1b28fb54db96147d16045203285a521d2d6a005f91cb2da), there was no alternative to `boost::shared_mutex` in STL library (`std::shared_mutex` exists from C++ 17 on, see: https://stackoverflow.com/questions/14306797/c11-equivalent-to-boost-shared-mutex).