### PR TITLE
[OSX] Fix segmentation fault when creating a CocoaWindow

### DIFF
--- a/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaContext.h
+++ b/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaContext.h
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 namespace Ogre {
 
-    class _OgrePrivate CocoaContext : public GL3PlusContext
+    class _OgrePrivate CocoaContext : public GL3PlusContext, public GeneralAllocatedObject
     {
     public:
         CocoaContext(NSOpenGLContext *context, NSOpenGLPixelFormat *pixelFormat);
@@ -56,8 +56,8 @@ namespace Ogre {
         NSOpenGLPixelFormat* getPixelFormat();
         
     private:
-        NSOpenGLContext* mNSGLContext;
-        NSOpenGLPixelFormat *mNSGLPixelFormat;
+        NSOpenGLContext* mNSGLContext{NULL};
+        NSOpenGLPixelFormat *mNSGLPixelFormat{NULL};
     };
 } // namespace Ogre
 

--- a/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaView.h
+++ b/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaView.h
@@ -34,16 +34,16 @@ THE SOFTWARE.
 
 @interface OgreGL3PlusView : NSOpenGLView
 {
-    Ogre::Window *window;
+    Ogre::Window *ogreWindow;
 }
 
-- (id)initWithFrame:(NSRect)f;
-- (id)initWithGLOSXWindow:(Ogre::Window*)w;
+- (id)initWithFrame:(NSRect)frameRect;
 
-- (void)setOgreWindow:(Ogre::Window*)w;
+- (void)setOgreWindow:(Ogre::Window*)newWindow;
+
 - (Ogre::Window*)ogreWindow;
 
-- (void)setFrameSize:(NSSize)s;
+- (void)setFrameSize:(NSSize)newSize;
 
 @end
 

--- a/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaWindow.h
+++ b/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaWindow.h
@@ -77,11 +77,9 @@ namespace Ogre
         
         int _getPixelFromPoint(int viewPt) const;
         void _setWindowParameters(unsigned int widthPt, unsigned int heightPt);
-        
-    public:
-        CocoaWindow(const String &title, uint32 widthPt, uint32 heightPt, bool fullscreenMode,
-            const NameValuePairList *miscParams);
 
+    public:
+        CocoaWindow(const String &title, uint32 widthPt, uint32 heightPt, bool fullscreenMode);
         virtual ~CocoaWindow();
 
         /** @copydoc see Window::_initialize */
@@ -142,10 +140,10 @@ namespace Ogre
         bool isDeactivatedOnFocusChange() const;
         void setDeactivateOnFocusChange(bool deactivate);
 
-    private:
-        void _create(const String &name, unsigned int widthPt, unsigned int heightPt,
+        void create(const String &name, unsigned int widthPt, unsigned int heightPt,
             bool fullScreen, const NameValuePairList *miscParams);
 
+    private:
         void _createNewWindow(String title, unsigned int widthPt, unsigned int heightPt);
 
     };

--- a/RenderSystems/GL3Plus/src/windowing/OSX/OgreOSXCocoaView.mm
+++ b/RenderSystems/GL3Plus/src/windowing/OSX/OgreOSXCocoaView.mm
@@ -31,47 +31,42 @@ THE SOFTWARE.
 
 @implementation OgreGL3PlusView
 
-- (id)initWithFrame:(NSRect)f
+- (id)initWithFrame:(NSRect)frameRect
 {
-	if((self = [super initWithFrame:f]))
+	  if((self = [super initWithFrame:frameRect]))
     {
         NSApplicationLoad();
         
-        window = 0;
+        ogreWindow = NULL;
     }
-	return self;
+	  return self;
 }
 
-- (id)initWithGLOSXWindow:(Ogre::Window*)w
+- (void)setOgreWindow:(Ogre::Window*)newWindow
 {
-	if((self = [super initWithFrame:NSMakeRect(0, 0, w->getWidth(), w->getHeight())]))
-    {
-        window = w;
-    }
-	return self;
-}
-
-- (void)setOgreWindow:(Ogre::Window*)w
-{
-	window = w;
+	  ogreWindow = newWindow;
 }
 
 - (Ogre::Window*)ogreWindow
 {
-	return window;
+	  return ogreWindow;
 }
 
-- (void)setFrameSize:(NSSize)s
+- (void)setFrameSize:(NSSize)newSize
 {
-	[super setFrameSize:s];
-    if (window)
-        window->windowMovedOrResized();
+  	[super setFrameSize:newSize];
+    if (ogreWindow)
+    {
+        ogreWindow->windowMovedOrResized();
+    }
 }
 
-- (void)drawRect:(NSRect)r
+- (void)drawRect:(NSRect)dirtyRect
 {
-	if(window)
-		window->swapBuffers();
+    if(ogreWindow)
+    {
+        ogreWindow->swapBuffers();
+    }
 }
 
 - (BOOL)acceptsFirstResponder

--- a/RenderSystems/GL3Plus/src/windowing/OSX/OgreOSXCocoaWindow.mm
+++ b/RenderSystems/GL3Plus/src/windowing/OSX/OgreOSXCocoaWindow.mm
@@ -77,10 +77,13 @@ namespace Ogre {
     };
 
     //-----------------------------------------------------------------------
+    // CocoaWindow::CocoaWindow(const String &title,
+    //     uint32 widthPt, uint32 heightPt,
+    //     bool fullscreenMode,
+    //     const NameValuePairList *miscParams) : 
     CocoaWindow::CocoaWindow(const String &title,
         uint32 widthPt, uint32 heightPt,
-        bool fullscreenMode,
-        const NameValuePairList *miscParams) : 
+        bool fullscreenMode) : 
         Window(title, widthPt, heightPt, fullscreenMode),
         mWindow(nil),
         mView(nil),
