### PR TITLE
Sm lights branching

### DIFF
--- a/Components/Hlms/Pbs/include/OgreHlmsPbs.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbs.h
@@ -270,6 +270,8 @@ namespace Ogre
         void postCommandBufferExecution( CommandBuffer *commandBuffer ) override;
         void frameEnded() override;
 
+        void setMaxShadowMapLights( uint16 maxShadowMapLights ) override;
+
         /** By default we see the reflection textures' mipmaps and store the largest one we found.
             By calling resetIblSpecMipmap; you can reset this process thus if a reflection texture
             with a large number of mipmaps was removed, these textures can be reevaluated

--- a/Components/Hlms/Pbs/include/OgreHlmsPbs.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbs.h
@@ -270,7 +270,7 @@ namespace Ogre
         void postCommandBufferExecution( CommandBuffer *commandBuffer ) override;
         void frameEnded() override;
 
-        void setMaxShadowMapLights( uint16 maxShadowMapLights ) override;
+        void setStaticBranchingLights( bool staticBranchingLights ) override;
 
         /** By default we see the reflection textures' mipmaps and store the largest one we found.
             By calling resetIblSpecMipmap; you can reset this process thus if a reflection texture

--- a/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
@@ -3621,14 +3621,14 @@ namespace Ogre
         mCurrentPassBuffer = 0;
     }
     //-----------------------------------------------------------------------------------
-    void HlmsPbs::setMaxShadowMapLights( uint16 maxShadowMapLights )
+    void HlmsPbs::setStaticBranchingLights( bool staticBranchingLights )
     {
-        if( maxShadowMapLights > 0 )
+        if( staticBranchingLights )
         {
             // Make sure we calculate light positions in pixel shaders
             setShadowReceiversInPixelShader( true );
         }
-        Hlms::setMaxShadowMapLights( maxShadowMapLights );
+        Hlms::setStaticBranchingLights( staticBranchingLights );
     }
     //-----------------------------------------------------------------------------------
     void HlmsPbs::resetIblSpecMipmap( uint8 numMipmaps )

--- a/OgreMain/include/OgreHlms.h
+++ b/OgreMain/include/OgreHlms.h
@@ -212,10 +212,13 @@ namespace Ogre
 
         LightGatheringMode mLightGatheringMode;
         uint16             mNumLightsLimit;
+        uint16             mNumShadowMapLightsLimit;
         uint16             mNumAreaApproxLightsLimit;
         uint16             mNumAreaLtcLightsLimit;
         uint32             mAreaLightsGlobalLightListStart;
         uint32             mRealNumDirectionalLights;
+        uint32             mRealShadowMapPointLights;
+        uint32             mRealShadowMapSpotLights;
         uint32             mRealNumAreaApproxLightsWithMask;
         uint32             mRealNumAreaApproxLights;
         uint32             mRealNumAreaLtcLights;
@@ -523,6 +526,38 @@ namespace Ogre
          */
         void   setMaxNonCasterDirectionalLights( uint16 maxLights );
         uint16 getMaxNonCasterDirectionalLights() const { return mNumLightsLimit; }
+
+        /** By default shadow-caster spot and point lights are hardcoded into shaders.
+
+            This means that if you have 8 spot/point lights and then you add a 9th one,
+            a whole new set of shaders will be created.
+            Even more if you have a combination of 3 spot and 5 point lights and the combination
+            has changed to 4 spot and 4 point lights then you'll get the next set of shaders
+
+            This setting allows you to tremendously reduce the amount of shader permutations
+            by forcing Ogre to switching to static branching with an upper limit to the max
+            number of shadow-casting spot or point lights.
+
+            See    Hlms::setAreaLightForwardSettings
+        @remarks
+            All point and spot lights must share the same hlms_shadowmap atlas
+
+            This is mostly an D3D11 / HLSL SM 5.0 restriction
+            (https://github.com/OGRECave/ogre-next/pull/255) but it may also help with
+            performance in other APIs.
+
+            If multiple atlas support is needed, using Texture2DArrays may be a good solution,
+            although it is currently untested and may need additional fixes to get it working
+
+        @param maxShadowMapLights
+            Maximum number of shadow-caster spot and point lights.
+            0 to allow unlimited number of lights, at the cost of shader recompilations
+            when spot or point  lights are added or removed or their combination are changed.
+
+            Default value is 0.
+         */
+        virtual void setMaxShadowMapLights( uint16 maxShadowMapLights );
+        uint16       getMaxShadowMapLights( void ) const { return mNumShadowMapLightsLimit; }
 
         /** Area lights use regular Forward.
         @param areaLightsApproxLimit
@@ -888,6 +923,7 @@ namespace Ogre
         static const IdString DualParaboloidMapping;
         static const IdString InstancedStereo;
         static const IdString StaticBranchLights;
+        static const IdString StaticBranchShadowMapLights;
         static const IdString NumShadowMapLights;
         static const IdString NumShadowMapTextures;
         static const IdString PssmSplits;

--- a/OgreMain/include/OgreHlms.h
+++ b/OgreMain/include/OgreHlms.h
@@ -211,8 +211,8 @@ namespace Ogre
         HlmsManager *mHlmsManager;
 
         LightGatheringMode mLightGatheringMode;
+        bool               mStaticBranchingLights;
         uint16             mNumLightsLimit;
-        uint16             mNumShadowMapLightsLimit;
         uint16             mNumAreaApproxLightsLimit;
         uint16             mNumAreaLtcLightsLimit;
         uint32             mAreaLightsGlobalLightListStart;
@@ -556,8 +556,8 @@ namespace Ogre
 
             Default value is 0.
          */
