### PR TITLE
better location for ogre.cfg and ogre.log on macOS

### DIFF
--- a/OgreMain/include/OSX/macUtils.h
+++ b/OgreMain/include/OSX/macUtils.h
@@ -42,5 +42,6 @@ namespace Ogre {
     _OgreExport String macTempFileName(void);
     _OgreExport String macResourcesPath();
     _OgreExport String macLogPath();
+    _OgreExport String macWriteAccessFolderPath();
     _OgreExport void mac_dispatchOneEvent();
 }

--- a/OgreMain/src/OSX/macUtils.mm
+++ b/OgreMain/src/OSX/macUtils.mm
@@ -181,6 +181,23 @@ namespace Ogre {
         NSURL* logURL = [libURL URLByAppendingPathComponent: @"Logs" isDirectory: YES];
         return String( logURL.absoluteURL.path.UTF8String ) + "/";
     }
+    
+    String macWriteAccessFolderPath()
+    {
+        NSURL* suppURL = [NSFileManager.defaultManager
+            URLForDirectory: NSApplicationSupportDirectory
+            inDomain: NSUserDomainMask
+            appropriateForURL: nil
+            create: YES
+            error: nil];
+        NSURL* ogreURL = [suppURL URLByAppendingPathComponent: @"Ogre"
+                                isDirectory: YES];
+        [NSFileManager.defaultManager createDirectoryAtURL: ogreURL
+        				withIntermediateDirectories: YES
+                        attributes: nil
+                        error: nil];
+        return String( ogreURL.absoluteURL.path.UTF8String ) + "/";
+    }
 
     String macCachePath()
     {

--- a/Samples/2.0/Common/src/GraphicsSystem.cpp
+++ b/Samples/2.0/Common/src/GraphicsSystem.cpp
@@ -91,7 +91,8 @@ namespace Demo
 #endif
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
         mPluginsFolder = mResourcePath;
-#endif
+        mWriteAccessFolder = Ogre::macWriteAccessFolderPath();
+#else
         if( isWriteAccessFolder( mPluginsFolder, "Ogre.log" ) )
             mWriteAccessFolder = mPluginsFolder;
         else
@@ -99,6 +100,7 @@ namespace Demo
             Ogre::FileSystemLayer filesystemLayer( OGRE_VERSION_NAME );
             mWriteAccessFolder = filesystemLayer.getWritablePath( "" );
         }
+#endif
     }
     //-----------------------------------------------------------------------------------
     GraphicsSystem::~GraphicsSystem()

--- a/Samples/2.0/Tutorials/Tutorial00_Basic/Tutorial00_Basic.cpp
+++ b/Samples/2.0/Tutorials/Tutorial00_Basic/Tutorial00_Basic.cpp
@@ -150,7 +150,7 @@ int main( int argc, const char *argv[] )
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
     const String pluginsFolder = macResourcesPath();
-    const String writeAccessFolder = macLogPath();
+    const String writeAccessFolder = macWriteAccessFolderPath();
 #else
     const String pluginsFolder = "./";
     const String writeAccessFolder = pluginsFolder;


### PR DESCRIPTION
It was suggested in pull request #223 that there could be a better location for `writeAccessFolder` on macOS.