@@ -103,14 +106,12 @@ namespace Ogre {
         mContentScalingFactor(1.0)
     {
         // Set vsync by default to save battery and reduce tearing
-
-        _create(title, widthPt, heightPt, fullscreenMode, miscParams);
     }
 
     //-----------------------------------------------------------------------
     CocoaWindow::~CocoaWindow()
     {
-		[mGLContext clearDrawable];
+    		[mGLContext clearDrawable];
 
         destroy();
         
@@ -189,7 +190,7 @@ namespace Ogre {
     // }
 
     //-----------------------------------------------------------------------
-	void CocoaWindow::_create(const String &name, unsigned int widthPt, unsigned int heightPt,
+	void CocoaWindow::create(const String &name, unsigned int widthPt, unsigned int heightPt,
 	            bool fullScreen, const NameValuePairList *miscParams)
     {
         @autoreleasepool {
@@ -697,7 +698,8 @@ namespace Ogre {
         [mWindow setTitle:[NSString stringWithCString:title.c_str() encoding:NSUTF8StringEncoding]];
         mWindowTitle = title;
 
-        mView = [[OgreGL3PlusView alloc] initWithGLOSXWindow:this];
+        mView = [[OgreGL3PlusView alloc] initWithFrame:windowRect];
+        [mView setOgreWindow:this];
 
         _setWindowParameters(widthPt, heightPt);
 

--- a/RenderSystems/GL3Plus/src/windowing/OSX/OgreOSXGL3PlusSupport.mm
+++ b/RenderSystems/GL3Plus/src/windowing/OSX/OgreOSXGL3PlusSupport.mm
@@ -319,7 +319,8 @@ Window* OSXGL3PlusSupport::newWindow( const String &name, unsigned int width, un
 {
 	// Create the window, if Cocoa return a Cocoa window
     LogManager::getSingleton().logMessage("Creating a Cocoa Compatible Render System");
-    CocoaWindow *window = OGRE_NEW CocoaWindow(name, width, height, fullScreen, miscParams);
+    CocoaWindow *window = OGRE_NEW CocoaWindow(name, width, height, fullScreen);
+    window->create(name, width, height, fullScreen, miscParams);
 
     return window;
 }


### PR DESCRIPTION
This PR fixes a segmentation fault when creating an `Ogre::CocoaWindow` if the parameter `externalWindowHandle` is null.

**Main change**

The branch of the code creating a `CocoaWindow` with `externalWindowHandle = 0` is failing because the initialiser for the `OgreGL3PlusView` in `CocoaWindow::create` calls `Ogre::Window::getWidth()`, which in turn delegates to a contained `TextureGPU`. However this has not been initialised at the point the `OgreGL3PlusView` is created resulting in a uninitialised pointer dereference. The proposed change removes this initialiser and creates the `NSView` from a frame and then sets the Ogre::Window.

**Other changes:**

- Remove the call to `create()` from the `Ogre::CocoaWindow` constructor as it relies on the virtual behaviour of `Ogre::Window` / `Ogre::CocoaWindow`
- Subclass `Ogre::CocoaContext` from `GeneralAllocatedObject` (restoring consistency with Ogre2.1)