### PR TITLE
Add comment to configure build to use distro packages

### DIFF
--- a/Docs/src/SettingUpOgre/SettingUpOgreLinux.md
+++ b/Docs/src/SettingUpOgre/SettingUpOgreLinux.md
@@ -26,6 +26,8 @@ cd Ogre/Dependencies
 mkdir build
 cd build
 cmake ../
+# Optionally configure build to use distro packages freeimage, freetype, and zlib if installed
+# cmake -D OGREDEPS_BUILD_FREEIMAGE=0 -D OGREDEPS_BUILD_FREETYPE=0 -D OGREDEPS_BUILD_ZLIB=0 ../
 cd build
 make
 make install```


### PR DESCRIPTION
Simple PR, the build instructions already suggest installing the packages from the Linux distros for use already so it's unnecessary to use the ones bundled in `ogre-next-deps`

Speeds up overall compilation and makes use of upstream packages provided by distro