### PR TITLE
fixed regression in NEON TestFlags4()

### DIFF
--- a/OgreMain/include/Math/Array/NEON/Single/OgreMathlibNEON.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreMathlibNEON.h
@@ -321,7 +321,7 @@ namespace Ogre
         {
             // !( (a & b) == 0 ) --> ( (a & b) == 0 ) ^ -1
             return veorq_u32(
-                vceqq_u32( vandq_u32( vreinterpretq_u32_s32( a ), b ), vdupq_n_u32( 0xFFFFFFFF ) ),
+                vceqq_u32( vandq_u32( vreinterpretq_u32_s32( a ), b ), vdupq_n_u32( 0 ) ),
                 vdupq_n_u32( 0xFFFFFFFF ) );
         }
         static inline ArrayMaskI TestFlags4( ArrayMaskI a, ArrayInt b )


### PR DESCRIPTION
After getting the latest changes I've noticed regression in dir light PSSM shadows on Arm Mac. I've dove in the code and discovered that method MovableObject::calculateCastersBox() does not calc correct casterBox, so I've found regression in NEON implementation of TestFlags4() inline method. Regression was made in commit de6dc58ab114467f094b83b243db928b2d19bdea (Jan 2, 2022)