### PR TITLE
fix misaligned pointer use in hash code

### DIFF
--- a/OgreMain/src/Hash/MurmurHash3.cpp
+++ b/OgreMain/src/Hash/MurmurHash3.cpp
@@ -11,6 +11,7 @@
 
 #include "OgrePlatform.h"
 #include "Hash/MurmurHash3.h"
+#include <string.h>
 
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros
@@ -54,17 +55,20 @@ inline uint64_t rotl64 ( uint64_t x, int8_t r )
 namespace Ogre
 {
 //-----------------------------------------------------------------------------
-// Block read - if your platform needs to do endian-swapping or can only
-// handle aligned reads, do the conversion here
+// Block read - if your platform needs to do endian-swapping, do the conversion here
 
-FORCE_INLINE uint32_t getblock32 ( const uint32_t * p, int i )
+FORCE_INLINE uint32_t getblock32 ( const uint8_t * p, int i )
 {
-  return p[i];
+    uint32_t dest;
+    memcpy( &dest, p + i * static_cast<int>(sizeof(uint32_t)), sizeof(uint32_t) );
+    return dest;
 }
 
-FORCE_INLINE uint64_t getblock64 ( const uint64_t * p, int i )
+FORCE_INLINE uint64_t getblock64 ( const uint8_t * p, int i )
 {
-  return p[i];
+    uint64_t dest;
+    memcpy( &dest, p + i * static_cast<int>(sizeof(uint64_t)), sizeof(uint64_t) );
+    return dest;
 }
 
 //-----------------------------------------------------------------------------
@@ -110,7 +114,7 @@ void _OgreExport MurmurHash3_x86_32 ( const void * key, const int len,
   //----------
   // body
 
-  const uint32_t * blocks = (const uint32_t *)(data + nblocks*4);
+  const uint8_t * blocks = (const uint8_t *)(data + nblocks*4);
 
   for(int i = -nblocks; i; i++)
   {
@@ -171,7 +175,7 @@ void _OgreExport MurmurHash3_x86_128 ( const void * key, const int len,
   //----------
   // body
 
-  const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
+  const uint8_t * blocks = (const uint8_t *)(data + nblocks*16);
 
   for(int i = -nblocks; i; i++)
   {
@@ -272,7 +276,7 @@ void _OgreExport MurmurHash3_x64_128 ( const void * key, const int len,
   //----------
   // body
 
-  const uint64_t * blocks = (const uint64_t *)(data);
+  const uint8_t * blocks = (const uint8_t *)(data);
 
   for(int i = 0; i < nblocks; i++)
   {


### PR DESCRIPTION
The MurmurHash code was using misaligned pointers, which is undefined behavior according to the C++ standard and probably unsafe on multiple platforms.  See [Is it well-defined to hold a misaligned pointer, as long as you don't ever dereference it?](https://stackoverflow.com/questions/51203570/is-it-well-defined-to-hold-a-misaligned-pointer-as-long-as-you-dont-ever-deref) on Stack Overflow.