-        virtual void setMaxShadowMapLights( uint16 maxShadowMapLights );
-        uint16       getMaxShadowMapLights( void ) const { return mNumShadowMapLightsLimit; }
+        virtual void setStaticBranchingLights( bool staticBranchingLights );
+        bool         getStaticBranchingLights( void ) const { return mStaticBranchingLights; }
 
         /** Area lights use regular Forward.
         @param areaLightsApproxLimit

--- a/OgreMain/src/OgreHlms.cpp
+++ b/OgreMain/src/OgreHlms.cpp
@@ -251,8 +251,8 @@ namespace Ogre
         mDataFolder( dataFolder ),
         mHlmsManager( 0 ),
         mLightGatheringMode( LightGatherForward ),
+        mStaticBranchingLights( false ),
         mNumLightsLimit( 0u ),
-        mNumShadowMapLightsLimit( 0u ),
         mNumAreaApproxLightsLimit( 1u ),
         mNumAreaLtcLightsLimit( 1u ),
         mAreaLightsGlobalLightListStart( 0u ),
@@ -1682,9 +1682,9 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     void Hlms::setMaxNonCasterDirectionalLights( uint16 maxLights ) { mNumLightsLimit = maxLights; }
     //-----------------------------------------------------------------------------------
-    void Hlms::setMaxShadowMapLights( uint16 maxShadowMapLights )
+    void Hlms::setStaticBranchingLights( bool staticBranchingLights )
     {
-        mNumShadowMapLightsLimit = maxShadowMapLights;
+        mStaticBranchingLights = staticBranchingLights;
     }
     //-----------------------------------------------------------------------------------
     void Hlms::setAreaLightForwardSettings( uint16 areaLightsApproxLimit, uint16 areaLightsLtcLimit )
@@ -2640,7 +2640,7 @@ namespace Ogre
                              static_cast<int32>( contiguousShadowMapTex.size() ) );
 
                 useStaticBranchShadowMapLights =
-                    getMaxShadowMapLights() > 0u && numShadowMapLights > numPssmSplits;
+                    mStaticBranchingLights && numShadowMapLights > numPssmSplits;
                 if( useStaticBranchShadowMapLights )
                     setProperty( HlmsBaseProp::StaticBranchShadowMapLights, 1 );
                 mRealShadowMapPointLights = 0u;

--- a/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCode.cpp
+++ b/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCode.cpp
@@ -228,7 +228,7 @@ namespace Demo
             assert( dynamic_cast<Ogre::HlmsPbs *>( hlms ) );
             Ogre::HlmsPbs *pbs = static_cast<Ogre::HlmsPbs *>( hlms );
             if( pbs )
-                pbs->setMaxShadowMapLights( 4u );
+                pbs->setStaticBranchingLights( true );
         }
 #endif
 

--- a/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCode.cpp
+++ b/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCode.cpp
@@ -6,10 +6,8 @@
 #include "Compositor/OgreCompositorNodeDef.h"
 #include "Compositor/OgreCompositorShadowNode.h"
 #include "Compositor/Pass/PassScene/OgreCompositorPassSceneDef.h"
-#include "OgreCamera.h"
-#include "OgreConfigFile.h"
-#include "OgreRoot.h"
-#include "OgreSceneManager.h"
+#include "OgreHlmsManager.h"
+#include "OgreHlmsPbs.h"
 #include "OgreWindow.h"
 
 // Declares WinMain / main
@@ -63,21 +61,46 @@ namespace Demo
             shadowParams.push_back( shadowParam );
 
             // Second light, directional, spot or point
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+            shadowParam.atlasId = 1;
+#endif
             shadowParam.technique = Ogre::SHADOWMAP_FOCUSED;
             shadowParam.resolution[0].x = 2048u;
             shadowParam.resolution[0].y = 2048u;
             shadowParam.atlasStart[0].x = 0u;
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+            shadowParam.atlasStart[0].y = 0u;
+#else
             shadowParam.atlasStart[0].y = 2048u + 1024u;
+#endif
 
             shadowParam.supportedLightTypes = 0u;
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
             shadowParam.addLightType( Ogre::Light::LT_DIRECTIONAL );
+#endif
             shadowParam.addLightType( Ogre::Light::LT_POINT );
             shadowParam.addLightType( Ogre::Light::LT_SPOTLIGHT );
             shadowParams.push_back( shadowParam );
 
             // Third light, directional, spot or point
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+            shadowParam.atlasStart[0].y = 2048u;
+#else
             shadowParam.atlasStart[0].y = 2048u + 1024u + 2048u;
+#endif
             shadowParams.push_back( shadowParam );
+
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+            // Fourth light
+            shadowParam.atlasStart[0].x = 2048u;
+            shadowParam.atlasStart[0].y = 0u;
+            shadowParams.push_back( shadowParam );
+
+            // Fifth light
+            shadowParam.atlasStart[0].x = 2048u;
+            shadowParam.atlasStart[0].y = 2048u;
+            shadowParams.push_back( shadowParam );
+#endif
 
             Ogre::ShadowNodeHelper::createShadowNodeWithSettings(
                 compositorManager, renderSystem->getCapabilities(), "ShadowMapFromCodeShadowNode",
@@ -115,6 +138,9 @@ namespace Demo
             shadowParams.push_back( shadowParam );
 
             // Second light, directional, spot or point
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+            shadowParam.atlasId = 1;
+#endif
             shadowParam.technique = Ogre::SHADOWMAP_FOCUSED;
             shadowParam.resolution[0].x = 1024u;
             shadowParam.resolution[0].y = 1024u;
@@ -130,6 +156,18 @@ namespace Demo
             // Third light, directional, spot or point
             shadowParam.atlasStart[0].x = 1024u;
             shadowParams.push_back( shadowParam );
+
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+            // Fourth light
+            shadowParam.atlasStart[0].x = 1024u;
+            shadowParam.atlasStart[0].y = 0u;
+            shadowParams.push_back( shadowParam );
+
+            // Fifth light
+            shadowParam.atlasStart[0].x = 1024u;
+            shadowParam.atlasStart[0].y = 1024u;
+            shadowParams.push_back( shadowParam );
+#endif
 
             const Ogre::RenderSystemCapabilities *capabilities = renderSystem->getCapabilities();
             Ogre::RenderSystemCapabilities capsCopy = *capabilities;
@@ -180,6 +218,19 @@ namespace Demo
                                                           mCamera, "ShadowMapFromCodeWorkspace", true );
             return mWorkspace;
         }
+
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+        void registerHlms( void ) override
+        {
+            GraphicsSystem::registerHlms();
+            Ogre::Root *root = getRoot();
+            Ogre::Hlms *hlms = root->getHlmsManager()->getHlms( Ogre::HLMS_PBS );
+            assert( dynamic_cast<Ogre::HlmsPbs *>( hlms ) );
+            Ogre::HlmsPbs *pbs = static_cast<Ogre::HlmsPbs *>( hlms );
+            if( pbs )
+                pbs->setMaxShadowMapLights( 4u );
+        }
+#endif
 
     public:
         ShadowMapFromCodeGraphicsSystem( GameState *gameState ) : GraphicsSystem( gameState ) {}

--- a/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCodeGameState.cpp
+++ b/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCodeGameState.cpp
@@ -139,6 +139,34 @@ namespace Demo
 
         mLightNodes[2] = lightNode;
 
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+        light = sceneManager->createLight();
+        lightNode = rootNode->createChildSceneNode();
+        lightNode->attachObject( light );
+        light->setDiffuseColour( 0.8f, 0.0f, 0.0f );  // Red
+        light->setSpecularColour( 0.8f, 0.0f, 0.0f );
+        light->setPowerScale( Ogre::Math::PI );
+        light->setType( Ogre::Light::LT_POINT );
+        lightNode->setPosition( -10.0f, -10.0f, 10.0f );
+        // light->setDirection( Ogre::Vector3( 1, -1, -1 ).normalisedCopy() );
+        light->setAttenuationBasedOnRadius( 10.0f, 0.01f );
+
+        mLightNodes[3] = lightNode;
+
+        light = sceneManager->createLight();
+        lightNode = rootNode->createChildSceneNode();
+        lightNode->attachObject( light );
+        light->setDiffuseColour( 0.0f, 0.8f, 0.0f );  // Green
+        light->setSpecularColour( 0.0f, 0.8f, 0.0f );
+        light->setPowerScale( Ogre::Math::PI );
+        light->setType( Ogre::Light::LT_POINT );
+        lightNode->setPosition( -10.0f, 10.0f, -10.0f );
+        // light->setDirection( Ogre::Vector3( -1, -1, 1 ).normalisedCopy() );
+        light->setAttenuationBasedOnRadius( 10.0f, 0.01f );
+
+        mLightNodes[4] = lightNode;
+#endif
+
         mCameraController = new CameraController( mGraphicsSystem, false );
 
         createShadowMapDebugOverlays();

--- a/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCodeGameState.h
+++ b/Samples/2.0/ApiUsage/ShadowMapFromCode/ShadowMapFromCodeGameState.h
@@ -8,13 +8,19 @@
 
 #include "TutorialGameState.h"
 
+#define USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS 1
+
 namespace Demo
 {
     class ShadowMapFromCodeGameState : public TutorialGameState
     {
         Ogre::SceneNode *mSceneNode[16];
 
+#ifdef USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS
+        Ogre::SceneNode *mLightNodes[5];
+#else
         Ogre::SceneNode *mLightNodes[3];
+#endif
 
         bool mAnimateObjects;
 

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -290,6 +290,9 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
             @piece( ObjLightMaskCmpNonCasterLoopEnd )@add( fineMaskLightIdx, hlms_lights_directional_non_caster )@end
         @end
         @piece( andObjLightMaskCmp )&& ((objLightMask & floatBitsToUint( light0Buf.lights[@counter(fineMaskLightIdx)].position.w )) != 0u)@end
+        @property( hlms_static_branch_shadow_map_lights )
+            @piece( andObjLightMaskCmp_light_idx )&& ((objLightMask & floatBitsToUint( light0Buf.lights[light_idx].position.w )) != 0u)@end
+        @end
         @piece( andObjAreaApproxLightMaskCmp )&& ((objLightMask & floatBitsToUint( light1Buf.areaApproxLights[i].position.w )) != 0u)@end
         @piece( andObjAreaLtcLightMaskCmp )&& ((objLightMask & floatBitsToUint( light2Buf.areaLtcLights[i].position.w )) != 0u)@end
     @else
@@ -299,6 +302,9 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
             @piece( ObjLightMaskCmpNonCasterLoopEnd )@add( fineMaskLightIdx, hlms_lights_directional_non_caster )@end
         @end
         @piece( andObjLightMaskCmp )&& ((objLightMask & light0Buf.lights[@counter(fineMaskLightIdx)].lightMask) != 0u)@end
+        @property( hlms_static_branch_shadow_map_lights )
+            @piece( andObjLightMaskCmp_light_idx )&& ((objLightMask & light0Buf.lights[light_idx].lightMask) != 0u)@end
+        @end
         @piece( andObjAreaApproxLightMaskCmp )&& ((objLightMask & light1Buf.areaApproxLights[i].lightMask) != 0u)@end
         @piece( andObjAreaLtcLightMaskCmp )&& ((objLightMask & light2Buf.areaLtcLights[i].lightMask) != 0u)@end
     @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
@@ -168,6 +168,10 @@ CONST_BUFFER_STRUCT_BEGIN( PassBuffer, 0 )
 	float pssmBlendPoints@n;@end @end
 @property( hlms_pssm_fade )
 	float pssmFadePoint;@end
+@property( hlms_static_branch_shadow_map_lights )
+	float numShadowMapPointLights;
+	float numShadowMapSpotLights;
+@end
 
 @property( !use_light_buffers )
 	@property( hlms_lights_spot )Light lights[@value(hlms_lights_spot)];@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -449,12 +449,41 @@
 		float3 finalColour = passBuf.ambientUpperHemi.xyz * pixelData.diffuse.xyz;
 	@end
 
-	@property( hlms_lights_point || hlms_lights_spot || hlms_lights_area_approx || hlms_lights_area_ltc )
+	@property( hlms_static_branch_shadow_map_lights || hlms_lights_point || hlms_lights_spot || hlms_lights_area_approx || hlms_lights_area_ltc )
 		float3 lightDir;
 		float fDistance;
 		float3 tmpColour;
 		float spotCosAngle;
 	@end
+
+	@property( hlms_static_branch_shadow_map_lights )
+		const int shadowmapIdx[@value(hlms_num_shadow_map_lights)] =
+			OGRE_ARRAY_START( int )
+				@value(hlms_shadowmap0)
+				@foreach( hlms_num_shadow_map_lights, n, 1 )
+				, @value(hlms_shadowmap@n)@end
+			OGRE_ARRAY_END;
+
+		const float2 shadowmap_uv_min[@value(hlms_num_shadow_map_lights)] =
+			OGRE_ARRAY_START( float2 )
+					hlms_shadowmap0_uv_min
+					@foreach( hlms_num_shadow_map_lights, n, 1 )
+					, hlms_shadowmap@n_uv_min@end
+			OGRE_ARRAY_END;
+		const float2 shadowmap_uv_max[@value(hlms_num_shadow_map_lights)] =
+			OGRE_ARRAY_START( float2 )
+				hlms_shadowmap0_uv_max
+				@foreach( hlms_num_shadow_map_lights, n, 1 )
+				, hlms_shadowmap@n_uv_max@end
+			OGRE_ARRAY_END;
+		const float2 shadowmap_uv_length[@value(hlms_num_shadow_map_lights)] =
+			OGRE_ARRAY_START( float2 )
+				hlms_shadowmap0_uv_length
+				@foreach( hlms_num_shadow_map_lights, n, 1 )
+				, hlms_shadowmap@n_uv_length@end
+			OGRE_ARRAY_END;
+	@end
+
 	@property( needs_refl_dir )
 		pixelData.reflDir = 2.0 * dot( pixelData.viewDir, pixelData.normal ) * pixelData.normal - pixelData.viewDir;
 	@end
@@ -489,6 +518,25 @@
 
 //Point lights
 @piece( DoPointLights )
+@property( hlms_static_branch_shadow_map_lights )
+	int cur_shadow_map = @value(CurrentShadowMap);
+	int light_idx = @value(hlms_lights_directional_non_caster);
+	const int sm_point_lights_num = floatBitsToInt( passBuf.numShadowMapPointLights );
+	const int sm_point_lights_end = light_idx + sm_point_lights_num;
+	for( ; light_idx<sm_point_lights_end; light_idx++ )
+	{
+		lightDir = light0Buf.lights[light_idx].position.xyz - inPs.pos;
+		fDistance= length( lightDir );
+		if( fDistance <= light0Buf.lights[light_idx].attenuation.x @insertpiece( andObjLightMaskCmp_light_idx ) )
+		{
+			lightDir *= 1.0 / fDistance;
+			tmpColour = BRDF( lightDir, light0Buf.lights[light_idx].diffuse.xyz, light0Buf.lights[light_idx].specular, pixelData )@insertpiece( DarkenWithShadowPoint_cur_shadow_map );
+			float atten = 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance );
+			finalColour += tmpColour * atten;
+		}
+		cur_shadow_map++;
+	}
+@else
 	@foreach( hlms_lights_point, n, hlms_lights_directional_non_caster )
 		lightDir = light0Buf.lights[@n].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
@@ -501,12 +549,40 @@
 		}
 	@end
 @end
+@end
 
 //Spot lights
 //spotParams[@value(spot_params)].x = 1.0 / cos( InnerAngle ) - cos( OuterAngle )
 //spotParams[@value(spot_params)].y = cos( OuterAngle / 2 )
 //spotParams[@value(spot_params)].z = falloff
 @piece( DoSpotLights )
+@property( hlms_static_branch_shadow_map_lights )
+	const int sm_spot_lights_num = floatBitsToInt( passBuf.numShadowMapSpotLights );
+	const int sm_spot_lights_end = light_idx + sm_spot_lights_num;
+	for( ; light_idx<sm_spot_lights_end; light_idx++ )
+	{
+		lightDir = light0Buf.lights[light_idx].position.xyz - inPs.pos;
+		fDistance= length( lightDir );
+		lightDir *= 1.0 / fDistance;
+		spotCosAngle = dot( -lightDir, light0Buf.lights[light_idx].spotDirection.xyz );
+		if( fDistance <= light0Buf.lights[light_idx].attenuation.x && spotCosAngle >= light0Buf.lights[light_idx].spotParams.y @insertpiece( andObjLightMaskCmp_light_idx ) )
+		{
+			float spotAtten = saturate( (spotCosAngle - light0Buf.lights[light_idx].spotParams.y) * light0Buf.lights[light_idx].spotParams.x );
+			spotAtten = pow( spotAtten, light0Buf.lights[light_idx].spotParams.z );
+
+			@property( light_profiles_texture )
+				spotAtten *= getPhotometricAttenuation( spotCosAngle,
+														light0Buf.lights[light_idx].lightTexProfileIdx
+														OGRE_PHOTOMETRIC_ARG );
+			@end
+
+			tmpColour = BRDF( lightDir, light0Buf.lights[light_idx].diffuse.xyz, light0Buf.lights[light_idx].specular, pixelData )@insertpiece( DarkenWithShadow_cur_shadow_map );
+			float atten = 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance );
+			finalColour += tmpColour * (atten * spotAtten);
+		}
+		cur_shadow_map++;
+	}
+@else
 	@foreach( hlms_lights_spot, n, hlms_lights_point )
 		lightDir = light0Buf.lights[@n].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
@@ -537,6 +613,7 @@
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 	@end
+@end
 @end
 
 @piece( DoEmissiveLight )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -457,13 +457,6 @@
 	@end
 
 	@property( hlms_static_branch_shadow_map_lights )
-		const int shadowmapIdx[@value(hlms_num_shadow_map_lights)] =
-			OGRE_ARRAY_START( int )
-				@value(hlms_shadowmap0)
-				@foreach( hlms_num_shadow_map_lights, n, 1 )
-				, @value(hlms_shadowmap@n)@end
-			OGRE_ARRAY_END;
-
 		const float2 shadowmap_uv_min[@value(hlms_num_shadow_map_lights)] =
 			OGRE_ARRAY_START( float2 )
 					hlms_shadowmap0_uv_min

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -26,8 +26,10 @@
 	#define hlms_shadowmap@n_uv_min float2( @value( hlms_shadowmap@n_uv_min_x_int ).@value( hlms_shadowmap@n_uv_min_x_fract ), @value( hlms_shadowmap@n_uv_min_y_int ).@value( hlms_shadowmap@n_uv_min_y_fract ) )
 	#define hlms_shadowmap@n_uv_max float2( @value( hlms_shadowmap@n_uv_max_x_int ).@value( hlms_shadowmap@n_uv_max_x_fract ), @value( hlms_shadowmap@n_uv_max_y_int ).@value( hlms_shadowmap@n_uv_max_y_fract ) )
 	@property( hlms_shadowmap@n_uvs_fulltex )
-		@property( hlms_shadowmap@n_is_point_light )
+		@property( hlms_shadowmap@n_is_point_light || hlms_static_branch_shadow_map_lights )
 			#define hlms_shadowmap@n_uv_length float2( @value( hlms_shadowmap@n_uv_length_x_int ).@value( hlms_shadowmap@n_uv_length_x_fract ), @value( hlms_shadowmap@n_uv_length_y_int ).@value( hlms_shadowmap@n_uv_length_y_fract ) )
+		@end
+		@property( hlms_shadowmap@n_is_point_light )
 			#define hlms_shadowmap@n_uv_param , hlms_shadowmap@n_uv_min, hlms_shadowmap@n_uv_max, hlms_shadowmap@n_uv_length
 		@else
 			#define hlms_shadowmap@n_uv_param , hlms_shadowmap@n_uv_min, hlms_shadowmap@n_uv_max
@@ -180,6 +182,15 @@
 			@property( hlms_shadowmap@n_is_spot )
 				#define inPs_posL@n worldPosToSpotLightSpace( inPs.worldPos, passBuf.shadowRcv[@n], @insertpiece( shadowMapNormalOffsetBias@n ) )
 			@end
+		@end
+		@property( hlms_static_branch_shadow_map_lights )
+			@property( !skip_normal_offset_bias_vs )
+				@piece( shadowMapNormalOffsetBias_cur_shadow_map )getNormalOffsetBias( inPs.worldNorm, pixelData.geomNormal, light0Buf.lights[light_idx].spotDirection.xyz, passBuf.shadowRcv[cur_shadow_map].invShadowMapSize.x, passBuf.shadowRcv[cur_shadow_map].shadowDepthRange.y, passBuf.shadowRcv[cur_shadow_map].normalOffsetBias, shadowmap_uv_min[cur_shadow_map], shadowmap_uv_max[cur_shadow_map] )@end
+			@else
+				@piece( shadowMapNormalOffsetBias_cur_shadow_map )float3( 0.0f, 0.0f, 0.0f )@end
+			@end
+
+			#define inPs_posL_cur_shadow_map worldPosToSpotLightSpace( inPs.worldPos, passBuf.shadowRcv[cur_shadow_map], @insertpiece( shadowMapNormalOffsetBias_cur_shadow_map ) )
 		@end
 
 		@foreach( 2, m )
@@ -516,6 +527,29 @@
 @property( receive_shadows )
 	@piece( DarkenWithShadowFirstLight )* fShadow@end
 
+@property( hlms_static_branch_shadow_map_lights )
+
+	// All point and spot lights must share the same hlms_shadowmap atlas
+	// See HlmsPbs::setMaxShadowMapLights
+	@piece( DarkenWithShadow_cur_shadow_map )
+		* getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
+					 inPs_posL_cur_shadow_map,
+					 passBuf.shadowRcv[cur_shadow_map].invShadowMapSize
+					 , shadowmap_uv_min[cur_shadow_map], shadowmap_uv_max[cur_shadow_map] )
+	@end
+
+	@piece( DarkenWithShadowPoint_cur_shadow_map )
+		* getShadowPoint( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
+						  pixelData.geomNormal,
+						  passBuf.shadowRcv[cur_shadow_map].normalOffsetBias,
+						  inPs.pos.xyz, light0Buf.lights[light_idx].position.xyz,
+						  passBuf.shadowRcv[cur_shadow_map].invShadowMapSize,
+						  passBuf.shadowRcv[cur_shadow_map].shadowDepthRange.xy
+						  , shadowmap_uv_min[cur_shadow_map], shadowmap_uv_max[cur_shadow_map], shadowmap_uv_length[cur_shadow_map] PASSBUF_ARG )
+	@end
+
+@else
+
 	@piece( DarkenWithShadow )
 		* getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
 					 inPs_posL@value(CurrentShadowMap),
@@ -534,6 +568,9 @@
 						  passBuf.shadowRcv[@value(CurrentShadowMap)].shadowDepthRange.xy
 						  hlms_shadowmap@counter(CurrentShadowMap)_uv_param PASSBUF_ARG )
 	@end
+
+@end
+
 @end ///!receive_shadows
 
 @end

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -530,7 +530,7 @@
 @property( hlms_static_branch_shadow_map_lights )
 
 	// All point and spot lights must share the same hlms_shadowmap atlas
-	// See HlmsPbs::setMaxShadowMapLights
+	// See HlmsPbs::setStaticBranchingLights
 	@piece( DarkenWithShadow_cur_shadow_map )
 		* getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
 					 inPs_posL_cur_shadow_map,


### PR DESCRIPTION
SM lights branching technique decreases possible shader variants for point and spot shadow-casting lights. The technique is very suitable when you have many regular (point or spot) shadow-casting lights in the scene and their combination may change in different scene locations. Default inline technique requires new shaders for every possible shadow-casting lights combination.
SM lights branching technique creates two separate loops in PS shader - one for point shadow-casting lights and one for spot lights. Make sure your lights are ordered and grouped correctly(point lights first, then - spots) if you have your own lights management.
Current implementation works for Metal, DirectX and Vulkan render systems. Default inline technique is used for OpenGL/OpenGLES.

To enable SM lights branching technique use Ogre::HlmsPbs::setMaxShadowMapLights() method before any PBS materials creation.
I've modified Sample_ShadowMapFromCode for demo and debug purposes. Use USE_STATIC_BRANCHING_FOR_SHADOWMAP_LIGHTS macro to turn on/off the technique.