### PR TITLE
Added missing include to OgreSTBICodec.h

### DIFF
--- a/OgreMain/include/OgreSTBICodec.h
+++ b/OgreMain/include/OgreSTBICodec.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #ifndef __STBICodec_H__
 #define __STBICodec_H__
 
+#include "ogrestd/list.h"
 #include "OgreImageCodec2.h"
 
 namespace Ogre {
@@ -62,8 +63,8 @@ namespace Ogre {
         /// @copydoc Codec::decode
         DecodeResult decode(DataStreamPtr& input) const;
 
-        
-        virtual String getType() const;        
+
+        virtual String getType() const;
 
         /// @copydoc Codec::magicNumberToFileExt
         String magicNumberToFileExt(const char *magicNumberPtr, size_t maxbytes) const;


### PR DESCRIPTION
Description:
Error list is not defined ocures when building OgreSTBICodec.h. This PR fixes error by adding ogrestd/list.h include to OgreSTBICodec.h.
Environment:
Windows 10 Pro x64
Compiller:
MSYS2 GCC 11.2.0