### PR TITLE
Fixed building error on MinGW

### DIFF
--- a/OgreMain/include/OgreCharconv.h
+++ b/OgreMain/include/OgreCharconv.h
@@ -48,7 +48,7 @@ THE SOFTWARE.
 #elif defined(_GLIBCXX_RELEASE) && _GLIBCXX_HOSTED && \
     (_GLIBCXX_RELEASE > 8 || _GLIBCXX_RELEASE == __GNUC__ && (__GNUC__ * 100 + __GNUC_MINOR__) >= 801)
 #define OGRE_HAS_CHARCONV
-#if (_GLIBCXX_RELEASE > 11 || _GLIBCXX_RELEASE == __GNUC__ && (__GNUC__ * 100 + __GNUC_MINOR__) >= 1101)
+#if ((_GLIBCXX_RELEASE > 11 || _GLIBCXX_RELEASE == __GNUC__ && (__GNUC__ * 100 + __GNUC_MINOR__) >= 1101) && !__MINGW32__ && !__MINGW64__)
 #define OGRE_HAS_CHARCONV_FLOAT
 #endif
 #endif


### PR DESCRIPTION
Description:
MinGW still does not support float from_char conversion: that causes from_char building errors in OgreCharconv.h.
Environment:
Windows 10 Pro x64
Compiller:
MSYS2 GCC 11.2.0