### PR TITLE
Implement 'half' floating point precision

### DIFF
--- a/OgreMain/include/OgreHlms.h
+++ b/OgreMain/include/OgreHlms.h
@@ -498,6 +498,17 @@ namespace Ogre
         void setHighQuality( bool highQuality );
         bool getHighQuality() const { return mHighQuality; }
 
+        /// Whether low quality is used depends on two things:
+        ///
+        /// 1. setHighQuality is set to false
+        /// 2. GPU support
+        ///
+        /// This function returns true only if if both conditions are met
+        bool willUseLowQuality() const;
+
+        /// Returns true if shaders are being compiled with Fast Shader Build Hack (D3D11 only)
+        bool getFastShaderBuildHack() const;
+
         /** Non-caster directional lights are hardcoded into shaders. This means that if you
             have 6 directional lights and then you add a 7th one, a whole new set of shaders
             will be created.

--- a/OgreMain/include/OgreHlms.h
+++ b/OgreMain/include/OgreHlms.h
@@ -87,20 +87,27 @@ namespace Ogre
 
         enum PrecisionMode
         {
-            /// half datatype maps to float (i.e. 32-bit)
+            /// midf datatype maps to float (i.e. 32-bit)
             /// This setting is always supported
             PrecisionFull32,
 
-            /// half datatype maps to float16_t (i.e. forced 16-bit)
+            /// midf datatype maps to float16_t (i.e. forced 16-bit)
             ///
-            /// This setting depends on GPU support (see RSC_SHADER_FLOAT16)
-            /// If unsupported, we fallback to PrecisionRelaxed
-            PrecisionHalf16,
+            /// It forces the driver to produce 16-bit code, even if unoptimal
+            /// Great for testing quality downgrades caused by 16-bit support
+            ///
+            /// - This depends on RSC_SHADER_FLOAT16.
+            /// - If unsupported, we fallback to PrecisionRelaxed (RSC_SHADER_RELAXED_FLOAT)
+            /// - If unsupported, we then fallback to PrecisionFull32
+            PrecisionMidf16,
 
-            /// half datatype maps to mediump float / min16float
+            /// midf datatype maps to mediump float / min16float
             ///
-            /// This setting is almost always supported; but we may
-            /// fallback to PrecisionFull32 on buggy drivers
+            /// The driver is allowed to work in either 16-bit or 32-bit code
+            ///
+            /// - This depends on RSC_SHADER_RELAXED_FLOAT.
+            /// - If unsupported, we fallback to PrecisionMidf16 (RSC_SHADER_FLOAT16)
+            /// - If unsupported, we then fallback to PrecisionFull32
             PrecisionRelaxed
         };
 
@@ -1017,7 +1024,7 @@ namespace Ogre
         static const IdString GLVersion;
         static const IdString PrecisionMode;
         static const IdString Full32;
-        static const IdString Half16;
+        static const IdString Midf16;
         static const IdString Relaxed;
         static const IdString FastShaderBuildHack;
         static const IdString TexGather;

--- a/OgreMain/include/OgreHlmsDiskCache.h
+++ b/OgreMain/include/OgreHlmsDiskCache.h
@@ -170,6 +170,9 @@ namespace Ogre
         Cache        mCache;
         HlmsManager *mHlmsManager;
         String       mShaderProfile;
+        uint16       mNativeShadingLangVer;
+        bool         mWillUseLowQuality;
+        bool         mFastShaderBuildHack;
         uint16       mDebugStrSize;
 
         void save( DataStreamPtr &dataStream, const IdString &hashedString );

--- a/OgreMain/include/OgreHlmsDiskCache.h
+++ b/OgreMain/include/OgreHlmsDiskCache.h
@@ -171,7 +171,7 @@ namespace Ogre
         HlmsManager *mHlmsManager;
         String       mShaderProfile;
         uint16       mNativeShadingLangVer;
-        bool         mWillUseLowQuality;
+        uint8        mPrecisionMode;
         bool         mFastShaderBuildHack;
         uint16       mDebugStrSize;
 

--- a/OgreMain/include/OgreRenderSystemCapabilities.h
+++ b/OgreMain/include/OgreRenderSystemCapabilities.h
@@ -232,10 +232,32 @@ namespace Ogre
         RSC_TEXTURE_COMPRESSION_ASTC = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 11),
         RSC_STORE_AND_MULTISAMPLE_RESOLVE = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 12),
         RSC_DEPTH_CLAMP = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 13),
+        /// Shaders supports mediump (aka relaxed precision) and is not masked
+        /// out due to known bugs
+        ///
+        /// OpenGL: Disabled, even if supported
+        ///
+        /// D3D11: Masked out due to fxc bugs.
+        /// See https://shader-playground.timjones.io/3110a80dff6acfbdd8384a64f2fa495d
+        /// and  https://gist.github.com/darksylinc/655495dae603c4e544dd475ae3537621
+        ///
+        /// Vulkan: Supported. May be masked out if driver is buggy
+        ///
+        /// Metal: Unsupported. Use RSC_SHADER_FLOAT16 instead
+        RSC_SHADER_RELAXED_FLOAT = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 14),
         /// Shaders support float16_t / half datatype as:
+        ///
         ///		- Math (i.e. a + b)
         ///		- In/Out blocks (i.e. to pass data between shader stages)
-        RSC_SHADER_FLOAT16 = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 14),
+        ///
+        /// OpenGL: Disabled, even if supported
+        ///
+        /// D3D11: Unsupported (needs SM 6.2 / DXC / DX12)
+        ///
+        /// Vulkan: Supported. Depends on HW GPU support.
+        ///
+        /// Metal: Always supported.
+        RSC_SHADER_FLOAT16 = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 15),
 
         // ***** DirectX specific caps *****
         /// Is DirectX feature "per stage constants" supported

--- a/OgreMain/include/OgreRenderSystemCapabilities.h
+++ b/OgreMain/include/OgreRenderSystemCapabilities.h
@@ -232,6 +232,10 @@ namespace Ogre
         RSC_TEXTURE_COMPRESSION_ASTC = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 11),
         RSC_STORE_AND_MULTISAMPLE_RESOLVE = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 12),
         RSC_DEPTH_CLAMP = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 13),
+        /// Shaders support float16_t / half datatype as:
+        ///		- Math (i.e. a + b)
+        ///		- In/Out blocks (i.e. to pass data between shader stages)
+        RSC_SHADER_FLOAT16 = OGRE_CAPS_VALUE(CAPS_CATEGORY_COMMON_3, 14),
 
         // ***** DirectX specific caps *****
         /// Is DirectX feature "per stage constants" supported

--- a/OgreMain/src/OSX/macUtils.mm
+++ b/OgreMain/src/OSX/macUtils.mm
@@ -31,6 +31,8 @@ THE SOFTWARE.
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
 #import <dlfcn.h>
+
+#import "OgreLogManager.h"
 #import "OgreString.h"
 
 namespace Ogre
@@ -194,8 +196,20 @@ namespace Ogre
                                                        appropriateForURL:nil
                                                                   create:YES
                                                                    error:nil];
-        NSURL *myDirURL = [cachesURL URLByAppendingPathComponent:NSBundle.mainBundle.bundleIdentifier
-                                                     isDirectory:YES];
+		NSURL *myDirURL = cachesURL;
+
+		if( NSBundle.mainBundle.bundleIdentifier )
+		{
+			// May be nullptr if bundle is not correctly set (e.g. samples)
+			myDirURL = [cachesURL URLByAppendingPathComponent:NSBundle.mainBundle.bundleIdentifier
+												  isDirectory:YES];
+		}
+		else
+		{
+			LogManager::getSingleton().logMessage( "WARNING: NS Bundle Identifier not set!",
+												   LML_CRITICAL );
+		}
+
         if( bAutoCreate )
         {
             [NSFileManager.defaultManager createDirectoryAtURL:myDirURL

--- a/OgreMain/src/OgreHlms.cpp
+++ b/OgreMain/src/OgreHlms.cpp
@@ -271,7 +271,7 @@ namespace Ogre
         mDebugOutput( false ),
 #endif
 #if OGRE_DEBUG_MODE >= OGRE_DEBUG_HIGH
-        mDebugOutputProperties( false ),
+        mDebugOutputProperties( true ),
 #else
         mDebugOutputProperties( false ),
 #endif

--- a/OgreMain/src/OgreHlms.cpp
+++ b/OgreMain/src/OgreHlms.cpp
@@ -275,7 +275,7 @@ namespace Ogre
 #else
         mDebugOutputProperties( false ),
 #endif
-        mPrecisionMode( PrecisionRelaxed ),
+        mPrecisionMode( PrecisionFull32 ),
         mFastShaderBuildHack( false ),
         mDefaultDatablock( 0 ),
         mType( type ),

--- a/OgreMain/src/OgreHlms.cpp
+++ b/OgreMain/src/OgreHlms.cpp
@@ -1678,6 +1678,14 @@ namespace Ogre
         mHighQuality = highQuality;
     }
     //-----------------------------------------------------------------------------------
+    bool Hlms::willUseLowQuality() const
+    {
+        const RenderSystemCapabilities *capabilities = mRenderSystem->getCapabilities();
+        return !mHighQuality && capabilities->hasCapability( RSC_SHADER_FLOAT16 );
+    }
+    //-----------------------------------------------------------------------------------
+    bool Hlms::getFastShaderBuildHack() const { return mFastShaderBuildHack; }
+    //-----------------------------------------------------------------------------------
     void Hlms::setMaxNonCasterDirectionalLights( uint16 maxLights ) { mNumLightsLimit = maxLights; }
     //-----------------------------------------------------------------------------------
     void Hlms::setStaticBranchingLights( bool staticBranchingLights )
@@ -2190,7 +2198,7 @@ namespace Ogre
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
                 setProperty( HlmsBaseProp::macOS, 1 );
 #endif
-                setProperty( HlmsBaseProp::HighQuality, mHighQuality );
+                setProperty( HlmsBaseProp::HighQuality, !willUseLowQuality() );
 
                 if( mFastShaderBuildHack )
                     setProperty( HlmsBaseProp::FastShaderBuildHack, 1 );

--- a/OgreMain/src/OgreHlms.cpp
+++ b/OgreMain/src/OgreHlms.cpp
@@ -205,7 +205,7 @@ namespace Ogre
     const IdString HlmsBaseProp::macOS          = IdString( "macOS" );
     const IdString HlmsBaseProp::PrecisionMode  = IdString( "precision_mode" );
     const IdString HlmsBaseProp::Full32         = IdString( "full32" );
-    const IdString HlmsBaseProp::Half16         = IdString( "half16" );
+    const IdString HlmsBaseProp::Midf16         = IdString( "midf16" );
     const IdString HlmsBaseProp::Relaxed        = IdString( "relaxed" );
     const IdString HlmsBaseProp::FastShaderBuildHack= IdString( "fast_shader_build_hack" );
     const IdString HlmsBaseProp::TexGather      = IdString( "hlms_tex_gather" );
@@ -1691,13 +1691,32 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     Hlms::PrecisionMode Hlms::getSupportedPrecisionMode() const
     {
-        if( mPrecisionMode == PrecisionHalf16 )
+        switch( mPrecisionMode )
+        {
+        case PrecisionFull32:
+            return PrecisionFull32;
+
+        case PrecisionMidf16:
         {
             const RenderSystemCapabilities *capabilities = mRenderSystem->getCapabilities();
             if( capabilities->hasCapability( RSC_SHADER_FLOAT16 ) )
-                return PrecisionHalf16;
-            else
+                return PrecisionMidf16;
+            else if( capabilities->hasCapability( RSC_SHADER_RELAXED_FLOAT ) )
                 return PrecisionRelaxed;
+            else
+                return PrecisionFull32;
+        }
+
+        case PrecisionRelaxed:
+        {
+            const RenderSystemCapabilities *capabilities = mRenderSystem->getCapabilities();
+            if( capabilities->hasCapability( RSC_SHADER_RELAXED_FLOAT ) )
+                return PrecisionRelaxed;
+            else if( capabilities->hasCapability( RSC_SHADER_FLOAT16 ) )
+                return PrecisionMidf16;
+            else
+                return PrecisionFull32;
+        }
         }
 
         return static_cast<PrecisionMode>( mPrecisionMode );
@@ -1709,8 +1728,8 @@ namespace Ogre
         {
         case PrecisionFull32:
             return static_cast<int32>( HlmsBaseProp::Full32.mHash );
-        case PrecisionHalf16:
-            return static_cast<int32>( HlmsBaseProp::Half16.mHash );
+        case PrecisionMidf16:
+            return static_cast<int32>( HlmsBaseProp::Midf16.mHash );
         case PrecisionRelaxed:
             return static_cast<int32>( HlmsBaseProp::Relaxed.mHash );
         }
@@ -2231,7 +2250,7 @@ namespace Ogre
                 setProperty( HlmsBaseProp::macOS, 1 );
 #endif
                 setProperty( HlmsBaseProp::Full32, static_cast<int32>( HlmsBaseProp::Full32.mHash ) );
-                setProperty( HlmsBaseProp::Half16, static_cast<int32>( HlmsBaseProp::Half16.mHash ) );
+                setProperty( HlmsBaseProp::Midf16, static_cast<int32>( HlmsBaseProp::Midf16.mHash ) );
                 setProperty( HlmsBaseProp::Relaxed, static_cast<int32>( HlmsBaseProp::Relaxed.mHash ) );
                 setProperty( HlmsBaseProp::PrecisionMode, getSupportedPrecisionModeHash() );
 

--- a/OgreMain/src/OgreHlmsCompute.cpp
+++ b/OgreMain/src/OgreHlmsCompute.cpp
@@ -208,7 +208,7 @@ namespace Ogre
         setProperty( HlmsBaseProp::macOS, 1 );
 #endif
         setProperty( HlmsBaseProp::Full32, static_cast<int32>( HlmsBaseProp::Full32.mHash ) );
-        setProperty( HlmsBaseProp::Half16, static_cast<int32>( HlmsBaseProp::Half16.mHash ) );
+        setProperty( HlmsBaseProp::Midf16, static_cast<int32>( HlmsBaseProp::Midf16.mHash ) );
         setProperty( HlmsBaseProp::Relaxed, static_cast<int32>( HlmsBaseProp::Relaxed.mHash ) );
         setProperty( HlmsBaseProp::PrecisionMode, getSupportedPrecisionModeHash() );
 

--- a/OgreMain/src/OgreHlmsCompute.cpp
+++ b/OgreMain/src/OgreHlmsCompute.cpp
@@ -207,7 +207,10 @@ namespace Ogre
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
         setProperty( HlmsBaseProp::macOS, 1 );
 #endif
-        setProperty( HlmsBaseProp::HighQuality, mHighQuality );
+        setProperty( HlmsBaseProp::Full32, static_cast<int32>( HlmsBaseProp::Full32.mHash ) );
+        setProperty( HlmsBaseProp::Half16, static_cast<int32>( HlmsBaseProp::Half16.mHash ) );
+        setProperty( HlmsBaseProp::Relaxed, static_cast<int32>( HlmsBaseProp::Relaxed.mHash ) );
+        setProperty( HlmsBaseProp::PrecisionMode, getSupportedPrecisionModeHash() );
 
         if( mFastShaderBuildHack )
             setProperty( HlmsBaseProp::FastShaderBuildHack, 1 );

--- a/OgreMain/src/OgreHlmsDiskCache.cpp
+++ b/OgreMain/src/OgreHlmsDiskCache.cpp
@@ -62,7 +62,7 @@ namespace Ogre
         mShaderProfile.clear();
 
         mNativeShadingLangVer = 0u;
-        mWillUseLowQuality = true;
+        mPrecisionMode = Hlms::PrecisionFull32;
         mFastShaderBuildHack = true;
     }
     //-----------------------------------------------------------------------------------
@@ -101,7 +101,7 @@ namespace Ogre
         mCache.type = hlms->getType();
         mShaderProfile = hlms->getShaderProfile();
         mNativeShadingLangVer = hlms->getRenderSystem()->getNativeShadingLanguageVersion();
-        mWillUseLowQuality = hlms->willUseLowQuality();
+        mPrecisionMode = hlms->getSupportedPrecisionMode();
         mFastShaderBuildHack = hlms->getFastShaderBuildHack();
         hlms->getTemplateChecksum( mCache.templateHash );
 
@@ -176,13 +176,13 @@ namespace Ogre
                 "'. This increases loading times." );
         }
 
-        if( !mTemplatesOutOfDate && mWillUseLowQuality != hlms->willUseLowQuality() )
+        if( !mTemplatesOutOfDate && mPrecisionMode != hlms->getSupportedPrecisionMode() )
         {
             mTemplatesOutOfDate = true;
             LogManager::getSingleton().logMessage(
-                "INFO: mWillUseLowQuality has changed from '" +
-                StringConverter::toString( mWillUseLowQuality ) + "' to the current value '" +
-                StringConverter::toString( hlms->willUseLowQuality() ) +
+                "INFO: mPrecisionMode has changed from '" +
+                StringConverter::toString( mPrecisionMode ) + "' to the current value '" +
+                StringConverter::toString( hlms->getSupportedPrecisionMode() ) +
                 "'. This increases loading times." );
         }
 
@@ -355,7 +355,7 @@ namespace Ogre
         save( dataStream, mShaderProfile );
 
         write<uint16>( dataStream, mNativeShadingLangVer );
-        write<bool>( dataStream, mWillUseLowQuality );
+        write<uint8>( dataStream, mPrecisionMode );
         write<bool>( dataStream, mFastShaderBuildHack );
 
         {
@@ -563,7 +563,7 @@ namespace Ogre
         load( dataStream, mShaderProfile );
 
         read<uint16>( dataStream, mNativeShadingLangVer );
-        read<bool>( dataStream, mWillUseLowQuality );
+        read<uint8>( dataStream, mPrecisionMode );
         read<bool>( dataStream, mFastShaderBuildHack );
 
         {

--- a/OgreMain/src/OgreHlmsDiskCache.cpp
+++ b/OgreMain/src/OgreHlmsDiskCache.cpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "OgreHlmsManager.h"
 #include "OgreLogManager.h"
 #include "OgreProfiler.h"
+#include "OgreRenderSystem.h"
 #include "OgreStringConverter.h"
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_APPLE_IOS
@@ -41,7 +42,7 @@ THE SOFTWARE.
 
 namespace Ogre
 {
-    static const uint16 c_hlmsDiskCacheVersion = 2u;
+    static const uint16 c_hlmsDiskCacheVersion = 3u;
 
     HlmsDiskCache::HlmsDiskCache( HlmsManager *hlmsManager ) :
         mTemplatesOutOfDate( false ),
@@ -59,6 +60,10 @@ namespace Ogre
         mCache.sourceCode.clear();
         mCache.pso.clear();
         mShaderProfile.clear();
+
+        mNativeShadingLangVer = 0u;
+        mWillUseLowQuality = true;
+        mFastShaderBuildHack = true;
     }
     //-----------------------------------------------------------------------------------
     //-----------------------------------------------------------------------------------
@@ -95,6 +100,9 @@ namespace Ogre
 
         mCache.type = hlms->getType();
         mShaderProfile = hlms->getShaderProfile();
+        mNativeShadingLangVer = hlms->getRenderSystem()->getNativeShadingLanguageVersion();
+        mWillUseLowQuality = hlms->willUseLowQuality();
+        mFastShaderBuildHack = hlms->getFastShaderBuildHack();
         hlms->getTemplateChecksum( mCache.templateHash );
 
         {
@@ -154,6 +162,37 @@ namespace Ogre
             LogManager::getSingleton().logMessage(
                 "INFO: The cached Hlms is for shader profile in '" + mShaderProfile +
                 "' but it does not match the current one '" + hlms->getShaderProfile() +
+                "'. This increases loading times." );
+        }
+
+        if( !mTemplatesOutOfDate &&
+            mNativeShadingLangVer != hlms->getRenderSystem()->getNativeShadingLanguageVersion() )
+        {
+            mTemplatesOutOfDate = true;
+            LogManager::getSingleton().logMessage(
+                "INFO: mNativeShadingLangVer has changed from '" +
+                StringConverter::toString( mNativeShadingLangVer ) + "' to the current value '" +
+                StringConverter::toString( hlms->getRenderSystem()->getNativeShadingLanguageVersion() ) +
+                "'. This increases loading times." );
+        }
+
+        if( !mTemplatesOutOfDate && mWillUseLowQuality != hlms->willUseLowQuality() )
+        {
+            mTemplatesOutOfDate = true;
+            LogManager::getSingleton().logMessage(
+                "INFO: mWillUseLowQuality has changed from '" +
+                StringConverter::toString( mWillUseLowQuality ) + "' to the current value '" +
+                StringConverter::toString( hlms->willUseLowQuality() ) +
+                "'. This increases loading times." );
+        }
+
+        if( !mTemplatesOutOfDate && mFastShaderBuildHack != hlms->getFastShaderBuildHack() )
+        {
+            mTemplatesOutOfDate = true;
+            LogManager::getSingleton().logMessage(
+                "INFO: mFastShaderBuildHack has changed from '" +
+                StringConverter::toString( mFastShaderBuildHack ) + "' to the current value '" +
+                StringConverter::toString( hlms->getFastShaderBuildHack() ) +
                 "'. This increases loading times." );
         }
 
@@ -241,6 +280,12 @@ namespace Ogre
     {
         dataStream->write( &value, sizeof( value ) );
     }
+    template <>
+    void write<bool>( DataStreamPtr &dataStream, const bool &value )
+    {
+        const uint8 valueAsU8 = value ? 1u : 0u;
+        dataStream->write( &valueAsU8, sizeof( valueAsU8 ) );
+    }
     //-----------------------------------------------------------------------------------
     void HlmsDiskCache::save( DataStreamPtr &dataStream, const IdString &hashedString )
     {
@@ -308,6 +353,10 @@ namespace Ogre
         write( dataStream, mCache.templateHash );
         write( dataStream, mCache.type );
         save( dataStream, mShaderProfile );
+
+        write<uint16>( dataStream, mNativeShadingLangVer );
+        write<bool>( dataStream, mWillUseLowQuality );
+        write<bool>( dataStream, mFastShaderBuildHack );
 
         {
             // Save shaders
@@ -401,6 +450,20 @@ namespace Ogre
         T value;
         dataStream->read( &value, sizeof( value ) );
         return value;
+    }
+    template <>
+    void read<bool>( DataStreamPtr &dataStream, bool &value )
+    {
+        uint8 valueU8;
+        dataStream->read( &valueU8, sizeof( valueU8 ) );
+        value = valueU8 != 0u;
+    }
+    template <>
+    bool read<bool>( DataStreamPtr &dataStream )
+    {
+        uint8 value;
+        dataStream->read( &value, sizeof( value ) );
+        return value != 0u;
     }
     //-----------------------------------------------------------------------------------
     void HlmsDiskCache::load( DataStreamPtr &dataStream, IdString &hashedString )
@@ -498,6 +561,10 @@ namespace Ogre
         read( dataStream, mCache.templateHash );
         read( dataStream, mCache.type );
         load( dataStream, mShaderProfile );
+
+        read<uint16>( dataStream, mNativeShadingLangVer );
+        read<bool>( dataStream, mWillUseLowQuality );
+        read<bool>( dataStream, mFastShaderBuildHack );
 
         {
             // Load shaders

--- a/OgreMain/src/OgreRenderSystemCapabilities.cpp
+++ b/OgreMain/src/OgreRenderSystemCapabilities.cpp
@@ -321,6 +321,9 @@ namespace Ogre {
             " * Hardware Atomic Counters: "
             + StringConverter::toString(hasCapability(RSC_ATOMIC_COUNTERS), true));
 
+        pLog->logMessage( " * Shader 16-bit floating point (half): " +
+                          StringConverter::toString( hasCapability( RSC_SHADER_FLOAT16 ), true ) );
+
         if( hasCapability( RSC_COMPUTE_PROGRAM ) )
         {
             pLog->logMessage(

--- a/OgreMain/src/iOS/macUtils.mm
+++ b/OgreMain/src/iOS/macUtils.mm
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <CoreFoundation/CoreFoundation.h>
 #include <Foundation/Foundation.h>
 
+#include "OgreLogManager.h"
 #include "OgreString.h"
 #include "macUtils.h"
 
@@ -73,8 +74,20 @@ namespace Ogre
                                                        appropriateForURL:nil
                                                                   create:YES
                                                                    error:nil];
-        NSURL *myDirURL = [cachesURL URLByAppendingPathComponent:NSBundle.mainBundle.bundleIdentifier
-                                                     isDirectory:YES];
+        NSURL *myDirURL = cachesURL;
+
+        if( NSBundle.mainBundle.bundleIdentifier )
+        {
+            // May be nullptr if bundle is not correctly set (e.g. samples)
+            myDirURL = [cachesURL URLByAppendingPathComponent:NSBundle.mainBundle.bundleIdentifier
+                                                  isDirectory:YES];
+        }
+        else
+        {
+            LogManager::getSingleton().logMessage( "WARNING: NS Bundle Identifier not set!",
+                                                   LML_CRITICAL );
+        }
+
         if( bAutoCreate )
         {
             [NSFileManager.defaultManager createDirectoryAtURL:myDirURL

--- a/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
+++ b/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
@@ -275,6 +275,7 @@ namespace Ogre
         rsc->setCapability( RSC_DOT3 );
         rsc->setCapability( RSC_CUBEMAPPING );
         rsc->setCapability( RSC_TEXTURE_COMPRESSION );
+        rsc->setCapability( RSC_SHADER_FLOAT16 );
 #if TARGET_OS_TV
         rsc->setCapability( RSC_TEXTURE_COMPRESSION_ASTC );
 #endif

--- a/RenderSystems/Vulkan/include/OgreVulkanDevice.h
+++ b/RenderSystems/Vulkan/include/OgreVulkanDevice.h
@@ -49,6 +49,16 @@ namespace Ogre
             SelectedQueue();
         };
 
+        struct ExtraVkFeatures
+        {
+            // VkPhysicalDevice16BitStorageFeatures
+            VkBool32 storageInputOutput16;
+
+            // VkPhysicalDeviceShaderFloat16Int8Features
+            VkBool32 shaderFloat16;
+            VkBool32 shaderInt8;
+        };
+
         // clang-format off
         VkInstance          mInstance;
         VkPhysicalDevice    mPhysicalDevice;
@@ -67,6 +77,7 @@ namespace Ogre
         VkPhysicalDeviceProperties mDeviceProperties;
         VkPhysicalDeviceMemoryProperties mDeviceMemoryProperties;
         VkPhysicalDeviceFeatures mDeviceFeatures;
+        ExtraVkFeatures mDeviceExtraFeatures;
         FastArray<VkQueueFamilyProperties> mQueueProps;
 
         /// Extensions requested when created. Sorted
@@ -106,6 +117,8 @@ namespace Ogre
                            uint32 maxTransferQueues );
 
         bool hasDeviceExtension( const IdString extension ) const;
+
+        static bool hasInstanceExtension( const IdString extension );
 
         void initQueues();
 

--- a/RenderSystems/Vulkan/src/OgreVulkanDevice.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanDevice.cpp
@@ -347,6 +347,8 @@ namespace Ogre
         }
 
         // Declared at this scope because they must be alive for createInfo.pNext
+        VkPhysicalDeviceFeatures2 deviceFeatures2;
+        makeVkStruct( deviceFeatures2, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 );
         VkPhysicalDevice16BitStorageFeatures _16BitStorageFeatures;
         makeVkStruct( _16BitStorageFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES );
         VkPhysicalDeviceShaderFloat16Int8Features shaderFloat16Int8Features;
@@ -359,9 +361,6 @@ namespace Ogre
             PFN_vkGetPhysicalDeviceFeatures2KHR GetPhysicalDeviceFeatures2KHR =
                 (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(
                     mInstance, "vkGetPhysicalDeviceFeatures2KHR" );
-
-            VkPhysicalDeviceFeatures2 deviceFeatures2;
-            makeVkStruct( deviceFeatures2, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 );
 
             void **lastNext = &deviceFeatures2.pNext;
 
@@ -377,7 +376,7 @@ namespace Ogre
             }
 
             // Send the same chain to vkCreateDevice
-            createInfo.pNext = deviceFeatures2.pNext;
+            createInfo.pNext = &deviceFeatures2;
 
             GetPhysicalDeviceFeatures2KHR( mPhysicalDevice, &deviceFeatures2 );
 

--- a/RenderSystems/Vulkan/src/OgreVulkanDevice.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanDevice.cpp
@@ -43,6 +43,8 @@ THE SOFTWARE.
 
 namespace Ogre
 {
+    static FastArray<IdString> msInstanceExtensions;
+
     VulkanDevice::VulkanDevice( VkInstance instance, uint32 deviceIdx,
                                 VulkanRenderSystem *renderSystem ) :
         mInstance( instance ),
@@ -134,6 +136,24 @@ namespace Ogre
         createInfo.pNext = &debugCb;
 #endif
 
+        {
+            msInstanceExtensions.clear();
+            msInstanceExtensions.reserve( extensions.size() );
+
+            FastArray<const char *>::const_iterator itor = extensions.begin();
+            FastArray<const char *>::const_iterator endt = extensions.end();
+
+            while( itor != endt )
+            {
+                LogManager::getSingleton().logMessage( "Requesting Instance Extension: " +
+                                                       String( *itor ) );
+                msInstanceExtensions.push_back( *itor );
+                ++itor;
+            }
+
+            std::sort( msInstanceExtensions.begin(), msInstanceExtensions.end() );
+        }
+
         VkInstance instance;
         VkResult result = vkCreateInstance( &createInfo, 0, &instance );
         checkVkResult( result, "vkCreateInstance" );
@@ -178,6 +198,9 @@ namespace Ogre
         mPhysicalDevice = pd[deviceIdx];
 
         vkGetPhysicalDeviceMemoryProperties( mPhysicalDevice, &mDeviceMemoryProperties );
+
+        // mDeviceExtraFeatures gets initialized later, once we analyzed all the extensions
+        memset( &mDeviceExtraFeatures, 0, sizeof( mDeviceExtraFeatures ) );
         vkGetPhysicalDeviceFeatures( mPhysicalDevice, &mDeviceFeatures );
 
         mSupportedStages = 0xFFFFFFFF;
@@ -323,6 +346,46 @@ namespace Ogre
             std::sort( mDeviceExtensions.begin(), mDeviceExtensions.end() );
         }
 
+        // Declared at this scope because they must be alive for createInfo.pNext
+        VkPhysicalDevice16BitStorageFeatures _16BitStorageFeatures;
+        makeVkStruct( _16BitStorageFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES );
+        VkPhysicalDeviceShaderFloat16Int8Features shaderFloat16Int8Features;
+        makeVkStruct( shaderFloat16Int8Features,
+                      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES );
+
+        // Initialize mDeviceExtraFeatures
+        if( hasInstanceExtension( VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME ) )
+        {
+            PFN_vkGetPhysicalDeviceFeatures2KHR GetPhysicalDeviceFeatures2KHR =
+                (PFN_vkGetPhysicalDeviceFeatures2KHR)vkGetInstanceProcAddr(
+                    mInstance, "vkGetPhysicalDeviceFeatures2KHR" );
+
+            VkPhysicalDeviceFeatures2 deviceFeatures2;
+            makeVkStruct( deviceFeatures2, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 );
+
+            void **lastNext = &deviceFeatures2.pNext;
+
+            if( this->hasDeviceExtension( VK_KHR_16BIT_STORAGE_EXTENSION_NAME ) )
+            {
+                *lastNext = &_16BitStorageFeatures;
+                lastNext = &_16BitStorageFeatures.pNext;
+            }
+            if( this->hasDeviceExtension( VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME ) )
+            {
+                *lastNext = &shaderFloat16Int8Features;
+                lastNext = &shaderFloat16Int8Features.pNext;
+            }
+
+            // Send the same chain to vkCreateDevice
+            createInfo.pNext = deviceFeatures2.pNext;
+
+            GetPhysicalDeviceFeatures2KHR( mPhysicalDevice, &deviceFeatures2 );
+
+            mDeviceExtraFeatures.storageInputOutput16 = _16BitStorageFeatures.storageInputOutput16;
+            mDeviceExtraFeatures.shaderFloat16 = shaderFloat16Int8Features.shaderFloat16;
+            mDeviceExtraFeatures.shaderInt8 = shaderFloat16Int8Features.shaderInt8;
+        }
+
         VkResult result = vkCreateDevice( mPhysicalDevice, &createInfo, NULL, &mDevice );
         checkVkResult( result, "vkCreateDevice" );
 
@@ -334,6 +397,13 @@ namespace Ogre
         FastArray<IdString>::const_iterator itor =
             std::lower_bound( mDeviceExtensions.begin(), mDeviceExtensions.end(), extension );
         return itor != mDeviceExtensions.end() && *itor == extension;
+    }
+    //-------------------------------------------------------------------------
+    bool VulkanDevice::hasInstanceExtension( const IdString extension )
+    {
+        FastArray<IdString>::const_iterator itor =
+            std::lower_bound( msInstanceExtensions.begin(), msInstanceExtensions.end(), extension );
+        return itor != msInstanceExtensions.end() && *itor == extension;
     }
     //-------------------------------------------------------------------------
     void VulkanDevice::initQueues()

--- a/RenderSystems/Vulkan/src/OgreVulkanDevice.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanDevice.cpp
@@ -327,7 +327,10 @@ namespace Ogre
         createInfo.queueCreateInfoCount = static_cast<uint32>( queueCreateInfo.size() );
         createInfo.pQueueCreateInfos = &queueCreateInfo[0];
 
-        createInfo.pEnabledFeatures = &mDeviceFeatures;
+        if( hasInstanceExtension( VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME ) )
+            createInfo.pEnabledFeatures = nullptr;
+        else
+            createInfo.pEnabledFeatures = &mDeviceFeatures;
 
         {
             mDeviceExtensions.clear();

--- a/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
@@ -505,6 +505,8 @@ namespace Ogre
         if( mActiveDevice->hasDeviceExtension( VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME ) )
             rsc->setCapability( RSC_VP_AND_RT_ARRAY_INDEX_FROM_ANY_SHADER );
 
+        rsc->setCapability( RSC_SHADER_RELAXED_FLOAT );
+
         if( mDevice->mDeviceExtraFeatures.shaderFloat16 &&
             mDevice->mDeviceExtraFeatures.storageInputOutput16 )
         {

--- a/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanRenderSystem.cpp
@@ -505,6 +505,12 @@ namespace Ogre
         if( mActiveDevice->hasDeviceExtension( VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME ) )
             rsc->setCapability( RSC_VP_AND_RT_ARRAY_INDEX_FROM_ANY_SHADER );
 
+        if( mDevice->mDeviceExtraFeatures.shaderFloat16 &&
+            mDevice->mDeviceExtraFeatures.storageInputOutput16 )
+        {
+            rsc->setCapability( RSC_SHADER_FLOAT16 );
+        }
+
         if( mActiveDevice->mDeviceFeatures.depthClamp )
             rsc->setCapability( RSC_DEPTH_CLAMP );
 
@@ -796,6 +802,12 @@ namespace Ogre
             if( extensionName == VK_EXT_DEBUG_UTILS_EXTENSION_NAME )
                 reqInstanceExtensions.push_back( VK_EXT_DEBUG_UTILS_EXTENSION_NAME );
 #endif
+
+            if( extensionName == VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME )
+            {
+                reqInstanceExtensions.push_back(
+                    VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME );
+            }
         }
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
@@ -985,10 +997,24 @@ namespace Ogre
                         deviceExtensions.push_back( VK_KHR_MAINTENANCE2_EXTENSION_NAME );
                         bCanRestrictImageViewUsage = true;
                     }
+                    else if( extensionName == VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME )
+                    {
+                        deviceExtensions.push_back(
+                            VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME );
+                    }
                     else if( extensionName == VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME )
                         deviceExtensions.push_back( VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME );
                     else if( extensionName == VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME )
                         deviceExtensions.push_back( VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME );
+                    else if( extensionName == VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME )
+                    {
+                        // Required by VK_KHR_16bit_storage
+                        deviceExtensions.push_back( VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME );
+                    }
+                    else if( extensionName == VK_KHR_16BIT_STORAGE_EXTENSION_NAME )
+                        deviceExtensions.push_back( VK_KHR_16BIT_STORAGE_EXTENSION_NAME );
+                    else if( extensionName == VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME )
+                        deviceExtensions.push_back( VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME );
                 }
             }
 

--- a/RenderSystems/Vulkan/src/SPIRV-Reflect/spirv_reflect.c
+++ b/RenderSystems/Vulkan/src/SPIRV-Reflect/spirv_reflect.c
@@ -1369,6 +1369,11 @@ static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser)
     CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
     SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
     if (IsNull(p_target_node)) {
+      if (p_node->op == (uint32_t)SpvOpDecorate && decoration == SpvDecorationRelaxedPrecision) {
+        // Many OPs can be decorated that we don't care about. Ignore those
+        // See https://github.com/KhronosGroup/SPIRV-Reflect/issues/134
+        continue;
+      }
       return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
     }
     // Get decorations

--- a/Samples/Media/Hlms/Common/Any/Cubemap_piece_all.any
+++ b/Samples/Media/Hlms/Common/Any/Cubemap_piece_all.any
@@ -93,20 +93,20 @@ INLINE float4 localCorrect( float3 reflDir, float3 posLS, CubemapProbe probe )
 /// 1 means being at the center of the probe.
 /// 0 means being at the edge of the probe
 /// <0 means position is outside the probe.
-@property( syntax == metal )inline @end half getProbeFade( half3 posLS, CubemapProbe probe )
+@property( syntax == metal )inline @end midf getProbeFade( midf3 posLS, CubemapProbe probe )
 {
-	half3 vDiff = ( half3_c( probe.halfSize.xyz ) - abs( posLS.xyz ) ) / half3_c( probe.halfSize.xyz );
+	midf3 vDiff = ( midf3_c( probe.halfSize.xyz ) - abs( posLS.xyz ) ) / midf3_c( probe.halfSize.xyz );
 	return min( min( vDiff.x, vDiff.y ), vDiff.z );
 }
 
-INLINE half getProbeNDF( half3 posLS, half3 probeToAreaCenterOffsetLS,
-						 half3 innerRange, half3 outerRange )
+INLINE midf getProbeNDF( midf3 posLS, midf3 probeToAreaCenterOffsetLS,
+						 midf3 innerRange, midf3 outerRange )
 {
-	half3 areaPosLS = posLS.xyz - probeToAreaCenterOffsetLS.xyz;
-	//half3 areaPosLS = posLS.xyz - half3_c( 0, 0, -5 );
-	half3 dist = abs( areaPosLS.xyz );
+	midf3 areaPosLS = posLS.xyz - probeToAreaCenterOffsetLS.xyz;
+	//midf3 areaPosLS = posLS.xyz - midf3_c( 0, 0, -5 );
+	midf3 dist = abs( areaPosLS.xyz );
 	//1e-6f avoids division by zero.
-	half3 ndf = (dist - innerRange) / (outerRange - innerRange + _h( 1e-6f ));
+	midf3 ndf = (dist - innerRange) / (outerRange - innerRange + _h( 1e-6f ));
 
 	return max3( ndf.x, ndf.y, ndf.z );
 }

--- a/Samples/Media/Hlms/Common/Any/Cubemap_piece_all.any
+++ b/Samples/Media/Hlms/Common/Any/Cubemap_piece_all.any
@@ -93,20 +93,20 @@ INLINE float4 localCorrect( float3 reflDir, float3 posLS, CubemapProbe probe )
 /// 1 means being at the center of the probe.
 /// 0 means being at the edge of the probe
 /// <0 means position is outside the probe.
-@property( syntax == metal )inline @end float getProbeFade( float3 posLS, CubemapProbe probe )
+@property( syntax == metal )inline @end half getProbeFade( half3 posLS, CubemapProbe probe )
 {
-	float3 vDiff = ( probe.halfSize.xyz - abs( posLS.xyz ) ) / probe.halfSize.xyz;
+	half3 vDiff = ( half3_c( probe.halfSize.xyz ) - abs( posLS.xyz ) ) / half3_c( probe.halfSize.xyz );
 	return min( min( vDiff.x, vDiff.y ), vDiff.z );
 }
 
-INLINE float getProbeNDF( float3 posLS, float3 probeToAreaCenterOffsetLS,
-						  float3 innerRange, float3 outerRange )
+INLINE half getProbeNDF( half3 posLS, half3 probeToAreaCenterOffsetLS,
+						 half3 innerRange, half3 outerRange )
 {
-	float3 areaPosLS = posLS.xyz - probeToAreaCenterOffsetLS.xyz;
-	//float3 areaPosLS = posLS.xyz - float3( 0, 0, -5 );
-	float3 dist = abs( areaPosLS.xyz );
+	half3 areaPosLS = posLS.xyz - probeToAreaCenterOffsetLS.xyz;
+	//half3 areaPosLS = posLS.xyz - half3_c( 0, 0, -5 );
+	half3 dist = abs( areaPosLS.xyz );
 	//1e-6f avoids division by zero.
-	float3 ndf = (dist - innerRange) / (outerRange - innerRange + 1e-6f);
+	half3 ndf = (dist - innerRange) / (outerRange - innerRange + _h( 1e-6f ));
 
 	return max3( ndf.x, ndf.y, ndf.z );
 }

--- a/Samples/Media/Hlms/Common/Any/Cubemap_piece_all.any
+++ b/Samples/Media/Hlms/Common/Any/Cubemap_piece_all.any
@@ -29,30 +29,30 @@ struct CubemapProbe
 
 	The w component contains the distance from pos to intersection walking across reflDir
 */
-INLINE float4 localCorrect( float3 reflDir, float3 posLS, CubemapProbe probe )
+INLINE midf4 localCorrect( midf3 reflDir, midf3 posLS, CubemapProbe probe )
 {
-	float3 probeShapeHalfSize	= probe.halfSize.xyz;
-	float3x3 viewSpaceToProbeLocal = buildFloat3x3( probe.row0_centerX.xyz,
-													probe.row1_centerY.xyz,
-													probe.row2_centerZ.xyz );
-	float3 reflDirLS = mul( reflDir, viewSpaceToProbeLocal );
+	midf3 probeShapeHalfSize	= midf3_c( probe.halfSize.xyz );
+	midf3x3 viewSpaceToProbeLocal = buildMidf3x3( probe.row0_centerX.xyz,
+												  probe.row1_centerY.xyz,
+												  probe.row2_centerZ.xyz );
+	midf3 reflDirLS = mul( reflDir, viewSpaceToProbeLocal );
 
 	//Find the ray intersection with box plane
-	float3 invReflDirLS = float3( 1.0, 1.0, 1.0 ) / reflDirLS;
-	float3 intersectAtMinPlane = ( -probeShapeHalfSize - posLS ) * invReflDirLS;
-	float3 intersectAtMaxPlane = (  probeShapeHalfSize - posLS ) * invReflDirLS;
+	midf3 invReflDirLS = midf3_c( 1.0, 1.0, 1.0 ) / reflDirLS;
+	midf3 intersectAtMinPlane = ( -probeShapeHalfSize - posLS ) * invReflDirLS;
+	midf3 intersectAtMaxPlane = (  probeShapeHalfSize - posLS ) * invReflDirLS;
 	//Get the largest intersection values (we are not intersted in negative values)
-	float3 largestIntersect = max( intersectAtMaxPlane.xyz, intersectAtMinPlane.xyz );
+	midf3 largestIntersect = max( intersectAtMaxPlane.xyz, intersectAtMinPlane.xyz );
 	//Get the closest of all solutions
-	float distance = min( min( largestIntersect.x, largestIntersect.y ), largestIntersect.z );
+	midf distance = min( min( largestIntersect.x, largestIntersect.y ), largestIntersect.z );
 	//Get the intersection position
-	float3 intersectPositionLS = posLS.xyz + reflDirLS.xyz * distance;
+	midf3 intersectPositionLS = posLS.xyz + reflDirLS.xyz * distance;
 	//Get corrected vector
-	float3 localCorrectedVec = intersectPositionLS.xyz - probe.cubemapPosLS.xyz;
+	midf3 localCorrectedVec = intersectPositionLS.xyz - midf3_c( probe.cubemapPosLS.xyz );
 
 	//Make it left-handed.
 	localCorrectedVec.z = -localCorrectedVec.z;
-	return float4( localCorrectedVec, distance );
+	return midf4_c( localCorrectedVec, distance );
 }
 
 /** Converts a position from view space to probe's local space.

--- a/Samples/Media/Hlms/Common/Any/DualParaboloid_piece_ps.any
+++ b/Samples/Media/Hlms/Common/Any/DualParaboloid_piece_ps.any
@@ -4,13 +4,13 @@
 
 /// Converts UVW coordinates that would be used for sampling a cubemap,
 /// and returns UV coordinates to sample a dual paraboloid in 2D
-INLINE float2 mapCubemapToDpm( float3 cubemapDir )
+INLINE midf2 mapCubemapToDpm( midf3 cubemapDir )
 {
     cubemapDir = normalize( cubemapDir );
-	float2 retVal;
-    retVal.x = (cubemapDir.x / (1.0 + abs( cubemapDir.z ))) * 0.25 +
-			   (cubemapDir.z < 0.0 ? 0.75 : 0.25 );
-	retVal.y = (cubemapDir.y / (1.0 + abs( cubemapDir.z ))) * 0.5 + 0.5;
+	midf2 retVal;
+	retVal.x = (cubemapDir.x / (_h( 1.0 ) + abs( cubemapDir.z ))) * _h( 0.25 ) +
+			   (cubemapDir.z < _h( 0.0 ) ? _h( 0.75 ) : _h( 0.25 ) );
+	retVal.y = (cubemapDir.y / (_h( 1.0 ) + abs( cubemapDir.z ))) * _h( 0.5 ) + _h( 0.5 );
 	return retVal;
 }
 

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -247,6 +247,15 @@
 	#define texture3D sampler3D
 	#define textureCube samplerCube
 	#define textureCubeArray samplerCubeArray
+
+	#define OGRE_Load2DF16( tex, iuv, lod ) half4_c( texelFetch( tex, ivec2( iuv ), lod ) )
+	#define OGRE_SampleF16( tex, sampler, uv ) half4_c( texture( tex, uv ) )
+	#define OGRE_SampleLevelF16( tex, sampler, uv, lod ) half4_c( textureLod( tex, uv, lod ) )
+	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) half4_c( texture( tex, vec3( uv, arrayIdx ) ) )
+	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( tex, vec3( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( tex, vec4( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) half4_c( textureGrad( tex, uv, ddx, ddy ) )
+	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) half4_c( textureGrad( tex, vec3( uv, arrayIdx ), ddx, ddy ) )
 @else
 	#define OGRE_Load2DF16( tex, iuv, lod ) half4_c( texelFetch( tex, ivec2( iuv ), lod ) )
 

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -11,7 +11,7 @@
 
 @insertpiece( CustomGlslExtensions )
 
-@property( !hlms_high_quality && syntax == glslvk )
+@property( precision_mode == half16 && syntax == glslvk )
 	#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 @end
 
@@ -70,7 +70,7 @@
 #define toFloat3x3( x ) mat3( x )
 #define buildFloat3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
-@property( hlms_high_quality )
+@property( precision_mode == full32 )
 	#define _h(x) (x)
 
 	#define half float
@@ -81,6 +81,14 @@
 	#define half3x3 mat3
 	#define half4x4 mat4
 
+	#define half_c float
+	#define half2_c vec2
+	#define half3_c vec3
+	#define half4_c vec4
+	#define half2x2_c mat2
+	#define half3x3_c mat3
+	#define half4x4_c mat4
+
 	#define toHalf3x3( x ) mat3( x )
 	#define buildHalf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
@@ -89,7 +97,8 @@
 	#define f16sampler2DArray sampler2DArray
 
 	#define saturate(x) clamp( (x), 0.0, 1.0 )
-@else
+@end
+@property( precision_mode == half16 )
 	#define _h(x) float16_t(x)
 
 	// TODO: Do the same with ushort
@@ -101,11 +110,47 @@
 	#define half3x3 f16mat3x3
 	#define half4x4 f16mat4x4
 
+	#define half_c float16_t
+	#define half2_c f16vec2
+	#define half3_c f16vec3
+	#define half4_c f16vec4
+	#define half2x2_c f16mat2x2
+	#define half3x3_c f16mat3x3
+	#define half4x4_c f16mat4x4
+
 	#define toHalf3x3( x ) f16mat3x3( x )
 	#define buildHalf3x3( row0, row1, row2 ) f16mat3x3( row0, row1, row2 )
 
 	float saturate( float x ) { return clamp( x, 0.0, 1.0 ); }
 	half saturate( half x ) { return clamp( x, half( 0.0 ), half( 1.0 ) ); }
+@end
+@property( precision_mode == relaxed )
+	precision highp int; // Silence warning about default is highp
+	precision highp float; // Silence warning about default is highp
+
+	#define _h(x) (x)
+
+	#define half mediump float
+	#define half2 mediump vec2
+	#define half3 mediump vec3
+	#define half4 mediump vec4
+	#define half2x2 mediump mat2
+	#define half3x3 mediump mat3
+	#define half4x4 mediump mat4
+
+	// For casting to half
+	#define half_c float
+	#define half2_c vec2
+	#define half3_c vec3
+	#define half4_c vec4
+	#define half2x2_c mat2
+	#define half3x3_c mat3
+	#define half4x4_c mat4
+
+	#define toHalf3x3( x ) mat3( x )
+	#define buildHalf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
+
+	float saturate( mediump float x ) { return clamp( x, 0.0, 1.0 ); }
 @end
 
 #define mul( x, y ) ((x) * (y))
@@ -172,10 +217,10 @@
 	#define OGRE_SampleArrayCubeLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod )
 	#define OGRE_SampleArray2DGrad( tex, sampler, uv, arrayIdx, ddx, ddy ) textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy )
 
-	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) half4( texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) ) )
-	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) half4( textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod ) )
-	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) half4( textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod ) )
-	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) half4( textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy ) )
+	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) half4_c( texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) ) )
+	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) half4_c( textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy ) )
 
 	float4 OGRE_Sample( texture2D t, sampler s, float2 uv ) { return texture( sampler2D( t, s ), uv ); }
 	float4 OGRE_Sample( texture3D t, sampler s, float3 uv ) { return texture( sampler3D( t, s ), uv ); }
@@ -189,17 +234,17 @@
 	float4 OGRE_SampleGrad( texture3D t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return textureGrad( sampler3D( t, s ), uv, myDdx, myDdy ); }
 	float4 OGRE_SampleGrad( textureCube t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return textureGrad( samplerCube( t, s ), uv, myDdx, myDdy ); }
 
-	half4 OGRE_SampleF16( texture2D t, sampler s, float2 uv ) { return half4( texture( sampler2D( t, s ), uv ) ); }
-	half4 OGRE_SampleF16( texture3D t, sampler s, float3 uv ) { return half4( texture( sampler3D( t, s ), uv ) ); }
-	half4 OGRE_SampleF16( textureCube t, sampler s, float3 uv ) { return half4( texture( samplerCube( t, s ), uv ) ); }
+	half4 OGRE_SampleF16( texture2D t, sampler s, float2 uv ) { return half4_c( texture( sampler2D( t, s ), uv ) ); }
+	half4 OGRE_SampleF16( texture3D t, sampler s, float3 uv ) { return half4_c( texture( sampler3D( t, s ), uv ) ); }
+	half4 OGRE_SampleF16( textureCube t, sampler s, float3 uv ) { return half4_c( texture( samplerCube( t, s ), uv ) ); }
 
-	half4 OGRE_SampleLevelF16( texture2D t, sampler s, float2 uv, float lod ) { return half4( textureLod( sampler2D( t, s ), uv, lod ) ); }
-	half4 OGRE_SampleLevelF16( texture3D t, sampler s, float3 uv, float lod ) { return half4( textureLod( sampler3D( t, s ), uv, lod ) ); }
-	half4 OGRE_SampleLevelF16( textureCube t, sampler s, float3 uv, float lod ) { return half4( textureLod( samplerCube( t, s ), uv, lod ) ); }
+	half4 OGRE_SampleLevelF16( texture2D t, sampler s, float2 uv, float lod ) { return half4_c( textureLod( sampler2D( t, s ), uv, lod ) ); }
+	half4 OGRE_SampleLevelF16( texture3D t, sampler s, float3 uv, float lod ) { return half4_c( textureLod( sampler3D( t, s ), uv, lod ) ); }
+	half4 OGRE_SampleLevelF16( textureCube t, sampler s, float3 uv, float lod ) { return half4_c( textureLod( samplerCube( t, s ), uv, lod ) ); }
 
-	half4 OGRE_SampleGradF16( texture2D t, sampler s, float2 uv, float2 myDdx, float2 myDdy ) { return half4( textureGrad( sampler2D( t, s ), uv, myDdx, myDdy ) ); }
-	half4 OGRE_SampleGradF16( texture3D t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return half4( textureGrad( sampler3D( t, s ), uv, myDdx, myDdy ) ); }
-	half4 OGRE_SampleGradF16( textureCube t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return half4( textureGrad( samplerCube( t, s ), uv, myDdx, myDdy ) ); }
+	half4 OGRE_SampleGradF16( texture2D t, sampler s, float2 uv, float2 myDdx, float2 myDdy ) { return half4_c( textureGrad( sampler2D( t, s ), uv, myDdx, myDdy ) ); }
+	half4 OGRE_SampleGradF16( texture3D t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return half4_c( textureGrad( sampler3D( t, s ), uv, myDdx, myDdy ) ); }
+	half4 OGRE_SampleGradF16( textureCube t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return half4_c( textureGrad( samplerCube( t, s ), uv, myDdx, myDdy ) ); }
 @end
 #define OGRE_ddx( val ) dFdx( val )
 #define OGRE_ddy( val ) dFdy( val )

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -124,9 +124,7 @@
 	#define toMidf3x3( x ) mat3( x )
 	#define buildMidf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
-	#define f16texture2D texture2D
-	#define f16texture2DArray texture2DArray
-	#define f16sampler2DArray sampler2DArray
+	#define ensureValidRangeF16(x)
 
 	#define saturate(x) clamp( (x), 0.0, 1.0 )
 @end
@@ -152,6 +150,8 @@
 
 	#define toMidf3x3( x ) f16mat3x3( x )
 	#define buildMidf3x3( row0, row1, row2 ) f16mat3x3( row0, row1, row2 )
+
+	#define ensureValidRangeF16(x) x = min(x, _h( 65504.0 ))
 
 	float saturate( float x ) { return clamp( x, 0.0, 1.0 ); }
 	vec2 saturate( vec2 x ) { return clamp( x, vec2( 0.0 ), vec2( 1.0 ) ); }

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -255,6 +255,7 @@
 	#define textureCubeArray samplerCubeArray
 
 	#define OGRE_Load2DF16( tex, iuv, lod ) midf4_c( texelFetch( tex, ivec2( iuv ), lod ) )
+	#define OGRE_Load2DMSF16( tex, iuv, subsample ) midf4_c( texelFetch( tex, iuv, subsample ) )
 	#define OGRE_SampleF16( tex, sampler, uv ) midf4_c( texture( tex, uv ) )
 	#define OGRE_SampleLevelF16( tex, sampler, uv, lod ) midf4_c( textureLod( tex, uv, lod ) )
 	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) midf4_c( texture( tex, vec3( uv, arrayIdx ) ) )
@@ -263,13 +264,14 @@
 	#define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) midf4_c( textureGrad( tex, uv, ddx, ddy ) )
 	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) midf4_c( textureGrad( tex, vec3( uv, arrayIdx ), ddx, ddy ) )
 @else
-	#define OGRE_Load2DF16( tex, iuv, lod ) midf4_c( texelFetch( tex, ivec2( iuv ), lod ) )
 
 	#define OGRE_SampleArray2D( tex, sampler, uv, arrayIdx ) texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) )
 	#define OGRE_SampleArray2DLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod )
 	#define OGRE_SampleArrayCubeLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod )
 	#define OGRE_SampleArray2DGrad( tex, sampler, uv, arrayIdx, ddx, ddy ) textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy )
 
+	#define OGRE_Load2DF16( tex, iuv, lod ) midf4_c( texelFetch( tex, ivec2( iuv ), lod ) )
+	#define OGRE_Load2DMSF16( tex, iuv, subsample ) midf4_c( texelFetch( tex, iuv, subsample ) )
 	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) midf4_c( texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) ) )
 	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) midf4_c( textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod ) )
 	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) midf4_c( textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod ) )

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -12,6 +12,7 @@
 @insertpiece( CustomGlslExtensions )
 
 @property( precision_mode == half16 && syntax == glslvk )
+	#extension GL_EXT_shader_16bit_storage: require
 	#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 @end
 

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -70,6 +70,32 @@
 #define toFloat3x3( x ) mat3( x )
 #define buildFloat3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
+// Let's explain this madness:
+//
+// When precision_mode == full32 half is float. Nothing weird
+//
+// When precision_mode == half16, half and half_c map both to float16_t. It's similar to full32
+// but literals need to be prefixed with _h()
+// Thus we can have:
+//		float16_t a = 1.0f;						// Error
+//		float16_t b = _h( 1.0f );				// OK!
+//		float16_t c = float16_t( someFloat );	// OK!
+// But when precision_mode == relaxed; we have the following problem:
+//		mediump float a = 1.0f;							// Error
+//		mediump float b = _h( 1.0f );					// OK!
+//		mediump float c = mediump float( someFloat );	// Invalid syntax!
+//
+// That's where 'half_c' comes into play. The "_c" means cast or construct. Hence we do instead:
+//		half c = half( someFloat );		// Will turn into invalid syntax on relaxed!
+//		half c = half_c( someFloat );	// OK!
+//
+// Therefore datatypes are declared with half. And casts and constructors are with half_c:
+//		half b = _h( 1.0f );
+//		half b = half_c( someFloat );
+//		half c = half3_c( 1.0f, 2.0f, 3.0f );
+//
+// Using this convention ensures that code will compile in all 3 precision modes.
+// Breaking this convention means one or more of the modes (except full32) will not compile.
 @property( precision_mode == full32 )
 	#define _h(x) (x)
 

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -11,7 +11,7 @@
 
 @insertpiece( CustomGlslExtensions )
 
-@property( precision_mode == half16 && syntax == glslvk )
+@property( precision_mode == midf16 && syntax == glslvk )
 	#extension GL_EXT_shader_16bit_storage: require
 	#extension GL_EXT_shader_explicit_arithmetic_types_float16: require
 @end
@@ -73,51 +73,56 @@
 
 // Let's explain this madness:
 //
-// When precision_mode == full32 half is float. Nothing weird
+// We use the keyword "midf" because "midf" is already taken on Metal.
 //
-// When precision_mode == half16, half and half_c map both to float16_t. It's similar to full32
+// When precision_mode == full32 midf is float. Nothing weird
+//
+// When precision_mode == midf16, midf and midf_c map both to float16_t. It's similar to full32
 // but literals need to be prefixed with _h()
-// Thus we can have:
+//
+// Thus, what happens if we resolve some of the macros, we end up with:
 //		float16_t a = 1.0f;						// Error
 //		float16_t b = _h( 1.0f );				// OK!
 //		float16_t c = float16_t( someFloat );	// OK!
+//
 // But when precision_mode == relaxed; we have the following problem:
 //		mediump float a = 1.0f;							// Error
 //		mediump float b = _h( 1.0f );					// OK!
 //		mediump float c = mediump float( someFloat );	// Invalid syntax!
 //
-// That's where 'half_c' comes into play. The "_c" means cast or construct. Hence we do instead:
-//		half c = half( someFloat );		// Will turn into invalid syntax on relaxed!
-//		half c = half_c( someFloat );	// OK!
+// That's where 'midf_c' comes into play. The "_c" means cast or construct. Hence we do instead:
+//		midf c = midf( someFloat );		// Will turn into invalid syntax on relaxed!
+//		midf c = midf_c( someFloat );	// OK!
 //
-// Therefore datatypes are declared with half. And casts and constructors are with half_c:
-//		half b = _h( 1.0f );
-//		half b = half_c( someFloat );
-//		half c = half3_c( 1.0f, 2.0f, 3.0f );
+// Therefore datatypes are declared with midf. And casts and constructors are with midf_c
+// Proper usage is as follows:
+//		midf b = _h( 1.0f );
+//		midf b = midf_c( someFloat );
+//		midf c = midf3_c( 1.0f, 2.0f, 3.0f );
 //
-// Using this convention ensures that code will compile in all 3 precision modes.
+// Using this convention ensures that code will compile with all 3 precision modes.
 // Breaking this convention means one or more of the modes (except full32) will not compile.
 @property( precision_mode == full32 )
 	#define _h(x) (x)
 
-	#define half float
-	#define half2 vec2
-	#define half3 vec3
-	#define half4 vec4
-	#define half2x2 mat2
-	#define half3x3 mat3
-	#define half4x4 mat4
+	#define midf float
+	#define midf2 vec2
+	#define midf3 vec3
+	#define midf4 vec4
+	#define midf2x2 mat2
+	#define midf3x3 mat3
+	#define midf4x4 mat4
 
-	#define half_c float
-	#define half2_c vec2
-	#define half3_c vec3
-	#define half4_c vec4
-	#define half2x2_c mat2
-	#define half3x3_c mat3
-	#define half4x4_c mat4
+	#define midf_c float
+	#define midf2_c vec2
+	#define midf3_c vec3
+	#define midf4_c vec4
+	#define midf2x2_c mat2
+	#define midf3x3_c mat3
+	#define midf4x4_c mat4
 
-	#define toHalf3x3( x ) mat3( x )
-	#define buildHalf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
+	#define toMidf3x3( x ) mat3( x )
+	#define buildMidf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
 	#define f16texture2D texture2D
 	#define f16texture2DArray texture2DArray
@@ -125,38 +130,38 @@
 
 	#define saturate(x) clamp( (x), 0.0, 1.0 )
 @end
-@property( precision_mode == half16 )
+@property( precision_mode == midf16 )
 	#define _h(x) float16_t(x)
 
 	// TODO: Do the same with ushort
-	#define half float16_t
-	#define half2 f16vec2
-	#define half3 f16vec3
-	#define half4 f16vec4
-	#define half2x2 f16mat2x2
-	#define half3x3 f16mat3x3
-	#define half4x4 f16mat4x4
+	#define midf float16_t
+	#define midf2 f16vec2
+	#define midf3 f16vec3
+	#define midf4 f16vec4
+	#define midf2x2 f16mat2x2
+	#define midf3x3 f16mat3x3
+	#define midf4x4 f16mat4x4
 
-	#define half_c float16_t
-	#define half2_c f16vec2
-	#define half3_c f16vec3
-	#define half4_c f16vec4
-	#define half2x2_c f16mat2x2
-	#define half3x3_c f16mat3x3
-	#define half4x4_c f16mat4x4
+	#define midf_c float16_t
+	#define midf2_c f16vec2
+	#define midf3_c f16vec3
+	#define midf4_c f16vec4
+	#define midf2x2_c f16mat2x2
+	#define midf3x3_c f16mat3x3
+	#define midf4x4_c f16mat4x4
 
-	#define toHalf3x3( x ) f16mat3x3( x )
-	#define buildHalf3x3( row0, row1, row2 ) f16mat3x3( row0, row1, row2 )
+	#define toMidf3x3( x ) f16mat3x3( x )
+	#define buildMidf3x3( row0, row1, row2 ) f16mat3x3( row0, row1, row2 )
 
 	float saturate( float x ) { return clamp( x, 0.0, 1.0 ); }
 	vec2 saturate( vec2 x ) { return clamp( x, vec2( 0.0 ), vec2( 1.0 ) ); }
 	vec3 saturate( vec3 x ) { return clamp( x, vec3( 0.0 ), vec3( 1.0 ) ); }
 	vec4 saturate( vec4 x ) { return clamp( x, vec4( 0.0 ), vec4( 1.0 ) ); }
 
-	half saturate( half x ) { return clamp( x, half( 0.0 ), half( 1.0 ) ); }
-	half2 saturate( half2 x ) { return clamp( x, half2( 0.0 ), half2( 1.0 ) ); }
-	half3 saturate( half3 x ) { return clamp( x, half3( 0.0 ), half3( 1.0 ) ); }
-	half4 saturate( half4 x ) { return clamp( x, half4( 0.0 ), half4( 1.0 ) ); }
+	midf saturate( midf x ) { return clamp( x, midf( 0.0 ), midf( 1.0 ) ); }
+	midf2 saturate( midf2 x ) { return clamp( x, midf2( 0.0 ), midf2( 1.0 ) ); }
+	midf3 saturate( midf3 x ) { return clamp( x, midf3( 0.0 ), midf3( 1.0 ) ); }
+	midf4 saturate( midf4 x ) { return clamp( x, midf4( 0.0 ), midf4( 1.0 ) ); }
 @end
 @property( precision_mode == relaxed )
 	precision highp int; // Silence warning about default is highp
@@ -164,25 +169,25 @@
 
 	#define _h(x) (x)
 
-	#define half mediump float
-	#define half2 mediump vec2
-	#define half3 mediump vec3
-	#define half4 mediump vec4
-	#define half2x2 mediump mat2
-	#define half3x3 mediump mat3
-	#define half4x4 mediump mat4
+	#define midf mediump float
+	#define midf2 mediump vec2
+	#define midf3 mediump vec3
+	#define midf4 mediump vec4
+	#define midf2x2 mediump mat2
+	#define midf3x3 mediump mat3
+	#define midf4x4 mediump mat4
 
-	// For casting to half
-	#define half_c float
-	#define half2_c vec2
-	#define half3_c vec3
-	#define half4_c vec4
-	#define half2x2_c mat2
-	#define half3x3_c mat3
-	#define half4x4_c mat4
+	// For casting to midf
+	#define midf_c float
+	#define midf2_c vec2
+	#define midf3_c vec3
+	#define midf4_c vec4
+	#define midf2x2_c mat2
+	#define midf3x3_c mat3
+	#define midf4x4_c mat4
 
-	#define toHalf3x3( x ) mat3( x )
-	#define buildHalf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
+	#define toMidf3x3( x ) mat3( x )
+	#define buildMidf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
 	mediump float saturate( mediump float x ) { return clamp( x, 0.0, 1.0 ); }
 	mediump vec2 saturate( mediump vec2 x ) { return clamp( x, vec2( 0.0 ), vec2( 1.0 ) ); }
@@ -249,26 +254,26 @@
 	#define textureCube samplerCube
 	#define textureCubeArray samplerCubeArray
 
-	#define OGRE_Load2DF16( tex, iuv, lod ) half4_c( texelFetch( tex, ivec2( iuv ), lod ) )
-	#define OGRE_SampleF16( tex, sampler, uv ) half4_c( texture( tex, uv ) )
-	#define OGRE_SampleLevelF16( tex, sampler, uv, lod ) half4_c( textureLod( tex, uv, lod ) )
-	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) half4_c( texture( tex, vec3( uv, arrayIdx ) ) )
-	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( tex, vec3( uv, arrayIdx ), lod ) )
-	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( tex, vec4( uv, arrayIdx ), lod ) )
-	#define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) half4_c( textureGrad( tex, uv, ddx, ddy ) )
-	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) half4_c( textureGrad( tex, vec3( uv, arrayIdx ), ddx, ddy ) )
+	#define OGRE_Load2DF16( tex, iuv, lod ) midf4_c( texelFetch( tex, ivec2( iuv ), lod ) )
+	#define OGRE_SampleF16( tex, sampler, uv ) midf4_c( texture( tex, uv ) )
+	#define OGRE_SampleLevelF16( tex, sampler, uv, lod ) midf4_c( textureLod( tex, uv, lod ) )
+	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) midf4_c( texture( tex, vec3( uv, arrayIdx ) ) )
+	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) midf4_c( textureLod( tex, vec3( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) midf4_c( textureLod( tex, vec4( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) midf4_c( textureGrad( tex, uv, ddx, ddy ) )
+	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) midf4_c( textureGrad( tex, vec3( uv, arrayIdx ), ddx, ddy ) )
 @else
-	#define OGRE_Load2DF16( tex, iuv, lod ) half4_c( texelFetch( tex, ivec2( iuv ), lod ) )
+	#define OGRE_Load2DF16( tex, iuv, lod ) midf4_c( texelFetch( tex, ivec2( iuv ), lod ) )
 
 	#define OGRE_SampleArray2D( tex, sampler, uv, arrayIdx ) texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) )
 	#define OGRE_SampleArray2DLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod )
 	#define OGRE_SampleArrayCubeLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod )
 	#define OGRE_SampleArray2DGrad( tex, sampler, uv, arrayIdx, ddx, ddy ) textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy )
 
-	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) half4_c( texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) ) )
-	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod ) )
-	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) half4_c( textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod ) )
-	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) half4_c( textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy ) )
+	#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) midf4_c( texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) ) )
+	#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) midf4_c( textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) midf4_c( textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod ) )
+	#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) midf4_c( textureGrad( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), ddx, ddy ) )
 
 	float4 OGRE_Sample( texture2D t, sampler s, float2 uv ) { return texture( sampler2D( t, s ), uv ); }
 	float4 OGRE_Sample( texture3D t, sampler s, float3 uv ) { return texture( sampler3D( t, s ), uv ); }
@@ -282,17 +287,17 @@
 	float4 OGRE_SampleGrad( texture3D t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return textureGrad( sampler3D( t, s ), uv, myDdx, myDdy ); }
 	float4 OGRE_SampleGrad( textureCube t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return textureGrad( samplerCube( t, s ), uv, myDdx, myDdy ); }
 
-	half4 OGRE_SampleF16( texture2D t, sampler s, float2 uv ) { return half4_c( texture( sampler2D( t, s ), uv ) ); }
-	half4 OGRE_SampleF16( texture3D t, sampler s, float3 uv ) { return half4_c( texture( sampler3D( t, s ), uv ) ); }
-	half4 OGRE_SampleF16( textureCube t, sampler s, float3 uv ) { return half4_c( texture( samplerCube( t, s ), uv ) ); }
+	midf4 OGRE_SampleF16( texture2D t, sampler s, float2 uv ) { return midf4_c( texture( sampler2D( t, s ), uv ) ); }
+	midf4 OGRE_SampleF16( texture3D t, sampler s, float3 uv ) { return midf4_c( texture( sampler3D( t, s ), uv ) ); }
+	midf4 OGRE_SampleF16( textureCube t, sampler s, float3 uv ) { return midf4_c( texture( samplerCube( t, s ), uv ) ); }
 
-	half4 OGRE_SampleLevelF16( texture2D t, sampler s, float2 uv, float lod ) { return half4_c( textureLod( sampler2D( t, s ), uv, lod ) ); }
-	half4 OGRE_SampleLevelF16( texture3D t, sampler s, float3 uv, float lod ) { return half4_c( textureLod( sampler3D( t, s ), uv, lod ) ); }
-	half4 OGRE_SampleLevelF16( textureCube t, sampler s, float3 uv, float lod ) { return half4_c( textureLod( samplerCube( t, s ), uv, lod ) ); }
+	midf4 OGRE_SampleLevelF16( texture2D t, sampler s, float2 uv, float lod ) { return midf4_c( textureLod( sampler2D( t, s ), uv, lod ) ); }
+	midf4 OGRE_SampleLevelF16( texture3D t, sampler s, float3 uv, float lod ) { return midf4_c( textureLod( sampler3D( t, s ), uv, lod ) ); }
+	midf4 OGRE_SampleLevelF16( textureCube t, sampler s, float3 uv, float lod ) { return midf4_c( textureLod( samplerCube( t, s ), uv, lod ) ); }
 
-	half4 OGRE_SampleGradF16( texture2D t, sampler s, float2 uv, float2 myDdx, float2 myDdy ) { return half4_c( textureGrad( sampler2D( t, s ), uv, myDdx, myDdy ) ); }
-	half4 OGRE_SampleGradF16( texture3D t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return half4_c( textureGrad( sampler3D( t, s ), uv, myDdx, myDdy ) ); }
-	half4 OGRE_SampleGradF16( textureCube t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return half4_c( textureGrad( samplerCube( t, s ), uv, myDdx, myDdy ) ); }
+	midf4 OGRE_SampleGradF16( texture2D t, sampler s, float2 uv, float2 myDdx, float2 myDdy ) { return midf4_c( textureGrad( sampler2D( t, s ), uv, myDdx, myDdy ) ); }
+	midf4 OGRE_SampleGradF16( texture3D t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return midf4_c( textureGrad( sampler3D( t, s ), uv, myDdx, myDdy ) ); }
+	midf4 OGRE_SampleGradF16( textureCube t, sampler s, float3 uv, float3 myDdx, float3 myDdy ) { return midf4_c( textureGrad( samplerCube( t, s ), uv, myDdx, myDdy ) ); }
 @end
 #define OGRE_ddx( val ) dFdx( val )
 #define OGRE_ddy( val ) dFdy( val )

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -73,7 +73,7 @@
 
 // Let's explain this madness:
 //
-// We use the keyword "midf" because "midf" is already taken on Metal.
+// We use the keyword "midf" because "half" is already taken on Metal.
 //
 // When precision_mode == full32 midf is float. Nothing weird
 //

--- a/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
@@ -122,7 +122,14 @@
 	#define buildHalf3x3( row0, row1, row2 ) f16mat3x3( row0, row1, row2 )
 
 	float saturate( float x ) { return clamp( x, 0.0, 1.0 ); }
+	vec2 saturate( vec2 x ) { return clamp( x, vec2( 0.0 ), vec2( 1.0 ) ); }
+	vec3 saturate( vec3 x ) { return clamp( x, vec3( 0.0 ), vec3( 1.0 ) ); }
+	vec4 saturate( vec4 x ) { return clamp( x, vec4( 0.0 ), vec4( 1.0 ) ); }
+
 	half saturate( half x ) { return clamp( x, half( 0.0 ), half( 1.0 ) ); }
+	half2 saturate( half2 x ) { return clamp( x, half2( 0.0 ), half2( 1.0 ) ); }
+	half3 saturate( half3 x ) { return clamp( x, half3( 0.0 ), half3( 1.0 ) ); }
+	half4 saturate( half4 x ) { return clamp( x, half4( 0.0 ), half4( 1.0 ) ); }
 @end
 @property( precision_mode == relaxed )
 	precision highp int; // Silence warning about default is highp
@@ -150,7 +157,10 @@
 	#define toHalf3x3( x ) mat3( x )
 	#define buildHalf3x3( row0, row1, row2 ) mat3( row0, row1, row2 )
 
-	float saturate( mediump float x ) { return clamp( x, 0.0, 1.0 ); }
+	mediump float saturate( mediump float x ) { return clamp( x, 0.0, 1.0 ); }
+	mediump vec2 saturate( mediump vec2 x ) { return clamp( x, vec2( 0.0 ), vec2( 1.0 ) ); }
+	mediump vec3 saturate( mediump vec3 x ) { return clamp( x, vec3( 0.0 ), vec3( 1.0 ) ); }
+	mediump vec4 saturate( mediump vec4 x ) { return clamp( x, vec4( 0.0 ), vec4( 1.0 ) ); }
 @end
 
 #define mul( x, y ) ((x) * (y))
@@ -212,6 +222,8 @@
 	#define textureCube samplerCube
 	#define textureCubeArray samplerCubeArray
 @else
+	#define OGRE_Load2DF16( tex, iuv, lod ) half4_c( texelFetch( tex, ivec2( iuv ), lod ) )
+
 	#define OGRE_SampleArray2D( tex, sampler, uv, arrayIdx ) texture( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ) )
 	#define OGRE_SampleArray2DLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( sampler2DArray( tex, sampler ), vec3( uv, arrayIdx ), lod )
 	#define OGRE_SampleArrayCubeLevel( tex, sampler, uv, arrayIdx, lod ) textureLod( samplerCubeArray( tex, sampler ), vec4( uv, arrayIdx ), lod )

--- a/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
@@ -1,101 +1,104 @@
 @piece( DeclQuat_xAxis )
-vec3 xAxis( vec4 qQuat )
-{
-	float fTy  = 2.0 * qQuat.y;
-	float fTz  = 2.0 * qQuat.z;
-	float fTwy = fTy * qQuat.w;
-	float fTwz = fTz * qQuat.w;
-	float fTxy = fTy * qQuat.x;
-	float fTxz = fTz * qQuat.x;
-	float fTyy = fTy * qQuat.y;
-	float fTzz = fTz * qQuat.z;
+	@property( precision_mode != relaxed )
+		vec3 xAxis( vec4 qQuat )
+		{
+			float fTy  = 2.0 * qQuat.y;
+			float fTz  = 2.0 * qQuat.z;
+			float fTwy = fTy * qQuat.w;
+			float fTwz = fTz * qQuat.w;
+			float fTxy = fTy * qQuat.x;
+			float fTxz = fTz * qQuat.x;
+			float fTyy = fTy * qQuat.y;
+			float fTzz = fTz * qQuat.z;
 
-	return vec3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
-}
+			return vec3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
+		}
+	@end
+	@property( precision_mode != full32 )
+		half3 xAxis( half4 qQuat )
+		{
+			half fTy  = _h( 2.0 ) * qQuat.y;
+			half fTz  = _h( 2.0 ) * qQuat.z;
+			half fTwy = fTy * qQuat.w;
+			half fTwz = fTz * qQuat.w;
+			half fTxy = fTy * qQuat.x;
+			half fTxz = fTz * qQuat.x;
+			half fTyy = fTy * qQuat.y;
+			half fTzz = fTz * qQuat.z;
 
-@property( !hlms_high_quality )
-	half3 xAxis( half4 qQuat )
-	{
-		half fTy  = half( 2.0 ) * qQuat.y;
-		half fTz  = half( 2.0 ) * qQuat.z;
-		half fTwy = fTy * qQuat.w;
-		half fTwz = fTz * qQuat.w;
-		half fTxy = fTy * qQuat.x;
-		half fTxz = fTz * qQuat.x;
-		half fTyy = fTy * qQuat.y;
-		half fTzz = fTz * qQuat.z;
-
-		return half3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
-	}
-@end
+			return half3_c( _h( 1.0 )-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
+		}
+	@end
 @end
 
 @piece( DeclQuat_yAxis )
-vec3 yAxis( vec4 qQuat )
-{
-	float fTx  = 2.0 * qQuat.x;
-	float fTy  = 2.0 * qQuat.y;
-	float fTz  = 2.0 * qQuat.z;
-	float fTwx = fTx * qQuat.w;
-	float fTwz = fTz * qQuat.w;
-	float fTxx = fTx * qQuat.x;
-	float fTxy = fTy * qQuat.x;
-	float fTyz = fTz * qQuat.y;
-	float fTzz = fTz * qQuat.z;
+	@property( precision_mode != relaxed )
+		vec3 yAxis( vec4 qQuat )
+		{
+			float fTx  = 2.0 * qQuat.x;
+			float fTy  = 2.0 * qQuat.y;
+			float fTz  = 2.0 * qQuat.z;
+			float fTwx = fTx * qQuat.w;
+			float fTwz = fTz * qQuat.w;
+			float fTxx = fTx * qQuat.x;
+			float fTxy = fTy * qQuat.x;
+			float fTyz = fTz * qQuat.y;
+			float fTzz = fTz * qQuat.z;
 
-	return vec3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
-}
+			return half3_c( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
+		}
+	@end
+	@property( precision_mode != full32 )
+		half3 yAxis( half4 qQuat )
+		{
+			half fTx  = _h( 2.0 ) * qQuat.x;
+			half fTy  = _h( 2.0 ) * qQuat.y;
+			half fTz  = _h( 2.0 ) * qQuat.z;
+			half fTwx = fTx * qQuat.w;
+			half fTwz = fTz * qQuat.w;
+			half fTxx = fTx * qQuat.x;
+			half fTxy = fTy * qQuat.x;
+			half fTyz = fTz * qQuat.y;
+			half fTzz = fTz * qQuat.z;
 
-@property( !hlms_high_quality )
-	half3 yAxis( half4 qQuat )
-	{
-		half fTx  = half( 2.0 ) * qQuat.x;
-		half fTy  = half( 2.0 ) * qQuat.y;
-		half fTz  = half( 2.0 ) * qQuat.z;
-		half fTwx = fTx * qQuat.w;
-		half fTwz = fTz * qQuat.w;
-		half fTxx = fTx * qQuat.x;
-		half fTxy = fTy * qQuat.x;
-		half fTyz = fTz * qQuat.y;
-		half fTzz = fTz * qQuat.z;
-
-		return half3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
-	}
-@end
+			return half3_c( fTxy-fTwz, _h( 1.0 )-(fTxx+fTzz), fTyz+fTwx );
+		}
+	@end
 @end
 
 @piece( DeclQuat_zAxis )
-vec3 zAxis( vec4 qQuat )
-{
-	float fTx  = 2.0 * qQuat.x;
-	float fTy  = 2.0 * qQuat.y;
-	float fTz  = 2.0 * qQuat.z;
-	float fTwx = fTx * qQuat.w;
-	float fTwy = fTy * qQuat.w;
-	float fTxx = fTx * qQuat.x;
-	float fTxz = fTz * qQuat.x;
-	float fTyy = fTy * qQuat.y;
-	float fTyz = fTz * qQuat.y;
+	@property( precision_mode != relaxed )
+		vec3 zAxis( vec4 qQuat )
+		{
+			float fTx  = 2.0 * qQuat.x;
+			float fTy  = 2.0 * qQuat.y;
+			float fTz  = 2.0 * qQuat.z;
+			float fTwx = fTx * qQuat.w;
+			float fTwy = fTy * qQuat.w;
+			float fTxx = fTx * qQuat.x;
+			float fTxz = fTz * qQuat.x;
+			float fTyy = fTy * qQuat.y;
+			float fTyz = fTz * qQuat.y;
 
-	return vec3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
-}
+			return vec3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
+		}
+	@end
+	@property( precision_mode != full32 )
+		half3 zAxis( half4 qQuat )
+		{
+			half fTx  = _h( 2.0 ) * qQuat.x;
+			half fTy  = _h( 2.0 ) * qQuat.y;
+			half fTz  = _h( 2.0 ) * qQuat.z;
+			half fTwx = fTx * qQuat.w;
+			half fTwy = fTy * qQuat.w;
+			half fTxx = fTx * qQuat.x;
+			half fTxz = fTz * qQuat.x;
+			half fTyy = fTy * qQuat.y;
+			half fTyz = fTz * qQuat.y;
 
-@property( !hlms_high_quality )
-	half3 zAxis( half4 qQuat )
-	{
-		half fTx  = half( 2.0 ) * qQuat.x;
-		half fTy  = half( 2.0 ) * qQuat.y;
-		half fTz  = half( 2.0 ) * qQuat.z;
-		half fTwx = fTx * qQuat.w;
-		half fTwy = fTy * qQuat.w;
-		half fTxx = fTx * qQuat.x;
-		half fTxz = fTz * qQuat.x;
-		half fTyy = fTy * qQuat.y;
-		half fTyz = fTz * qQuat.y;
-
-		return half3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
-	}
-@end
+			return half3_c( fTxz+fTwy, fTyz-fTwx, _h( 1.0 )-(fTxx+fTyy) );
+		}
+	@end
 @end
 
 @piece( DeclQuat_AllAxis )

--- a/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
@@ -12,6 +12,22 @@ vec3 xAxis( vec4 qQuat )
 
 	return vec3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
 }
+
+@property( !hlms_high_quality )
+	half3 xAxis( half4 qQuat )
+	{
+		half fTy  = half( 2.0 ) * qQuat.y;
+		half fTz  = half( 2.0 ) * qQuat.z;
+		half fTwy = fTy * qQuat.w;
+		half fTwz = fTz * qQuat.w;
+		half fTxy = fTy * qQuat.x;
+		half fTxz = fTz * qQuat.x;
+		half fTyy = fTy * qQuat.y;
+		half fTzz = fTz * qQuat.z;
+
+		return half3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
+	}
+@end
 @end
 
 @piece( DeclQuat_yAxis )
@@ -29,6 +45,23 @@ vec3 yAxis( vec4 qQuat )
 
 	return vec3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
 }
+
+@property( !hlms_high_quality )
+	half3 yAxis( half4 qQuat )
+	{
+		half fTx  = half( 2.0 ) * qQuat.x;
+		half fTy  = half( 2.0 ) * qQuat.y;
+		half fTz  = half( 2.0 ) * qQuat.z;
+		half fTwx = fTx * qQuat.w;
+		half fTwz = fTz * qQuat.w;
+		half fTxx = fTx * qQuat.x;
+		half fTxy = fTy * qQuat.x;
+		half fTyz = fTz * qQuat.y;
+		half fTzz = fTz * qQuat.z;
+
+		return half3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
+	}
+@end
 @end
 
 @piece( DeclQuat_zAxis )
@@ -46,6 +79,23 @@ vec3 zAxis( vec4 qQuat )
 
 	return vec3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
 }
+
+@property( !hlms_high_quality )
+	half3 zAxis( half4 qQuat )
+	{
+		half fTx  = half( 2.0 ) * qQuat.x;
+		half fTy  = half( 2.0 ) * qQuat.y;
+		half fTz  = half( 2.0 ) * qQuat.z;
+		half fTwx = fTx * qQuat.w;
+		half fTwy = fTy * qQuat.w;
+		half fTxx = fTx * qQuat.x;
+		half fTxz = fTz * qQuat.x;
+		half fTyy = fTy * qQuat.y;
+		half fTyz = fTz * qQuat.y;
+
+		return half3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
+	}
+@end
 @end
 
 @piece( DeclQuat_AllAxis )

--- a/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
@@ -45,7 +45,7 @@
 			float fTyz = fTz * qQuat.y;
 			float fTzz = fTz * qQuat.z;
 
-			return midf3_c( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
+			return vec3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
 		}
 	@end
 	@property( precision_mode != full32 )

--- a/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
+++ b/Samples/Media/Hlms/Common/GLSL/QuaternionCode_piece_all.glsl
@@ -15,18 +15,18 @@
 		}
 	@end
 	@property( precision_mode != full32 )
-		half3 xAxis( half4 qQuat )
+		midf3 xAxis( midf4 qQuat )
 		{
-			half fTy  = _h( 2.0 ) * qQuat.y;
-			half fTz  = _h( 2.0 ) * qQuat.z;
-			half fTwy = fTy * qQuat.w;
-			half fTwz = fTz * qQuat.w;
-			half fTxy = fTy * qQuat.x;
-			half fTxz = fTz * qQuat.x;
-			half fTyy = fTy * qQuat.y;
-			half fTzz = fTz * qQuat.z;
+			midf fTy  = _h( 2.0 ) * qQuat.y;
+			midf fTz  = _h( 2.0 ) * qQuat.z;
+			midf fTwy = fTy * qQuat.w;
+			midf fTwz = fTz * qQuat.w;
+			midf fTxy = fTy * qQuat.x;
+			midf fTxz = fTz * qQuat.x;
+			midf fTyy = fTy * qQuat.y;
+			midf fTzz = fTz * qQuat.z;
 
-			return half3_c( _h( 1.0 )-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
+			return midf3_c( _h( 1.0 )-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
 		}
 	@end
 @end
@@ -45,23 +45,23 @@
 			float fTyz = fTz * qQuat.y;
 			float fTzz = fTz * qQuat.z;
 
-			return half3_c( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
+			return midf3_c( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
 		}
 	@end
 	@property( precision_mode != full32 )
-		half3 yAxis( half4 qQuat )
+		midf3 yAxis( midf4 qQuat )
 		{
-			half fTx  = _h( 2.0 ) * qQuat.x;
-			half fTy  = _h( 2.0 ) * qQuat.y;
-			half fTz  = _h( 2.0 ) * qQuat.z;
-			half fTwx = fTx * qQuat.w;
-			half fTwz = fTz * qQuat.w;
-			half fTxx = fTx * qQuat.x;
-			half fTxy = fTy * qQuat.x;
-			half fTyz = fTz * qQuat.y;
-			half fTzz = fTz * qQuat.z;
+			midf fTx  = _h( 2.0 ) * qQuat.x;
+			midf fTy  = _h( 2.0 ) * qQuat.y;
+			midf fTz  = _h( 2.0 ) * qQuat.z;
+			midf fTwx = fTx * qQuat.w;
+			midf fTwz = fTz * qQuat.w;
+			midf fTxx = fTx * qQuat.x;
+			midf fTxy = fTy * qQuat.x;
+			midf fTyz = fTz * qQuat.y;
+			midf fTzz = fTz * qQuat.z;
 
-			return half3_c( fTxy-fTwz, _h( 1.0 )-(fTxx+fTzz), fTyz+fTwx );
+			return midf3_c( fTxy-fTwz, _h( 1.0 )-(fTxx+fTzz), fTyz+fTwx );
 		}
 	@end
 @end
@@ -84,19 +84,19 @@
 		}
 	@end
 	@property( precision_mode != full32 )
-		half3 zAxis( half4 qQuat )
+		midf3 zAxis( midf4 qQuat )
 		{
-			half fTx  = _h( 2.0 ) * qQuat.x;
-			half fTy  = _h( 2.0 ) * qQuat.y;
-			half fTz  = _h( 2.0 ) * qQuat.z;
-			half fTwx = fTx * qQuat.w;
-			half fTwy = fTy * qQuat.w;
-			half fTxx = fTx * qQuat.x;
-			half fTxz = fTz * qQuat.x;
-			half fTyy = fTy * qQuat.y;
-			half fTyz = fTz * qQuat.y;
+			midf fTx  = _h( 2.0 ) * qQuat.x;
+			midf fTy  = _h( 2.0 ) * qQuat.y;
+			midf fTz  = _h( 2.0 ) * qQuat.z;
+			midf fTwx = fTx * qQuat.w;
+			midf fTwy = fTy * qQuat.w;
+			midf fTxx = fTx * qQuat.x;
+			midf fTxz = fTz * qQuat.x;
+			midf fTyy = fTy * qQuat.y;
+			midf fTyz = fTz * qQuat.y;
 
-			return half3_c( fTxz+fTwy, fTyz-fTwx, _h( 1.0 )-(fTxx+fTyy) );
+			return midf3_c( fTxz+fTwy, fTyz-fTwx, _h( 1.0 )-(fTxx+fTyy) );
 		}
 	@end
 @end

--- a/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
+++ b/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
@@ -37,6 +37,8 @@
 
 	#define toMidf3x3( x ) ((float3x3)( x ))
 	#define buildMidf3x3( row0, row1, row2 ) transpose( float3x3( row0, row1, row2 ) )
+
+	#define ensureValidRangeF16(x)
 @end
 @property( precision_mode == relaxed )
 	#define _h(x) min16float((x))
@@ -60,6 +62,8 @@
 
 	#define toMidf3x3( x ) ((min16float3x3)( x ))
 	#define buildMidf3x3( row0, row1, row2 ) transpose( min16float3x3( row0, row1, row2 ) )
+
+	#define ensureValidRangeF16(x) x = min(x, min16float(65504.0))
 @end
 
 #define min3( a, b, c ) min( a, min( b, c ) )

--- a/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
+++ b/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
@@ -126,6 +126,7 @@
 #define OGRE_Load3D( tex, iuv, lod ) tex.Load( int4( iuv, lod ) )
 
 #define OGRE_Load2DF16( tex, iuv, lod ) tex.Load( int3( iuv, lod ) )
+#define OGRE_Load2DMSF16( tex, iuv, subsample ) tex.Load( iuv, subsample )
 #define OGRE_SampleF16( tex, sampler, uv ) tex.Sample( sampler, uv )
 #define OGRE_SampleLevelF16( tex, sampler, uv, lod ) tex.SampleLevel( sampler, uv, lod )
 #define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) tex.Sample( sampler, float3( uv, arrayIdx ) )

--- a/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
+++ b/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
@@ -19,47 +19,47 @@
 @property( precision_mode == full32 )
 	#define _h(x) (x)
 
-	#define half float
-	#define half2 float2
-	#define half3 float3
-	#define half4 float4
-	#define half2x2 float2x2
-	#define half3x3 float3x3
-	#define half4x4 float4x4
+	#define midf float
+	#define midf2 float2
+	#define midf3 float3
+	#define midf4 float4
+	#define midf2x2 float2x2
+	#define midf3x3 float3x3
+	#define midf4x4 float4x4
 
-	#define half_c float
-	#define half2_c float2
-	#define half3_c float3
-	#define half4_c float4
-	#define half2x2_c float2x2
-	#define half3x3_c float3x3
-	#define half4x4_c float4x4
+	#define midf_c float
+	#define midf2_c float2
+	#define midf3_c float3
+	#define midf4_c float4
+	#define midf2x2_c float2x2
+	#define midf3x3_c float3x3
+	#define midf4x4_c float4x4
 
-	#define toHalf3x3( x ) ((float3x3)( x ))
-	#define buildHalf3x3( row0, row1, row2 ) transpose( float3x3( row0, row1, row2 ) )
+	#define toMidf3x3( x ) ((float3x3)( x ))
+	#define buildMidf3x3( row0, row1, row2 ) transpose( float3x3( row0, row1, row2 ) )
 @end
 @property( precision_mode == relaxed )
 	#define _h(x) min16float((x))
 
-	#define half min16float
-	#define half2 min16float2
-	#define half3 min16float3
-	#define half4 min16float4
-	#define half2x2 min16float2x2
-	#define half3x3 min16float3x3
-	#define half4x4 min16float4x4
+	#define midf min16float
+	#define midf2 min16float2
+	#define midf3 min16float3
+	#define midf4 min16float4
+	#define midf2x2 min16float2x2
+	#define midf3x3 min16float3x3
+	#define midf4x4 min16float4x4
 
-	// For casting to half
-	#define half_c min16float
-	#define half2_c min16float2
-	#define half3_c min16float3
-	#define half4_c min16float4
-	#define half2x2_c min16float2x2
-	#define half3x3_c min16float3x3
-	#define half4x4_c min16float4x4
+	// For casting to midf
+	#define midf_c min16float
+	#define midf2_c min16float2
+	#define midf3_c min16float3
+	#define midf4_c min16float4
+	#define midf2x2_c min16float2x2
+	#define midf3x3_c min16float3x3
+	#define midf4x4_c min16float4x4
 
-	#define toHalf3x3( x ) ((min16float3x3)( x ))
-	#define buildHalf3x3( row0, row1, row2 ) transpose( min16float3x3( row0, row1, row2 ) )
+	#define toMidf3x3( x ) ((min16float3x3)( x ))
+	#define buildMidf3x3( row0, row1, row2 ) transpose( min16float3x3( row0, row1, row2 ) )
 @end
 
 #define min3( a, b, c ) min( a, min( b, c ) )

--- a/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
+++ b/Samples/Media/Hlms/Common/HLSL/CrossPlatformSettings_piece_all.hlsl
@@ -15,6 +15,53 @@
 #define toFloat3x3( x ) ((float3x3)(x))
 #define buildFloat3x3( row0, row1, row2 ) transpose( float3x3( row0, row1, row2 ) )
 
+// See CrossPlatformSettings_piece_all.glsl for an explanation
+@property( precision_mode == full32 )
+	#define _h(x) (x)
+
+	#define half float
+	#define half2 float2
+	#define half3 float3
+	#define half4 float4
+	#define half2x2 float2x2
+	#define half3x3 float3x3
+	#define half4x4 float4x4
+
+	#define half_c float
+	#define half2_c float2
+	#define half3_c float3
+	#define half4_c float4
+	#define half2x2_c float2x2
+	#define half3x3_c float3x3
+	#define half4x4_c float4x4
+
+	#define toHalf3x3( x ) ((float3x3)( x ))
+	#define buildHalf3x3( row0, row1, row2 ) transpose( float3x3( row0, row1, row2 ) )
+@end
+@property( precision_mode == relaxed )
+	#define _h(x) min16float((x))
+
+	#define half min16float
+	#define half2 min16float2
+	#define half3 min16float3
+	#define half4 min16float4
+	#define half2x2 min16float2x2
+	#define half3x3 min16float3x3
+	#define half4x4 min16float4x4
+
+	// For casting to half
+	#define half_c min16float
+	#define half2_c min16float2
+	#define half3_c min16float3
+	#define half4_c min16float4
+	#define half2x2_c min16float2x2
+	#define half3x3_c min16float3x3
+	#define half4x4_c min16float4x4
+
+	#define toHalf3x3( x ) ((min16float3x3)( x ))
+	#define buildHalf3x3( row0, row1, row2 ) transpose( min16float3x3( row0, row1, row2 ) )
+@end
+
 #define min3( a, b, c ) min( a, min( b, c ) )
 #define max3( a, b, c ) max( a, max( b, c ) )
 
@@ -77,6 +124,15 @@
 #define OGRE_Load2DMS( tex, iuv, subsample ) tex.Load( iuv, subsample )
 
 #define OGRE_Load3D( tex, iuv, lod ) tex.Load( int4( iuv, lod ) )
+
+#define OGRE_Load2DF16( tex, iuv, lod ) tex.Load( int3( iuv, lod ) )
+#define OGRE_SampleF16( tex, sampler, uv ) tex.Sample( sampler, uv )
+#define OGRE_SampleLevelF16( tex, sampler, uv, lod ) tex.SampleLevel( sampler, uv, lod )
+#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) tex.Sample( sampler, float3( uv, arrayIdx ) )
+#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) tex.SampleLevel( sampler, float3( uv, arrayIdx ), lod )
+#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) tex.SampleLevel( sampler, float4( uv, arrayIdx ), lod )
+#define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) tex.SampleGrad( sampler, uv, ddx, ddy )
+#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) tex.SampleGrad( sampler, float3( uv, arrayIdx ), ddx, ddy )
 
 #define bufferFetch( buffer, idx ) buffer.Load( idx )
 #define bufferFetch1( buffer, idx ) buffer.Load( idx ).x

--- a/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
+++ b/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
@@ -11,11 +11,28 @@ struct float1
 
 inline float3x3 toMat3x3( float4x4 m )
 {
-    return float3x3( m[0].xyz, m[1].xyz, m[2].xyz );
+	return float3x3( m[0].xyz, m[1].xyz, m[2].xyz );
 }
 inline float3x3 toMat3x3( float3x4 m )
 {
 	return float3x3( m[0].xyz, m[1].xyz, m[2].xyz );
+}
+
+inline half3x3 toMatHalf3x3( half4x4 m )
+{
+	return half3x3( m[0].xyz, m[1].xyz, m[2].xyz );
+}
+inline half3x3 toMatHalf3x3( half3x4 m )
+{
+	return half3x3( m[0].xyz, m[1].xyz, m[2].xyz );
+}
+inline half3x3 toMatHalf3x3( float4x4 m )
+{
+	return half3x3( half3( m[0].xyz ), half3(  m[1].xyz ), half3(  m[2].xyz ) );
+}
+inline half3x3 toMatHalf3x3( float3x4 m )
+{
+	return half3x3( half3( m[0].xyz ), half3(  m[1].xyz ), half3(  m[2].xyz ) );
 }
 
 #define ogre_float4x3 float3x4
@@ -59,7 +76,7 @@ inline float3x3 toMat3x3( float3x4 m )
 @property( precision_mode == midf16 )
 	// In Metal 'half' is an actual datatype. It should be OK to override it
 	// as long as we do it before including metal_stdlib
-	#define _h(x) (x)
+	#define _h(x) half(x)
 
 	#define midf half
 	#define midf2 half2
@@ -77,8 +94,8 @@ inline float3x3 toMat3x3( float3x4 m )
 	#define midf3x3_c half3x3
 	#define midf4x4_c half4x4
 
-	#define toMidf3x3( x ) toMat3x3( x )
-	#define buildMidf3x3( row0, row1, row2 ) half3x3( row0, row1, row2 )
+	#define toMidf3x3( x ) toMatHalf3x3( x )
+	#define buildMidf3x3( row0, row1, row2 ) half3x3( half3( row0 ), half3( row1 ), half3( row2 ) )
 @end
 
 #define min3( a, b, c ) min( a, min( b, c ) )
@@ -152,6 +169,7 @@ inline float3x3 toMat3x3( float3x4 m )
 #define OGRE_Load3D( tex, iuv, lod ) tex.read( ushort3( iuv ), lod )
 
 #define OGRE_Load2DF16( tex, iuv, lod ) tex.read( iuv, lod )
+#define OGRE_Load2DMSF16( tex, iuv, subsample ) tex.read( iuv, subsample )
 #define OGRE_SampleF16( tex, sampler, uv ) tex.sample( sampler, uv )
 #define OGRE_SampleLevelF16( tex, sampler, uv, lod ) tex.sample( sampler, uv, level( lod ) )
 #define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) tex.sample( sampler, float2( uv ), arrayIdx )

--- a/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
+++ b/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
@@ -46,7 +46,7 @@ inline half3x3 toMatHalf3x3( float3x4 m )
 #define wshort3 ushort3
 
 #define toFloat3x3( x ) toMat3x3( x )
-#define buildFloat3x3( row0, row1, row2 ) float3x3( row0, row1, row2 )
+#define buildFloat3x3( row0, row1, row2 ) float3x3( float3( row0 ), float3( row1 ), float3( row2 ) )
 
 // See CrossPlatformSettings_piece_all.glsl for an explanation
 @property( precision_mode == full32 )

--- a/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
+++ b/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
@@ -37,24 +37,48 @@ inline float3x3 toMat3x3( float3x4 m )
 	// as long as we do it before including metal_stdlib
 	#define _h(x) (x)
 
-	#define half float
-	#define half2 float2
-	#define half3 float3
-	#define half4 float4
-	#define half2x2 float2x2
-	#define half3x3 float3x3
-	#define half4x4 float4x4
+	#define midf float
+	#define midf2 float2
+	#define midf3 float3
+	#define midf4 float4
+	#define midf2x2 float2x2
+	#define midf3x3 float3x3
+	#define midf4x4 float4x4
 
-	#define half_c float
-	#define half2_c float2
-	#define half3_c float3
-	#define half4_c float4
-	#define half2x2_c float2x2
-	#define half3x3_c float3x3
-	#define half4x4_c float4x4
+	#define midf_c float
+	#define midf2_c float2
+	#define midf3_c float3
+	#define midf4_c float4
+	#define midf2x2_c float2x2
+	#define midf3x3_c float3x3
+	#define midf4x4_c float4x4
 
-	#define toHalf3x3( x ) toMat3x3( x )
-	#define buildHalf3x3( row0, row1, row2 ) float3x3( row0, row1, row2 )
+	#define toMidf3x3( x ) toMat3x3( x )
+	#define buildMidf3x3( row0, row1, row2 ) float3x3( row0, row1, row2 )
+@end
+@property( precision_mode == midf16 )
+	// In Metal 'half' is an actual datatype. It should be OK to override it
+	// as long as we do it before including metal_stdlib
+	#define _h(x) (x)
+
+	#define midf half
+	#define midf2 half2
+	#define midf3 half3
+	#define midf4 half4
+	#define midf2x2 half2x2
+	#define midf3x3 half3x3
+	#define midf4x4 half4x4
+
+	#define midf_c half
+	#define midf2_c half2
+	#define midf3_c half3
+	#define midf4_c half4
+	#define midf2x2_c half2x2
+	#define midf3x3_c half3x3
+	#define midf4x4_c half4x4
+
+	#define toMidf3x3( x ) toMat3x3( x )
+	#define buildMidf3x3( row0, row1, row2 ) half3x3( row0, row1, row2 )
 @end
 
 #define min3( a, b, c ) min( a, min( b, c ) )
@@ -134,7 +158,7 @@ inline float3x3 toMat3x3( float3x4 m )
 #define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) tex.sample( sampler, float2( uv ), ushort( arrayIdx ), level( lod ) )
 #define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) tex.sample( sampler, float3( uv ), ushort( arrayIdx ), level( lod ) )
 #define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) tex.sample( sampler, uv, gradient2d( ddx, ddy ) )
-#define OGRE_SampleArray2DGrad( tex, sampler, uv, arrayIdx, ddx, ddy ) tex.sample( sampler, uv, ushort( arrayIdx ), gradient2d( ddx, ddy ) )
+#define OGRE_SampleArray2DGradF16( tex, sampler, uv, arrayIdx, ddx, ddy ) tex.sample( sampler, uv, ushort( arrayIdx ), gradient2d( ddx, ddy ) )
 
 #define bufferFetch( buffer, idx ) buffer[idx]
 #define bufferFetch1( buffer, idx ) buffer[idx]

--- a/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
+++ b/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
@@ -72,6 +72,8 @@ inline half3x3 toMatHalf3x3( float3x4 m )
 
 	#define toMidf3x3( x ) toMat3x3( x )
 	#define buildMidf3x3( row0, row1, row2 ) float3x3( row0, row1, row2 )
+
+	#define ensureValidRangeF16(x)
 @end
 @property( precision_mode == midf16 )
 	// In Metal 'half' is an actual datatype. It should be OK to override it
@@ -96,6 +98,8 @@ inline half3x3 toMatHalf3x3( float3x4 m )
 
 	#define toMidf3x3( x ) toMatHalf3x3( x )
 	#define buildMidf3x3( row0, row1, row2 ) half3x3( half3( row0 ), half3( row1 ), half3( row2 ) )
+
+	#define ensureValidRangeF16(x) x = min(x, 65504.0h)
 @end
 
 #define min3( a, b, c ) min( a, min( b, c ) )

--- a/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
+++ b/Samples/Media/Hlms/Common/Metal/CrossPlatformSettings_piece_all.metal
@@ -31,6 +31,32 @@ inline float3x3 toMat3x3( float3x4 m )
 #define toFloat3x3( x ) toMat3x3( x )
 #define buildFloat3x3( row0, row1, row2 ) float3x3( row0, row1, row2 )
 
+// See CrossPlatformSettings_piece_all.glsl for an explanation
+@property( precision_mode == full32 )
+	// In Metal 'half' is an actual datatype. It should be OK to override it
+	// as long as we do it before including metal_stdlib
+	#define _h(x) (x)
+
+	#define half float
+	#define half2 float2
+	#define half3 float3
+	#define half4 float4
+	#define half2x2 float2x2
+	#define half3x3 float3x3
+	#define half4x4 float4x4
+
+	#define half_c float
+	#define half2_c float2
+	#define half3_c float3
+	#define half4_c float4
+	#define half2x2_c float2x2
+	#define half3x3_c float3x3
+	#define half4x4_c float4x4
+
+	#define toHalf3x3( x ) toMat3x3( x )
+	#define buildHalf3x3( row0, row1, row2 ) float3x3( row0, row1, row2 )
+@end
+
 #define min3( a, b, c ) min( a, min( b, c ) )
 #define max3( a, b, c ) max( a, max( b, c ) )
 
@@ -100,6 +126,15 @@ inline float3x3 toMat3x3( float3x4 m )
 #define OGRE_Load2DMS( tex, iuv, subsample ) tex.read( iuv, subsample )
 
 #define OGRE_Load3D( tex, iuv, lod ) tex.read( ushort3( iuv ), lod )
+
+#define OGRE_Load2DF16( tex, iuv, lod ) tex.read( iuv, lod )
+#define OGRE_SampleF16( tex, sampler, uv ) tex.sample( sampler, uv )
+#define OGRE_SampleLevelF16( tex, sampler, uv, lod ) tex.sample( sampler, uv, level( lod ) )
+#define OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) tex.sample( sampler, float2( uv ), arrayIdx )
+#define OGRE_SampleArray2DLevelF16( tex, sampler, uv, arrayIdx, lod ) tex.sample( sampler, float2( uv ), ushort( arrayIdx ), level( lod ) )
+#define OGRE_SampleArrayCubeLevelF16( tex, sampler, uv, arrayIdx, lod ) tex.sample( sampler, float3( uv ), ushort( arrayIdx ), level( lod ) )
+#define OGRE_SampleGradF16( tex, sampler, uv, ddx, ddy ) tex.sample( sampler, uv, gradient2d( ddx, ddy ) )
+#define OGRE_SampleArray2DGrad( tex, sampler, uv, arrayIdx, ddx, ddy ) tex.sample( sampler, uv, ushort( arrayIdx ), gradient2d( ddx, ddy ) )
 
 #define bufferFetch( buffer, idx ) buffer[idx]
 #define bufferFetch1( buffer, idx ) buffer[idx]

--- a/Samples/Media/Hlms/Common/Metal/QuaternionCode_piece_all.metal
+++ b/Samples/Media/Hlms/Common/Metal/QuaternionCode_piece_all.metal
@@ -1,51 +1,104 @@
 @piece( DeclQuat_xAxis )
-inline float3 xAxis( float4 qQuat )
-{
-	float fTy  = 2.0 * qQuat.y;
-	float fTz  = 2.0 * qQuat.z;
-	float fTwy = fTy * qQuat.w;
-	float fTwz = fTz * qQuat.w;
-	float fTxy = fTy * qQuat.x;
-	float fTxz = fTz * qQuat.x;
-	float fTyy = fTy * qQuat.y;
-	float fTzz = fTz * qQuat.z;
+	@property( precision_mode != relaxed )
+		float3 xAxis( float4 qQuat )
+		{
+			float fTy  = 2.0 * qQuat.y;
+			float fTz  = 2.0 * qQuat.z;
+			float fTwy = fTy * qQuat.w;
+			float fTwz = fTz * qQuat.w;
+			float fTxy = fTy * qQuat.x;
+			float fTxz = fTz * qQuat.x;
+			float fTyy = fTy * qQuat.y;
+			float fTzz = fTz * qQuat.z;
 
-    return float3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
-}
+			return float3( 1.0-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
+		}
+	@end
+	@property( precision_mode != full32 )
+		midf3 xAxis( midf4 qQuat )
+		{
+			midf fTy  = _h( 2.0 ) * qQuat.y;
+			midf fTz  = _h( 2.0 ) * qQuat.z;
+			midf fTwy = fTy * qQuat.w;
+			midf fTwz = fTz * qQuat.w;
+			midf fTxy = fTy * qQuat.x;
+			midf fTxz = fTz * qQuat.x;
+			midf fTyy = fTy * qQuat.y;
+			midf fTzz = fTz * qQuat.z;
+
+			return midf3_c( _h( 1.0 )-(fTyy+fTzz), fTxy+fTwz, fTxz-fTwy );
+		}
+	@end
 @end
 
 @piece( DeclQuat_yAxis )
-inline float3 yAxis( float4 qQuat )
-{
-	float fTx  = 2.0 * qQuat.x;
-	float fTy  = 2.0 * qQuat.y;
-	float fTz  = 2.0 * qQuat.z;
-	float fTwx = fTx * qQuat.w;
-	float fTwz = fTz * qQuat.w;
-	float fTxx = fTx * qQuat.x;
-	float fTxy = fTy * qQuat.x;
-	float fTyz = fTz * qQuat.y;
-	float fTzz = fTz * qQuat.z;
+	@property( precision_mode != relaxed )
+		float3 yAxis( float4 qQuat )
+		{
+			float fTx  = 2.0 * qQuat.x;
+			float fTy  = 2.0 * qQuat.y;
+			float fTz  = 2.0 * qQuat.z;
+			float fTwx = fTx * qQuat.w;
+			float fTwz = fTz * qQuat.w;
+			float fTxx = fTx * qQuat.x;
+			float fTxy = fTy * qQuat.x;
+			float fTyz = fTz * qQuat.y;
+			float fTzz = fTz * qQuat.z;
 
-    return float3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
-}
+			return float3( fTxy-fTwz, 1.0-(fTxx+fTzz), fTyz+fTwx );
+		}
+	@end
+	@property( precision_mode != full32 )
+		midf3 yAxis( midf4 qQuat )
+		{
+			midf fTx  = _h( 2.0 ) * qQuat.x;
+			midf fTy  = _h( 2.0 ) * qQuat.y;
+			midf fTz  = _h( 2.0 ) * qQuat.z;
+			midf fTwx = fTx * qQuat.w;
+			midf fTwz = fTz * qQuat.w;
+			midf fTxx = fTx * qQuat.x;
+			midf fTxy = fTy * qQuat.x;
+			midf fTyz = fTz * qQuat.y;
+			midf fTzz = fTz * qQuat.z;
+
+			return midf3_c( fTxy-fTwz, _h( 1.0 )-(fTxx+fTzz), fTyz+fTwx );
+		}
+	@end
 @end
 
 @piece( DeclQuat_zAxis )
-inline float3 zAxis( float4 qQuat )
-{
-	float fTx  = 2.0 * qQuat.x;
-	float fTy  = 2.0 * qQuat.y;
-	float fTz  = 2.0 * qQuat.z;
-	float fTwx = fTx * qQuat.w;
-	float fTwy = fTy * qQuat.w;
-	float fTxx = fTx * qQuat.x;
-	float fTxz = fTz * qQuat.x;
-	float fTyy = fTy * qQuat.y;
-	float fTyz = fTz * qQuat.y;
+	@property( precision_mode != relaxed )
+		float3 zAxis( float4 qQuat )
+		{
+			float fTx  = 2.0 * qQuat.x;
+			float fTy  = 2.0 * qQuat.y;
+			float fTz  = 2.0 * qQuat.z;
+			float fTwx = fTx * qQuat.w;
+			float fTwy = fTy * qQuat.w;
+			float fTxx = fTx * qQuat.x;
+			float fTxz = fTz * qQuat.x;
+			float fTyy = fTy * qQuat.y;
+			float fTyz = fTz * qQuat.y;
 
-    return float3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
-}
+			return float3( fTxz+fTwy, fTyz-fTwx, 1.0-(fTxx+fTyy) );
+		}
+	@end
+	@property( precision_mode != full32 )
+		midf3 zAxis( midf4 qQuat )
+		{
+			midf fTx  = _h( 2.0 ) * qQuat.x;
+			midf fTy  = _h( 2.0 ) * qQuat.y;
+			midf fTz  = _h( 2.0 ) * qQuat.z;
+			midf fTwx = fTx * qQuat.w;
+			midf fTwy = fTy * qQuat.w;
+			midf fTxx = fTx * qQuat.x;
+			midf fTxz = fTz * qQuat.x;
+			midf fTyy = fTy * qQuat.y;
+			midf fTyz = fTz * qQuat.y;
+
+			return midf3_c( fTxz+fTwy, fTyz-fTwx, _h( 1.0 )-(fTxx+fTyy) );
+		}
+	@end
 @end
 
 @piece( DeclQuat_AllAxis )

--- a/Samples/Media/Hlms/Common/Metal/RenderDepthOnly_piece_ps.metal
+++ b/Samples/Media/Hlms/Common/Metal/RenderDepthOnly_piece_ps.metal
@@ -13,7 +13,7 @@
 	struct PS_OUTPUT
 	{
 		@property( !hlms_shadowcaster )
-			float4 colour0	[[ color(@counter(rtv_target)) ]];
+			midf4 colour0	[[ color(@counter(rtv_target)) ]];
 		@else
 			@property( !hlms_render_depth_only )
 				float colour0	[[ color(@counter(rtv_target)) ]];

--- a/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
@@ -49,10 +49,10 @@
 
 @property( ambient_hemisphere || vct_ambient_hemisphere )
 	@piece( DoAmbientHeader )
-		half ambientWD =
-			dot( half3_c( passBuf.ambientHemisphereDir.xyz ), pixelData.normal ) * _h( 0.5 ) + _h( 0.5 );
-		half ambientWS =
-			dot( half3_c( passBuf.ambientHemisphereDir.xyz ), pixelData.reflDir ) * _h( 0.5 ) + _h( 0.5 );
+		midf ambientWD =
+			dot( midf3_c( passBuf.ambientHemisphereDir.xyz ), pixelData.normal ) * _h( 0.5 ) + _h( 0.5 );
+		midf ambientWS =
+			dot( midf3_c( passBuf.ambientHemisphereDir.xyz ), pixelData.reflDir ) * _h( 0.5 ) + _h( 0.5 );
 	@end
 @end
 
@@ -77,10 +77,10 @@
 			if( vctSpecular.w == 0 )
 			{
 		@end
-				pixelData.envColourS += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
-											  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
-				pixelData.envColourD += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
-											  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
+				pixelData.envColourS += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+											  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
+				pixelData.envColourD += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+											  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
 		@property( vct_num_probes )
 			}
 		@end

--- a/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
@@ -49,8 +49,10 @@
 
 @property( ambient_hemisphere || vct_ambient_hemisphere )
 	@piece( DoAmbientHeader )
-		float ambientWD = dot( passBuf.ambientHemisphereDir.xyz, pixelData.normal ) * 0.5 + 0.5;
-		float ambientWS = dot( passBuf.ambientHemisphereDir.xyz, pixelData.reflDir ) * 0.5 + 0.5;
+		half ambientWD =
+			dot( half3( passBuf.ambientHemisphereDir.xyz ), pixelData.normal ) * _h( 0.5 ) + _h( 0.5 );
+		half ambientWS =
+			dot( half3( passBuf.ambientHemisphereDir.xyz ), pixelData.reflDir ) * _h( 0.5 ) + _h( 0.5 );
 	@end
 @end
 
@@ -75,8 +77,10 @@
 			if( vctSpecular.w == 0 )
 			{
 		@end
-				pixelData.envColourS += lerp( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-				pixelData.envColourD += lerp( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+				pixelData.envColourS += lerp( half3( passBuf.ambientLowerHemi.xyz ),
+											  half3( passBuf.ambientUpperHemi.xyz ), ambientWD );
+				pixelData.envColourD += lerp( half3( passBuf.ambientLowerHemi.xyz ),
+											  half3( passBuf.ambientUpperHemi.xyz ), ambientWS );
 		@property( vct_num_probes )
 			}
 		@end

--- a/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
@@ -50,9 +50,9 @@
 @property( ambient_hemisphere || vct_ambient_hemisphere )
 	@piece( DoAmbientHeader )
 		half ambientWD =
-			dot( half3( passBuf.ambientHemisphereDir.xyz ), pixelData.normal ) * _h( 0.5 ) + _h( 0.5 );
+			dot( half3_c( passBuf.ambientHemisphereDir.xyz ), pixelData.normal ) * _h( 0.5 ) + _h( 0.5 );
 		half ambientWS =
-			dot( half3( passBuf.ambientHemisphereDir.xyz ), pixelData.reflDir ) * _h( 0.5 ) + _h( 0.5 );
+			dot( half3_c( passBuf.ambientHemisphereDir.xyz ), pixelData.reflDir ) * _h( 0.5 ) + _h( 0.5 );
 	@end
 @end
 
@@ -77,10 +77,10 @@
 			if( vctSpecular.w == 0 )
 			{
 		@end
-				pixelData.envColourS += lerp( half3( passBuf.ambientLowerHemi.xyz ),
-											  half3( passBuf.ambientUpperHemi.xyz ), ambientWD );
-				pixelData.envColourD += lerp( half3( passBuf.ambientLowerHemi.xyz ),
-											  half3( passBuf.ambientUpperHemi.xyz ), ambientWS );
+				pixelData.envColourS += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
+											  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
+				pixelData.envColourD += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
+											  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
 		@property( vct_num_probes )
 			}
 		@end

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
@@ -43,31 +43,30 @@ Adapted to Ogre by Matias N. Goldberg
 #define LUT_SCALE ((LUT_SIZE - 1.0)/LUT_SIZE)
 #define LUT_BIAS  (0.5/LUT_SIZE)
 
-INLINE midf3 IntegrateEdgeVec( midf3 v1, midf3 v2 )
+INLINE float3 IntegrateEdgeVec( float3 v1, float3 v2 )
 {
-	midf x = dot(v1, v2);
-	midf y = abs(x);
+	float x = dot(v1, v2);
+	float y = abs(x);
 
-	midf a = _h( 0.8543985 ) + ( _h( 0.4965155 ) + _h( 0.0145206 ) * y ) * y;
-	midf b = _h( 3.4175940 ) + ( _h( 4.1616724 ) + y ) * y;
-	midf v = a / b;
+	float a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;
+	float b = 3.4175940 + ( 4.1616724 + y ) * y;
+	float v = a / b;
 
-	midf theta_sintheta =
-		( x > _h( 0.0 ) ) ? v : _h( 0.5 ) * rsqrt( max( _h( 1.0 ) - x * x, _h( 1e-7 ) ) ) - v;
+	float theta_sintheta = ( x > 0.0 ) ? v : 0.5 * rsqrt( max( 1.0 - x * x, 1e-7 ) ) - v;
 
 	return cross( v1, v2 ) * theta_sintheta;
 }
 
-INLINE midf IntegrateEdge( midf3 v1, midf3 v2 )
+INLINE float IntegrateEdge( float3 v1, float3 v2 )
 {
 	return IntegrateEdgeVec( v1, v2 ).z;
 }
 
 @property( syntax == metal )
-INLINE void ClipQuadToHorizon( thread midf3 L[5], thread int &n )
+INLINE void ClipQuadToHorizon( thread float3 L[5], thread int &n )
 @end
 @property( syntax != metal )
-INLINE void ClipQuadToHorizon( inout midf3 L[5], out int n )
+INLINE void ClipQuadToHorizon( inout float3 L[5], out int n )
 @end
 {
 	// detect clipping config
@@ -179,7 +178,7 @@ INLINE void ClipQuadToHorizon( inout midf3 L[5], out int n )
 		L[4] = L[0];
 }
 
-INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, midf3x3 Minv,
+INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, float3x3 Minv,
 						  @property( syntax == metal )constant@end  float4 points[4],
 						  bool twoSided )
 {
@@ -189,21 +188,21 @@ INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, midf3x3 Minv,
 	T2 = cross(N, T1);
 
 	// rotate area light in (T1, T2, N) basis
-	Minv = mul( Minv, transpose( buildMidf3x3( T1, T2, N ) ) );
+	Minv = mul( Minv, transpose( buildFloat3x3( T1, T2, N ) ) );
 
 	// polygon (allocate 5 vertices for clipping)
-	midf3 L[5];
-	L[0] = mul( Minv, midf3_c( points[0].xyz - P ) );
-	L[1] = mul( Minv, midf3_c( points[1].xyz - P ) );
-	L[2] = mul( Minv, midf3_c( points[2].xyz - P ) );
-	L[3] = mul( Minv, midf3_c( points[3].xyz - P ) );
+	float3 L[5];
+	L[0] = mul( Minv, points[0].xyz - P );
+	L[1] = mul( Minv, points[1].xyz - P );
+	L[2] = mul( Minv, points[2].xyz - P );
+	L[3] = mul( Minv, points[3].xyz - P );
 	//Initialize L[4]. Some HLSL compiler versions complains this is uninitialized even though
 	//it shouldn't complain.
 	//See https://forums.ogre3d.org/viewtopic.php?f=25&t=94804#p544184
-	L[4] = midf3_c( 0, 1, 0 );
+	L[4] = float3( 0, 1, 0 );
 
 	// integrate
-	midf sum = _h( 0.0 );
+	float sum = 0.0;
 
 	@property( hlms_lights_ltc_clipless )
 		midf3 dir = midf3_c( points[0].xyz - P );
@@ -215,15 +214,15 @@ INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, midf3x3 Minv,
 		L[2] = normalize(L[2]);
 		L[3] = normalize(L[3]);
 
-		midf3 vsum = midf3_c(0.0);
+		float3 vsum = midf3_c(0.0);
 
 		vsum += IntegrateEdgeVec(L[0], L[1]);
 		vsum += IntegrateEdgeVec(L[1], L[2]);
 		vsum += IntegrateEdgeVec(L[2], L[3]);
 		vsum += IntegrateEdgeVec(L[3], L[0]);
 
-		midf len = length(vsum);
-		midf z = vsum.z/len;
+		float len = length(vsum);
+		float z = vsum.z/len;
 
 		if (behind)
 			z = -z;
@@ -231,14 +230,13 @@ INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, midf3x3 Minv,
 		float2 uv = float2(z*0.5 + 0.5, len);
 		uv = uv * LUT_SCALE + LUT_BIAS;
 
-		midf scale = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, uv, 1, 0 ).w;
+		float scale = float( OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, uv, 1, 0 ).w );
 
-		sum = len*scale;
+		sum = len * scale;
 
 		if( behind && !twoSided )
-			sum = _h( 0.0 );
-	@end
-	@property( !hlms_lights_ltc_clipless )
+			sum = 0.0;
+	@else
 		int n;
 		ClipQuadToHorizon( L, n );
 
@@ -260,10 +258,10 @@ INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, midf3x3 Minv,
 		if( n == 5 )
 			sum += IntegrateEdge( L[4], L[0] );
 
-		sum = twoSided ? abs(sum) : max(_h( 0.0 ), sum);
+		sum = twoSided ? abs(sum) : max( 0.0f, sum );
 	@end
 
-	return sum;
+	return midf( sum );
 }
 @end
 @end
@@ -295,10 +293,10 @@ for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 		midf4 ltc0 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 0, 0 );
 		midf4 ltc1 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 1, 0 );
 
-		midf3x3 Minv = buildMidf3x3(
-			midf3_c(ltc0.x, 0, ltc0.y),
-			midf3_c(  0,  1,    0),
-			midf3_c(ltc0.z, 0, ltc0.w)
+		float3x3 Minv = buildFloat3x3(
+			float3(ltc0.x, 0, ltc0.y),
+			float3(  0,  1,    0),
+			float3(ltc0.z, 0, ltc0.w)
 		);
 
 		bool doubleSidedLtc = light2Buf.areaLtcLights[i].specular.w != 0.0f;
@@ -318,7 +316,7 @@ for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 		@end
 
 		midf ltcDiffuse = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz,
-										buildMidf3x3( midf3_c( 1, 0, 0 ), midf3_c( 0, 1, 0 ), midf3_c( 0, 0, 1 ) ),
+										buildFloat3x3( float3( 1, 0, 0 ), float3( 0, 1, 0 ), float3( 0, 0, 1 ) ),
 										light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 
 		@property( obb_restraint_ltc )

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
@@ -43,31 +43,31 @@ Adapted to Ogre by Matias N. Goldberg
 #define LUT_SCALE ((LUT_SIZE - 1.0)/LUT_SIZE)
 #define LUT_BIAS  (0.5/LUT_SIZE)
 
-INLINE half3 IntegrateEdgeVec( half3 v1, half3 v2 )
+INLINE midf3 IntegrateEdgeVec( midf3 v1, midf3 v2 )
 {
-	half x = dot(v1, v2);
-	half y = abs(x);
+	midf x = dot(v1, v2);
+	midf y = abs(x);
 
-	half a = _h( 0.8543985 ) + ( _h( 0.4965155 ) + _h( 0.0145206 ) * y ) * y;
-	half b = _h( 3.4175940 ) + ( _h( 4.1616724 ) + y ) * y;
-	half v = a / b;
+	midf a = _h( 0.8543985 ) + ( _h( 0.4965155 ) + _h( 0.0145206 ) * y ) * y;
+	midf b = _h( 3.4175940 ) + ( _h( 4.1616724 ) + y ) * y;
+	midf v = a / b;
 
-	half theta_sintheta =
+	midf theta_sintheta =
 		( x > _h( 0.0 ) ) ? v : _h( 0.5 ) * rsqrt( max( _h( 1.0 ) - x * x, _h( 1e-7 ) ) ) - v;
 
 	return cross( v1, v2 ) * theta_sintheta;
 }
 
-INLINE half IntegrateEdge( half3 v1, half3 v2 )
+INLINE midf IntegrateEdge( midf3 v1, midf3 v2 )
 {
 	return IntegrateEdgeVec( v1, v2 ).z;
 }
 
 @property( syntax == metal )
-INLINE void ClipQuadToHorizon( thread half3 L[5], thread int &n )
+INLINE void ClipQuadToHorizon( thread midf3 L[5], thread int &n )
 @end
 @property( syntax != metal )
-INLINE void ClipQuadToHorizon( inout half3 L[5], out int n )
+INLINE void ClipQuadToHorizon( inout midf3 L[5], out int n )
 @end
 {
 	// detect clipping config
@@ -179,35 +179,35 @@ INLINE void ClipQuadToHorizon( inout half3 L[5], out int n )
 		L[4] = L[0];
 }
 
-INLINE half LTC_Evaluate( half3 N, half3 V, float3 P, half3x3 Minv,
+INLINE midf LTC_Evaluate( midf3 N, midf3 V, float3 P, midf3x3 Minv,
 						  @property( syntax == metal )constant@end  float4 points[4],
 						  bool twoSided )
 {
 	// construct orthonormal basis around N
-	half3 T1, T2;
+	midf3 T1, T2;
 	T1 = normalize( V - N*dot(V, N) );
 	T2 = cross(N, T1);
 
 	// rotate area light in (T1, T2, N) basis
-	Minv = mul( Minv, transpose( buildHalf3x3( T1, T2, N ) ) );
+	Minv = mul( Minv, transpose( buildMidf3x3( T1, T2, N ) ) );
 
 	// polygon (allocate 5 vertices for clipping)
-	half3 L[5];
-	L[0] = mul( Minv, half3_c( points[0].xyz - P ) );
-	L[1] = mul( Minv, half3_c( points[1].xyz - P ) );
-	L[2] = mul( Minv, half3_c( points[2].xyz - P ) );
-	L[3] = mul( Minv, half3_c( points[3].xyz - P ) );
+	midf3 L[5];
+	L[0] = mul( Minv, midf3_c( points[0].xyz - P ) );
+	L[1] = mul( Minv, midf3_c( points[1].xyz - P ) );
+	L[2] = mul( Minv, midf3_c( points[2].xyz - P ) );
+	L[3] = mul( Minv, midf3_c( points[3].xyz - P ) );
 	//Initialize L[4]. Some HLSL compiler versions complains this is uninitialized even though
 	//it shouldn't complain.
 	//See https://forums.ogre3d.org/viewtopic.php?f=25&t=94804#p544184
-	L[4] = half3_c( 0, 1, 0 );
+	L[4] = midf3_c( 0, 1, 0 );
 
 	// integrate
-	half sum = _h( 0.0 );
+	midf sum = _h( 0.0 );
 
 	@property( hlms_lights_ltc_clipless )
-		half3 dir = half3_c( points[0].xyz - P );
-		half3 lightNormal = half3_c( cross( points[1].xyz - points[0].xyz, points[3].xyz - points[0].xyz ) );
+		midf3 dir = midf3_c( points[0].xyz - P );
+		midf3 lightNormal = midf3_c( cross( points[1].xyz - points[0].xyz, points[3].xyz - points[0].xyz ) );
 		bool behind = (dot(dir, lightNormal) < _h( 0.0 ));
 
 		L[0] = normalize(L[0]);
@@ -215,15 +215,15 @@ INLINE half LTC_Evaluate( half3 N, half3 V, float3 P, half3x3 Minv,
 		L[2] = normalize(L[2]);
 		L[3] = normalize(L[3]);
 
-		half3 vsum = half3_c(0.0);
+		midf3 vsum = midf3_c(0.0);
 
 		vsum += IntegrateEdgeVec(L[0], L[1]);
 		vsum += IntegrateEdgeVec(L[1], L[2]);
 		vsum += IntegrateEdgeVec(L[2], L[3]);
 		vsum += IntegrateEdgeVec(L[3], L[0]);
 
-		half len = length(vsum);
-		half z = vsum.z/len;
+		midf len = length(vsum);
+		midf z = vsum.z/len;
 
 		if (behind)
 			z = -z;
@@ -231,7 +231,7 @@ INLINE half LTC_Evaluate( half3 N, half3 V, float3 P, half3x3 Minv,
 		float2 uv = float2(z*0.5 + 0.5, len);
 		uv = uv * LUT_SCALE + LUT_BIAS;
 
-		half scale = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, uv, 1, 0 ).w;
+		midf scale = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, uv, 1, 0 ).w;
 
 		sum = len*scale;
 
@@ -292,24 +292,24 @@ for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 		float2 ltcUV = float2( pixelData.roughness, sqrt(1.0 - pixelData.NdotV) );
 		ltcUV = ltcUV * LUT_SCALE + LUT_BIAS;
 
-		half4 ltc0 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 0, 0 );
-		half4 ltc1 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 1, 0 );
+		midf4 ltc0 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 0, 0 );
+		midf4 ltc1 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 1, 0 );
 
-		half3x3 Minv = buildHalf3x3(
-			half3_c(ltc0.x, 0, ltc0.y),
-			half3_c(  0,  1,    0),
-			half3_c(ltc0.z, 0, ltc0.w)
+		midf3x3 Minv = buildMidf3x3(
+			midf3_c(ltc0.x, 0, ltc0.y),
+			midf3_c(  0,  1,    0),
+			midf3_c(ltc0.z, 0, ltc0.w)
 		);
 
 		bool doubleSidedLtc = light2Buf.areaLtcLights[i].specular.w != 0.0f;
 
 		@property( !fresnel_scalar )
-			half ltcSpecular = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
+			midf ltcSpecular = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
 											 light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 			// BRDF shadowing and Fresnel
 			ltcSpecular *= pixelData.F0 * ltc1.x + ( _h( 1.0 ) - pixelData.F0) * ltc1.y;
 		@else
-			half3 ltcSpecular;
+			midf3 ltcSpecular;
 			ltcSpecular.x = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
 										  light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 			ltcSpecular.yz = ltcSpecular.xx;
@@ -317,8 +317,8 @@ for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 			ltcSpecular.xyz *= pixelData.F0.xyz * ltc1.x + (_h( 1.0 ) - pixelData.F0.xyz) * ltc1.y;
 		@end
 
-		half ltcDiffuse = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz,
-										buildHalf3x3( half3_c( 1, 0, 0 ), half3_c( 0, 1, 0 ), half3_c( 0, 0, 1 ) ),
+		midf ltcDiffuse = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz,
+										buildMidf3x3( midf3_c( 1, 0, 0 ), midf3_c( 0, 1, 0 ), midf3_c( 0, 0, 1 ) ),
 										light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 
 		@property( obb_restraint_ltc )
@@ -326,8 +326,8 @@ for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 			ltcSpecular	*= obbRestraintFade;
 		@end
 
-		finalColour += half3_c( light2Buf.areaLtcLights[i].diffuse.xyz ) * ltcDiffuse * pixelData.diffuse.xyz;
-		finalColour += half3_c( light2Buf.areaLtcLights[i].specular.xyz ) * ltcSpecular * pixelData.specular.xyz;
+		finalColour += midf3_c( light2Buf.areaLtcLights[i].diffuse.xyz ) * ltcDiffuse * pixelData.diffuse.xyz;
+		finalColour += midf3_c( light2Buf.areaLtcLights[i].specular.xyz ) * ltcSpecular * pixelData.specular.xyz;
 	}
 }
 @end

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_LTC_piece_ps.any
@@ -43,38 +43,39 @@ Adapted to Ogre by Matias N. Goldberg
 #define LUT_SCALE ((LUT_SIZE - 1.0)/LUT_SIZE)
 #define LUT_BIAS  (0.5/LUT_SIZE)
 
-INLINE float3 IntegrateEdgeVec( float3 v1, float3 v2 )
+INLINE half3 IntegrateEdgeVec( half3 v1, half3 v2 )
 {
-	float x = dot(v1, v2);
-	float y = abs(x);
+	half x = dot(v1, v2);
+	half y = abs(x);
 
-	float a = 0.8543985 + (0.4965155 + 0.0145206*y)*y;
-	float b = 3.4175940 + (4.1616724 + y)*y;
-	float v = a / b;
+	half a = _h( 0.8543985 ) + ( _h( 0.4965155 ) + _h( 0.0145206 ) * y ) * y;
+	half b = _h( 3.4175940 ) + ( _h( 4.1616724 ) + y ) * y;
+	half v = a / b;
 
-	float theta_sintheta = (x > 0.0) ? v : 0.5*rsqrt(max(1.0 - x*x, 1e-7)) - v;
+	half theta_sintheta =
+		( x > _h( 0.0 ) ) ? v : _h( 0.5 ) * rsqrt( max( _h( 1.0 ) - x * x, _h( 1e-7 ) ) ) - v;
 
 	return cross( v1, v2 ) * theta_sintheta;
 }
 
-INLINE float IntegrateEdge( float3 v1, float3 v2 )
+INLINE half IntegrateEdge( half3 v1, half3 v2 )
 {
 	return IntegrateEdgeVec( v1, v2 ).z;
 }
 
 @property( syntax == metal )
-INLINE void ClipQuadToHorizon( thread float3 L[5], thread int &n )
+INLINE void ClipQuadToHorizon( thread half3 L[5], thread int &n )
 @end
 @property( syntax != metal )
-INLINE void ClipQuadToHorizon( inout float3 L[5], out int n )
+INLINE void ClipQuadToHorizon( inout half3 L[5], out int n )
 @end
 {
 	// detect clipping config
 	int config = 0;
-	if (L[0].z > 0.0) config += 1;
-	if (L[1].z > 0.0) config += 2;
-	if (L[2].z > 0.0) config += 4;
-	if (L[3].z > 0.0) config += 8;
+	if (L[0].z > _h( 0.0 )) config += 1;
+	if (L[1].z > _h( 0.0 )) config += 2;
+	if (L[2].z > _h( 0.0 )) config += 4;
+	if (L[3].z > _h( 0.0 )) config += 8;
 
 	// clip
 	n = 0;
@@ -178,51 +179,51 @@ INLINE void ClipQuadToHorizon( inout float3 L[5], out int n )
 		L[4] = L[0];
 }
 
-INLINE float LTC_Evaluate( float3 N, float3 V, float3 P, float3x3 Minv,
-							@property( syntax == metal )constant@end  float4 points[4],
-							bool twoSided )
+INLINE half LTC_Evaluate( half3 N, half3 V, float3 P, half3x3 Minv,
+						  @property( syntax == metal )constant@end  float4 points[4],
+						  bool twoSided )
 {
 	// construct orthonormal basis around N
-	float3 T1, T2;
+	half3 T1, T2;
 	T1 = normalize( V - N*dot(V, N) );
 	T2 = cross(N, T1);
 
 	// rotate area light in (T1, T2, N) basis
-	Minv = mul( Minv, transpose( buildFloat3x3( T1, T2, N ) ) );
+	Minv = mul( Minv, transpose( buildHalf3x3( T1, T2, N ) ) );
 
 	// polygon (allocate 5 vertices for clipping)
-	float3 L[5];
-	L[0] = mul( Minv, points[0].xyz - P );
-	L[1] = mul( Minv, points[1].xyz - P );
-	L[2] = mul( Minv, points[2].xyz - P );
-	L[3] = mul( Minv, points[3].xyz - P );
+	half3 L[5];
+	L[0] = mul( Minv, half3_c( points[0].xyz - P ) );
+	L[1] = mul( Minv, half3_c( points[1].xyz - P ) );
+	L[2] = mul( Minv, half3_c( points[2].xyz - P ) );
+	L[3] = mul( Minv, half3_c( points[3].xyz - P ) );
 	//Initialize L[4]. Some HLSL compiler versions complains this is uninitialized even though
 	//it shouldn't complain.
 	//See https://forums.ogre3d.org/viewtopic.php?f=25&t=94804#p544184
-	L[4] = float3( 0, 1, 0 );
+	L[4] = half3_c( 0, 1, 0 );
 
 	// integrate
-	float sum = 0.0;
+	half sum = _h( 0.0 );
 
 	@property( hlms_lights_ltc_clipless )
-		float3 dir = points[0].xyz - P;
-		float3 lightNormal = cross( points[1].xyz - points[0].xyz, points[3].xyz - points[0].xyz );
-		bool behind = (dot(dir, lightNormal) < 0.0);
+		half3 dir = half3_c( points[0].xyz - P );
+		half3 lightNormal = half3_c( cross( points[1].xyz - points[0].xyz, points[3].xyz - points[0].xyz ) );
+		bool behind = (dot(dir, lightNormal) < _h( 0.0 ));
 
 		L[0] = normalize(L[0]);
 		L[1] = normalize(L[1]);
 		L[2] = normalize(L[2]);
 		L[3] = normalize(L[3]);
 
-		float3 vsum = float3(0.0);
+		half3 vsum = half3_c(0.0);
 
 		vsum += IntegrateEdgeVec(L[0], L[1]);
 		vsum += IntegrateEdgeVec(L[1], L[2]);
 		vsum += IntegrateEdgeVec(L[2], L[3]);
 		vsum += IntegrateEdgeVec(L[3], L[0]);
 
-		float len = length(vsum);
-		float z = vsum.z/len;
+		half len = length(vsum);
+		half z = vsum.z/len;
 
 		if (behind)
 			z = -z;
@@ -230,19 +231,19 @@ INLINE float LTC_Evaluate( float3 N, float3 V, float3 P, float3x3 Minv,
 		float2 uv = float2(z*0.5 + 0.5, len);
 		uv = uv * LUT_SCALE + LUT_BIAS;
 
-		float scale = OGRE_SampleArray2DLevel( ltcMatrix, ltcSampler, uv, 1, 0 ).w;
+		half scale = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, uv, 1, 0 ).w;
 
 		sum = len*scale;
 
 		if( behind && !twoSided )
-			sum = 0.0;
+			sum = _h( 0.0 );
 	@end
 	@property( !hlms_lights_ltc_clipless )
 		int n;
 		ClipQuadToHorizon( L, n );
 
 		if( n == 0 )
-			return 0;
+			return _h( 0 );
 		// project onto sphere
 		L[0] = normalize( L[0] );
 		L[1] = normalize( L[1] );
@@ -259,7 +260,7 @@ INLINE float LTC_Evaluate( float3 N, float3 V, float3 P, float3x3 Minv,
 		if( n == 5 )
 			sum += IntegrateEdge( L[4], L[0] );
 
-		sum = twoSided ? abs(sum) : max(0.0, sum);
+		sum = twoSided ? abs(sum) : max(_h( 0.0 ), sum);
 	@end
 
 	return sum;
@@ -291,42 +292,42 @@ for( int i=0; i<floatBitsToInt( light2Buf.numAreaLtcLights ); ++i )
 		float2 ltcUV = float2( pixelData.roughness, sqrt(1.0 - pixelData.NdotV) );
 		ltcUV = ltcUV * LUT_SCALE + LUT_BIAS;
 
-		float4 ltc0 = OGRE_SampleArray2DLevel( ltcMatrix, ltcSampler, ltcUV, 0, 0 );
-		float4 ltc1 = OGRE_SampleArray2DLevel( ltcMatrix, ltcSampler, ltcUV, 1, 0 );
+		half4 ltc0 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 0, 0 );
+		half4 ltc1 = OGRE_SampleArray2DLevelF16( ltcMatrix, ltcSampler, ltcUV, 1, 0 );
 
-		float3x3 Minv = buildFloat3x3(
-			float3(ltc0.x, 0, ltc0.y),
-			float3(  0,  1,    0),
-			float3(ltc0.z, 0, ltc0.w)
+		half3x3 Minv = buildHalf3x3(
+			half3_c(ltc0.x, 0, ltc0.y),
+			half3_c(  0,  1,    0),
+			half3_c(ltc0.z, 0, ltc0.w)
 		);
 
 		bool doubleSidedLtc = light2Buf.areaLtcLights[i].specular.w != 0.0f;
 
 		@property( !fresnel_scalar )
-			float ltcSpecular = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
-											  light2Buf.areaLtcLights[i].points, doubleSidedLtc );
+			half ltcSpecular = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
+											 light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 			// BRDF shadowing and Fresnel
-			ltcSpecular *= pixelData.F0 * ltc1.x + (1.0 - pixelData.F0) * ltc1.y;
+			ltcSpecular *= pixelData.F0 * ltc1.x + ( _h( 1.0 ) - pixelData.F0) * ltc1.y;
 		@else
-			float3 ltcSpecular;
+			half3 ltcSpecular;
 			ltcSpecular.x = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz, Minv,
 										  light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 			ltcSpecular.yz = ltcSpecular.xx;
 			// BRDF shadowing and Fresnel
-			ltcSpecular.xyz *= pixelData.F0.xyz * ltc1.x + (1.0 - pixelData.F0.xyz) * ltc1.y;
+			ltcSpecular.xyz *= pixelData.F0.xyz * ltc1.x + (_h( 1.0 ) - pixelData.F0.xyz) * ltc1.y;
 		@end
 
-		float ltcDiffuse = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz,
-										 buildFloat3x3( float3( 1, 0, 0 ), float3( 0, 1, 0 ), float3( 0, 0, 1 ) ),
-										 light2Buf.areaLtcLights[i].points, doubleSidedLtc );
+		half ltcDiffuse = LTC_Evaluate( pixelData.normal.xyz, pixelData.viewDir.xyz, inPs.pos.xyz,
+										buildHalf3x3( half3_c( 1, 0, 0 ), half3_c( 0, 1, 0 ), half3_c( 0, 0, 1 ) ),
+										light2Buf.areaLtcLights[i].points, doubleSidedLtc );
 
 		@property( obb_restraint_ltc )
 			ltcDiffuse	*= obbRestraintFade;
 			ltcSpecular	*= obbRestraintFade;
 		@end
 
-		finalColour += light2Buf.areaLtcLights[i].diffuse.xyz * ltcDiffuse * pixelData.diffuse.xyz;
-		finalColour += light2Buf.areaLtcLights[i].specular.xyz * ltcSpecular * pixelData.specular.xyz;
+		finalColour += half3_c( light2Buf.areaLtcLights[i].diffuse.xyz ) * ltcDiffuse * pixelData.diffuse.xyz;
+		finalColour += half3_c( light2Buf.areaLtcLights[i].specular.xyz ) * ltcSpecular * pixelData.specular.xyz;
 	}
 }
 @end

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
@@ -43,9 +43,9 @@
 		fDistance = length( lightDir );
 
 		@property( obb_restraint_approx )
-			float obbRestraintFade = getObbRestraintFade( light1Buf.areaApproxLights[i].obbRestraint, inPs.pos,
-														  light1Buf.areaApproxLights[i].obbFadeFactorApprox.xyz );
-			@piece( obbRestraintTestApprox )&& obbRestraintFade > 0.0@end
+			half obbRestraintFade = getObbRestraintFade( light1Buf.areaApproxLights[i].obbRestraint, inPs.pos,
+														 light1Buf.areaApproxLights[i].obbFadeFactorApprox.xyz );
+			@piece( obbRestraintTestApprox )&& obbRestraintFade > _h( 0.0 )@end
 		@end
 
 		if( fDistance <= light1Buf.areaApproxLights[i].attenuation.x
@@ -67,18 +67,18 @@
 			//a surface is close and perpendicular to the light. This is fully a hack and
 			//the values (e.g. 0.25) is completely eye balled.
 			lightUVForTex.xy = lightUV.xy;
-			lightUV.xy += float2( dot( light1Buf.areaApproxLights[i].tangent.xyz, pixelData.normal ),
-								  dot( areaLightBitangent, pixelData.normal ) ) * 3.75 * invHalfRectSize.xy;
+			lightUV.xy += float2( dot( ( light1Buf.areaApproxLights[i].tangent.xyz ), float3( pixelData.normal ) ),
+								  dot( areaLightBitangent, float3( pixelData.normal ) ) ) * 3.75 * invHalfRectSize.xy;
 			lightUV.xy = clamp( lightUV.xy, -0.5f, 0.5f );
 			lightUVForTex = clamp( lightUVForTex.xy, -0.5f, 0.5f );
 	//		float booster = 1.0f - smoothstep( 0.2f, 1.9f, max( abs( lightUV.x ), abs( lightUV.y ) ) );
 	//		booster = 1.0f + booster * 2.25f;
-			float booster = lerp( 1.0f, 4.0f, pixelData.roughness );
+			half booster = lerp( _h( 1.0f ), _h( 4.0f ), pixelData.roughness );
 
 		@property( !hlms_lights_area_tex_colour || !hlms_lights_area_tex_mask )
-			float diffuseMask = 1.0f;
+			half diffuseMask = _h( 1.0f );
 		@else
-			float3 diffuseMask = float3( 1.0f, 1.0f, 1.0f );
+			half3 diffuseMask = half3_c( 1.0f, 1.0f, 1.0f );
 		@end
 		@property( hlms_lights_area_tex_mask )
 			if( i < floatBitsToInt( light1Buf.numAreaApproxLightsWithMask ) )
@@ -86,11 +86,11 @@
 				// 1 / (1 - 0.02) = 1.020408163
 				float diffuseMipsLeft = light1Buf.areaLightNumMipmapsSpecFactor * 0.5 -
 										light1Buf.areaLightDiffuseMipmapStart * 1.020408163f;
-				diffuseMask = OGRE_SampleArray2DLevel( areaLightMasks, areaLightMasksSampler,
-													   lightUVForTex + 0.5f,
-													   light1Buf.areaApproxLights[i].attenuation.w,
-													   light1Buf.areaLightDiffuseMipmapStart +
-													   (pixelData.roughness - 0.02f) * diffuseMipsLeft ).AREA_LIGHTS_TEX_SWIZZLE;
+				diffuseMask = OGRE_SampleArray2DLevelF16( areaLightMasks, areaLightMasksSampler,
+														  lightUVForTex + 0.5f,
+														  light1Buf.areaApproxLights[i].attenuation.w,
+														  light1Buf.areaLightDiffuseMipmapStart +
+														  (pixelData.roughness - 0.02f) * diffuseMipsLeft ).AREA_LIGHTS_TEX_SWIZZLE;
 			}
 		@end
 
@@ -105,9 +105,9 @@
 			float3 toShapeLight = reflect( -pixelData.viewDir, pixelData.normal );
 			float denom = dot( toShapeLight, -light1Buf.areaApproxLights[i].direction.xyz );
 			@property( !hlms_lights_area_tex_mask || !hlms_lights_area_tex_colour )
-				float specCol = 0;
+				half specCol = _h( 0 );
 			@else
-				float3 specCol = float3( 0, 0, 0 );
+				half3 specCol = half3_c( 0, 0, 0 );
 			@end
 			if( denom > 1e-6f || light1Buf.areaApproxLights[i].doubleSided.x != 0.0f )
 			{
@@ -129,19 +129,19 @@
 					specVal = pow( specVal, areaPower ) * min( areaPower * areaPower, 1.0f );
 
 					@property( !hlms_lights_area_tex_mask || !hlms_lights_area_tex_colour )
-						specCol = specVal;
+						specCol = half_c( specVal );
 					@else
-						specCol = float3( specVal, specVal, specVal );
+						specCol = half3_c( specVal, specVal, specVal );
 					@end
 
 					@property( hlms_lights_area_tex_mask )
 						if( i < floatBitsToInt( light1Buf.numAreaApproxLightsWithMask ) )
 						{
-							specCol *= OGRE_SampleArray2DLevel( areaLightMasks, areaLightMasksSampler,
-																reflClipSpace * invHalfRectSize + 0.5f,
-																light1Buf.areaApproxLights[i].attenuation.w,
-																(pixelData.roughness - 0.02f) *
-																light1Buf.areaLightNumMipmapsSpecFactor ).AREA_LIGHTS_TEX_SWIZZLE;
+							specCol *= OGRE_SampleArray2DLevelF16( areaLightMasks, areaLightMasksSampler,
+																   reflClipSpace * invHalfRectSize + 0.5f,
+																   light1Buf.areaApproxLights[i].attenuation.w,
+																   (pixelData.roughness - _h( 0.02f )) *
+																   light1Buf.areaLightNumMipmapsSpecFactor ).AREA_LIGHTS_TEX_SWIZZLE;
 						}
 					@end
 				}
@@ -151,13 +151,13 @@
 			//float fAreaW = dot( lightDir, -light1Buf.areaApproxLights[i].direction.xyz ) * 0.5f + 0.5f;
 			//lightDir = (-light1Buf.areaApproxLights[i].direction.xyz + lightDir) * 0.50f;
 			//lightDir = lerp( lightDir2, lightDir, fAreaW );
-			float globalDot = saturate( dot( -lightDir, light1Buf.areaApproxLights[i].direction.xyz ) );
-			globalDot = light1Buf.areaApproxLights[i].doubleSided.x != 0.0f ? 1.0f : globalDot;
-			tmpColour = BRDF_AreaLightApprox( lightDir,
-											  light1Buf.areaApproxLights[i].diffuse.xyz * diffuseMask,
-											  light1Buf.areaApproxLights[i].specular.xyz * specCol,
+			half globalDot = half_c( saturate( dot( -lightDir, light1Buf.areaApproxLights[i].direction.xyz ) ) );
+			globalDot = light1Buf.areaApproxLights[i].doubleSided.x != 0.0f ? _h( 1.0f ) : globalDot;
+			tmpColour = BRDF_AreaLightApprox( half3_c( lightDir ),
+											  half3_c( light1Buf.areaApproxLights[i].diffuse.xyz ) * diffuseMask,
+											  half3_c( light1Buf.areaApproxLights[i].specular.xyz ) * specCol,
 											  pixelData ) * ( globalDot * globalDot ) * booster;
-			float atten = 1.0 / (0.5 + (light1Buf.areaApproxLights[i].attenuation.y + light1Buf.areaApproxLights[i].attenuation.z * fDistance) * fDistance );
+			half atten = half_c( 1.0 / (0.5 + (light1Buf.areaApproxLights[i].attenuation.y + light1Buf.areaApproxLights[i].attenuation.z * fDistance) * fDistance ) );
 
 			@property( obb_restraint_approx )
 				atten *= obbRestraintFade;
@@ -173,38 +173,38 @@
 @end
 
 @piece( DeclareBRDF_AreaLightApprox )
-INLINE float3 BRDF_AreaLightApprox
+INLINE half3 BRDF_AreaLightApprox
 (
-	float3 lightDir, float3 lightDiffuse, float3 lightSpecular, PixelData pixelData
+	half3 lightDir, half3 lightDiffuse, half3 lightSpecular, PixelData pixelData
 )
 {
-	float3 halfWay= normalize( lightDir + pixelData.viewDir );
-	float NdotL = saturate( dot( pixelData.normal, lightDir ) );
-	float VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
+	half3 halfWay= normalize( lightDir + pixelData.viewDir );
+	half NdotL = saturate( dot( pixelData.normal, lightDir ) );
+	half VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
 
 	//Formula:
 	//	fresnelS = lerp( (1 - V*H)^5, 1, F0 )
 	float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 
 	//We should divide Rs by PI, but it was done inside G for performance
-	float3 Rs = fresnelS * pixelData.specular.xyz * lightSpecular;
+	half3 Rs = fresnelS * pixelData.specular.xyz * lightSpecular;
 
 	//Diffuse BRDF (*Normalized* Disney, see course_notes_moving_frostbite_to_pbr.pdf
 	//"Moving Frostbite to Physically Based Rendering" Sebastien Lagarde & Charles de Rousiers)
-	float energyBias	= pixelData.roughness * 0.5;
-	float energyFactor	= lerp( 1.0, 1.0 / 1.51, pixelData.roughness );
-	float fd90			= energyBias + 2.0 * VdotH * VdotH * pixelData.roughness;
-	float lightScatter	= 1.0 + (fd90 - 1.0) * pow( 1.0 - NdotL, 5.0 );
-	float viewScatter	= 1.0 + (fd90 - 1.0) * pow( 1.0 - pixelData.NdotV, 5.0 );
+	half energyBias	= pixelData.roughness * _h( 0.5 );
+	half energyFactor	= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.roughness );
+	half fd90			= energyBias + _h( 2.0 ) * VdotH * VdotH * pixelData.roughness;
+	half lightScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - NdotL, _h( 5.0 ) );
+	half viewScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) );
 
 @property( fresnel_separate_diffuse )
 	float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
 @else
-	float fresnelD = 1.0f - @insertpiece( getMaxFresnelS );
+	half fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
 @end
 
 	//We should divide Rd by PI, but it is already included in kD
-	float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
+	half3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
 
 	return NdotL * (Rs + Rd);
 }

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
@@ -20,7 +20,7 @@
 			SamplerState areaLightMasksSampler		: register(s@value(areaLightMasks));
 		@end
 		@property( syntax == metal )
-			, texture2d_array<float> areaLightMasks	[[texture(@value(areaLightMasks))]]
+			, texture2d_array<midf> areaLightMasks	[[texture(@value(areaLightMasks))]]
 			, sampler areaLightMasksSampler			[[sampler(@value(areaLightMasks))]]
 		@end
 	@end
@@ -102,8 +102,8 @@
 			lightDir = closestPoint.xyz - inPs.pos;
 			fDistance= length( lightDir );
 
-			float3 toShapeLight = reflect( -pixelData.viewDir, pixelData.normal );
-			float denom = dot( toShapeLight, -light1Buf.areaApproxLights[i].direction.xyz );
+			midf3 toShapeLight = reflect( -pixelData.viewDir, pixelData.normal );
+			midf denom = dot( toShapeLight, midf3_c( -light1Buf.areaApproxLights[i].direction.xyz ) );
 			@property( !hlms_lights_area_tex_mask || !hlms_lights_area_tex_colour )
 				midf specCol = _h( 0 );
 			@else
@@ -112,10 +112,10 @@
 			if( denom > 1e-6f || light1Buf.areaApproxLights[i].doubleSided.x != 0.0f )
 			{
 				float3 p0l0 = light1Buf.areaApproxLights[i].position.xyz - inPs.pos;
-				float t = dot( p0l0, -light1Buf.areaApproxLights[i].direction.xyz ) / denom;
+				float t = dot( p0l0, -light1Buf.areaApproxLights[i].direction.xyz ) / float( denom );
 				if( t >= 0 )
 				{
-					float3 posInShape = inPs.pos.xyz + toShapeLight.xyz * t - light1Buf.areaApproxLights[i].position.xyz;
+					float3 posInShape = inPs.pos.xyz + float3( toShapeLight.xyz ) * t - light1Buf.areaApproxLights[i].position.xyz;
 					float2 reflClipSpace;
 					reflClipSpace.x = dot( light1Buf.areaApproxLights[i].tangent.xyz, posInShape );
 					reflClipSpace.y = dot( areaLightBitangent, posInShape );

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
@@ -13,9 +13,9 @@
 		@end
 		@property( syntax == hlsl )
 			@property( !hlms_lights_area_tex_colour )
-				Texture2DArray<float> areaLightMasks	: register(t@value(areaLightMasks));
+				Texture2DArray<half> areaLightMasks	: register(t@value(areaLightMasks));
 			@else
-				Texture2DArray<float3> areaLightMasks	: register(t@value(areaLightMasks));
+				Texture2DArray<half3> areaLightMasks: register(t@value(areaLightMasks));
 			@end
 			SamplerState areaLightMasksSampler		: register(s@value(areaLightMasks));
 		@end

--- a/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AreaLights_piece_ps.any
@@ -13,9 +13,9 @@
 		@end
 		@property( syntax == hlsl )
 			@property( !hlms_lights_area_tex_colour )
-				Texture2DArray<half> areaLightMasks	: register(t@value(areaLightMasks));
+				Texture2DArray<midf> areaLightMasks	: register(t@value(areaLightMasks));
 			@else
-				Texture2DArray<half3> areaLightMasks: register(t@value(areaLightMasks));
+				Texture2DArray<midf3> areaLightMasks: register(t@value(areaLightMasks));
 			@end
 			SamplerState areaLightMasksSampler		: register(s@value(areaLightMasks));
 		@end
@@ -43,7 +43,7 @@
 		fDistance = length( lightDir );
 
 		@property( obb_restraint_approx )
-			half obbRestraintFade = getObbRestraintFade( light1Buf.areaApproxLights[i].obbRestraint, inPs.pos,
+			midf obbRestraintFade = getObbRestraintFade( light1Buf.areaApproxLights[i].obbRestraint, inPs.pos,
 														 light1Buf.areaApproxLights[i].obbFadeFactorApprox.xyz );
 			@piece( obbRestraintTestApprox )&& obbRestraintFade > _h( 0.0 )@end
 		@end
@@ -73,12 +73,12 @@
 			lightUVForTex = clamp( lightUVForTex.xy, -0.5f, 0.5f );
 	//		float booster = 1.0f - smoothstep( 0.2f, 1.9f, max( abs( lightUV.x ), abs( lightUV.y ) ) );
 	//		booster = 1.0f + booster * 2.25f;
-			half booster = lerp( _h( 1.0f ), _h( 4.0f ), pixelData.roughness );
+			midf booster = lerp( _h( 1.0f ), _h( 4.0f ), pixelData.roughness );
 
 		@property( !hlms_lights_area_tex_colour || !hlms_lights_area_tex_mask )
-			half diffuseMask = _h( 1.0f );
+			midf diffuseMask = _h( 1.0f );
 		@else
-			half3 diffuseMask = half3_c( 1.0f, 1.0f, 1.0f );
+			midf3 diffuseMask = midf3_c( 1.0f, 1.0f, 1.0f );
 		@end
 		@property( hlms_lights_area_tex_mask )
 			if( i < floatBitsToInt( light1Buf.numAreaApproxLightsWithMask ) )
@@ -105,9 +105,9 @@
 			float3 toShapeLight = reflect( -pixelData.viewDir, pixelData.normal );
 			float denom = dot( toShapeLight, -light1Buf.areaApproxLights[i].direction.xyz );
 			@property( !hlms_lights_area_tex_mask || !hlms_lights_area_tex_colour )
-				half specCol = _h( 0 );
+				midf specCol = _h( 0 );
 			@else
-				half3 specCol = half3_c( 0, 0, 0 );
+				midf3 specCol = midf3_c( 0, 0, 0 );
 			@end
 			if( denom > 1e-6f || light1Buf.areaApproxLights[i].doubleSided.x != 0.0f )
 			{
@@ -129,9 +129,9 @@
 					specVal = pow( specVal, areaPower ) * min( areaPower * areaPower, 1.0f );
 
 					@property( !hlms_lights_area_tex_mask || !hlms_lights_area_tex_colour )
-						specCol = half_c( specVal );
+						specCol = midf_c( specVal );
 					@else
-						specCol = half3_c( specVal, specVal, specVal );
+						specCol = midf3_c( specVal, specVal, specVal );
 					@end
 
 					@property( hlms_lights_area_tex_mask )
@@ -151,13 +151,13 @@
 			//float fAreaW = dot( lightDir, -light1Buf.areaApproxLights[i].direction.xyz ) * 0.5f + 0.5f;
 			//lightDir = (-light1Buf.areaApproxLights[i].direction.xyz + lightDir) * 0.50f;
 			//lightDir = lerp( lightDir2, lightDir, fAreaW );
-			half globalDot = half_c( saturate( dot( -lightDir, light1Buf.areaApproxLights[i].direction.xyz ) ) );
+			midf globalDot = midf_c( saturate( dot( -lightDir, light1Buf.areaApproxLights[i].direction.xyz ) ) );
 			globalDot = light1Buf.areaApproxLights[i].doubleSided.x != 0.0f ? _h( 1.0f ) : globalDot;
-			tmpColour = BRDF_AreaLightApprox( half3_c( lightDir ),
-											  half3_c( light1Buf.areaApproxLights[i].diffuse.xyz ) * diffuseMask,
-											  half3_c( light1Buf.areaApproxLights[i].specular.xyz ) * specCol,
+			tmpColour = BRDF_AreaLightApprox( midf3_c( lightDir ),
+											  midf3_c( light1Buf.areaApproxLights[i].diffuse.xyz ) * diffuseMask,
+											  midf3_c( light1Buf.areaApproxLights[i].specular.xyz ) * specCol,
 											  pixelData ) * ( globalDot * globalDot ) * booster;
-			half atten = half_c( 1.0 / (0.5 + (light1Buf.areaApproxLights[i].attenuation.y + light1Buf.areaApproxLights[i].attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (light1Buf.areaApproxLights[i].attenuation.y + light1Buf.areaApproxLights[i].attenuation.z * fDistance) * fDistance ) );
 
 			@property( obb_restraint_approx )
 				atten *= obbRestraintFade;
@@ -173,38 +173,38 @@
 @end
 
 @piece( DeclareBRDF_AreaLightApprox )
-INLINE half3 BRDF_AreaLightApprox
+INLINE midf3 BRDF_AreaLightApprox
 (
-	half3 lightDir, half3 lightDiffuse, half3 lightSpecular, PixelData pixelData
+	midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, PixelData pixelData
 )
 {
-	half3 halfWay= normalize( lightDir + pixelData.viewDir );
-	half NdotL = saturate( dot( pixelData.normal, lightDir ) );
-	half VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
+	midf3 halfWay= normalize( lightDir + pixelData.viewDir );
+	midf NdotL = saturate( dot( pixelData.normal, lightDir ) );
+	midf VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
 
 	//Formula:
 	//	fresnelS = lerp( (1 - V*H)^5, 1, F0 )
 	float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 
 	//We should divide Rs by PI, but it was done inside G for performance
-	half3 Rs = fresnelS * pixelData.specular.xyz * lightSpecular;
+	midf3 Rs = fresnelS * pixelData.specular.xyz * lightSpecular;
 
 	//Diffuse BRDF (*Normalized* Disney, see course_notes_moving_frostbite_to_pbr.pdf
 	//"Moving Frostbite to Physically Based Rendering" Sebastien Lagarde & Charles de Rousiers)
-	half energyBias	= pixelData.roughness * _h( 0.5 );
-	half energyFactor	= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.roughness );
-	half fd90			= energyBias + _h( 2.0 ) * VdotH * VdotH * pixelData.roughness;
-	half lightScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - NdotL, _h( 5.0 ) );
-	half viewScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) );
+	midf energyBias	= pixelData.roughness * _h( 0.5 );
+	midf energyFactor	= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.roughness );
+	midf fd90			= energyBias + _h( 2.0 ) * VdotH * VdotH * pixelData.roughness;
+	midf lightScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - NdotL, _h( 5.0 ) );
+	midf viewScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) );
 
 @property( fresnel_separate_diffuse )
 	float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
 @else
-	half fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
+	midf fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
 @end
 
 	//We should divide Rd by PI, but it is already included in kD
-	half3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
+	midf3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz * lightDiffuse;
 
 	return NdotL * (Rs + Rd);
 }

--- a/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
@@ -8,10 +8,10 @@
 	@insertpiece( forward3dHeader )
 
 	@property( hlms_decals_normals && normal_map )
-		half3 finalDecalTsNormal = half3_c( 0.0f, 0.0f, 1.0f );
+		midf3 finalDecalTsNormal = midf3_c( 0.0f, 0.0f, 1.0f );
 	@end
 	@property( hlms_decals_emissive )
-		half3 finalDecalEmissive = half3_c( 0.0f, 0.0f, 0.0f );
+		midf3 finalDecalEmissive = midf3_c( 0.0f, 0.0f, 0.0f );
 	@end
 
 	ushort numLightsInGrid = bufferFetch1( f3dGrid, int(sampleOffset + @value(hlms_forwardplus_decals_slot_offset)u) );
@@ -47,17 +47,17 @@
 
 		@property( hlms_decals_diffuse )
 			ushort decalDiffuseIdx = floatBitsToUint( texIndices.x ) & 0xFFFFu;
-			half4 decalDiffuse = OGRE_SampleArray2DGradF16( decalsDiffuseTex, decalsSampler, decalUV.xy,
+			midf4 decalDiffuse = OGRE_SampleArray2DGradF16( decalsDiffuseTex, decalsSampler, decalUV.xy,
 															decalDiffuseIdx, decalUvDdx, decalUvDdy ).xyzw;
 		@end
 		@property( hlms_decals_normals && normal_map )
 			ushort decalNormalsIdx = floatBitsToUint( texIndices.x ) >> 16u;
-			half2 decalNormals = OGRE_SampleArray2DGradF16( decalsNormalsTex, decalsSampler, decalUV.xy,
+			midf2 decalNormals = OGRE_SampleArray2DGradF16( decalsNormalsTex, decalsSampler, decalUV.xy,
 															decalNormalsIdx, decalUvDdx, decalUvDdy ).xy;
 		@end
 		@property( hlms_decals_emissive )
 			ushort decalEmissiveIdx = floatBitsToUint( texIndices.y ) & 0xFFFFu;
-			half3 decalEmissive = OGRE_SampleArray2DGradF16( decalsEmissiveTex, decalsSampler, decalUV.xy,
+			midf3 decalEmissive = OGRE_SampleArray2DGradF16( decalsEmissiveTex, decalsSampler, decalUV.xy,
 															 decalEmissiveIdx, decalUvDdx, decalUvDdy ).xyz;
 		@end
 
@@ -77,27 +77,27 @@
 		//
 		//Use a smooth fade to avoid flickering due to floating point precision when the normal
 		//and the decal are perpendicular to each other. (tolerance set to 0.0002)
-		half3 decalDir = normalize( half3_c( invWorldView1.xyz ) );
+		midf3 decalDir = normalize( midf3_c( invWorldView1.xyz ) );
 		//isOutsideDecal = dot( decalDir.xyz, inPs.normal.xyz ) <= 0.0 ? true : isOutsideDecal;
-		half normalAway = saturate( (dot( decalDir.xyz, inPs.normal.xyz ) + _h( 0.0002 ) ) / _h( 0.0002 ) );
+		midf normalAway = saturate( (dot( decalDir.xyz, inPs.normal.xyz ) + _h( 0.0002 ) ) / _h( 0.0002 ) );
 		normalAway = isOutsideDecal ? _h( 0.0f ) : normalAway;
 
-		half decalMask = normalAway;
+		midf decalMask = normalAway;
 
 		@property( hlms_decals_diffuse )
 			decalMask *= decalDiffuse.w;
-			half decalMetalness = half_c( texIndices.z );
-			half3 decalF0 = lerp( half3_c( 0.03f, 0.03f, 0.03f ), decalDiffuse.xyz, decalMetalness );
+			midf decalMetalness = midf_c( texIndices.z );
+			midf3 decalF0 = lerp( midf3_c( 0.03f, 0.03f, 0.03f ), decalDiffuse.xyz, decalMetalness );
 			decalDiffuse.xyz = decalDiffuse.xyz - decalDiffuse.xyz * decalMetalness;
 
 			pixelData.diffuse.xyz	= lerp( pixelData.diffuse.xyz, decalDiffuse.xyz * _h( 0.318309886f ), decalMask );
-			pixelData.roughness		= lerp( pixelData.roughness, half_c( texIndices.w ), decalMask );
+			pixelData.roughness		= lerp( pixelData.roughness, midf_c( texIndices.w ), decalMask );
 
 			@property( !metallic_workflow && !fresnel_workflow && !fresnel_scalar )
 				pixelData.specular	= lerp( pixelData.specular.xyz, decalF0, decalMask );
 				pixelData.F0		= lerp( pixelData.F0, decalMetalness, decalMask );
 			@else
-				pixelData.specular	= lerp( pixelData.specular.xyz, half3_c( 1.0f, 1.0f, 1.0f ), decalMask );
+				pixelData.specular	= lerp( pixelData.specular.xyz, midf3_c( 1.0f, 1.0f, 1.0f ), decalMask );
 				pixelData.F0.xyz	= lerp( pixelData.F0.xyz, decalF0.xyz, decalMask );
 			@end
 
@@ -111,7 +111,7 @@
 		@end
 		@property( hlms_decals_emissive )
 			finalDecalEmissive	+= (absLocalPos.x > 0.5f || absLocalPos.y > 0.5f ||
-									absLocalPos.z > 0.5f) ? half3_c( 0.0f, 0.0f, 0.0f ) :
+									absLocalPos.z > 0.5f) ? midf3_c( 0.0f, 0.0f, 0.0f ) :
 															(decalEmissive.xyz * decalMask);
 		@end
 
@@ -140,13 +140,13 @@
 
 	@property( hlms_forwardplus_debug )totalNumLightsInGrid += numLightsInGrid;@end
 
-	half cubemapAccumWeight = _h( 0 );
+	midf cubemapAccumWeight = _h( 0 );
 
-	half3 pccEnvS = half3_c( 0, 0, 0 );
-	half3 pccEnvD = half3_c( 0, 0, 0 );
+	midf3 pccEnvS = midf3_c( 0, 0, 0 );
+	midf3 pccEnvD = midf3_c( 0, 0, 0 );
 
 	@property( clear_coat )
-		half3 clearCoatPccEnvS = half3_c( 0, 0, 0 );
+		midf3 clearCoatPccEnvS = midf3_c( 0, 0, 0 );
 	@end
 
 	@property( vct_num_probes )
@@ -171,8 +171,8 @@
 		float4 probeInnerRange = readOnlyFetch( f3dLightList, int(idx + 6u) ).xyzw;
 		float4 probeOuterRange = readOnlyFetch( f3dLightList, int(idx + 7u) ).xyzw;
 
-		half3 posInProbSpace = half3_c( toProbeLocalSpace( inPs.pos, probe ) );
-		half probeFade = getProbeFade( posInProbSpace, probe );
+		midf3 posInProbSpace = midf3_c( toProbeLocalSpace( inPs.pos, probe ) );
+		midf probeFade = getProbeFade( posInProbSpace, probe );
 
 		if( probeFade > _h( 0 ) )
 		{
@@ -180,16 +180,16 @@
 			float probeCubemapIdx   = cubemapIdx_priority.x;
 			float probePriority     = cubemapIdx_priority.y;
 
-			half3 probeToAreaCenterOffsetLS = half3_c( probe.cubemapPosLS.w,
+			midf3 probeToAreaCenterOffsetLS = midf3_c( probe.cubemapPosLS.w,
 													   probe.cubemapPosVS.w,
 													   probeInnerRange.w );
-			half ndf = getProbeNDF( posInProbSpace.xyz, probeToAreaCenterOffsetLS.xyz,
-									half3_c( probeInnerRange.xyz ), half3_c( probeOuterRange.xyz ) );
+			midf ndf = getProbeNDF( posInProbSpace.xyz, probeToAreaCenterOffsetLS.xyz,
+									midf3_c( probeInnerRange.xyz ), midf3_c( probeOuterRange.xyz ) );
 			ndf = saturate( ndf );
 			probeFade = _h( 1.0 ) - ndf;
 			probeFade = probeFade * probeFade;
 			probeFade = probeFade * probeFade;
-			probeFade *= half_c( probePriority );
+			probeFade *= midf_c( probePriority );
 
 			@property( vct_num_probes )
 				float4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, probe );
@@ -199,10 +199,10 @@
 			@end
 			float3 normalLS = localCorrect( pixelData.normal, posInProbSpace, probe ).xyz;
 
-			half4 pccSingleEnvS;
+			midf4 pccSingleEnvS;
 
 			@property( clear_coat )
-				half3 clearCoatPccSingleEnvS;
+				midf3 clearCoatPccSingleEnvS;
 			@end
 
 			@property( !hlms_cubemaps_use_dpm )
@@ -245,7 +245,7 @@
 
 			pccSingleEnvS.xyz *= probeFade;
 			@property( envmap_scale )
-				pccSingleEnvS.xyz *= half_c( passBuf.ambientUpperHemi.w );
+				pccSingleEnvS.xyz *= midf_c( passBuf.ambientUpperHemi.w );
 			@end
 
 			@property( vct_num_probes )
@@ -292,7 +292,7 @@
 									 pixelData.envColourS * (numProbesVctLerp - accumVctLerp) ) /
 								   numProbesVctLerp;
 		@property( cubemaps_as_diffuse_gi )
-			pixelData.envColourD += vctSpecular.w > 0 ? half3_c( 0, 0, 0 ) : pccEnvD;
+			pixelData.envColourD += vctSpecular.w > 0 ? midf3_c( 0, 0, 0 ) : pccEnvD;
 		@end
 
 		@property( clear_coat )

--- a/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
@@ -192,12 +192,12 @@
 			probeFade *= midf_c( probePriority );
 
 			@property( vct_num_probes )
-				float4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, probe );
-				float3 reflDirLS = reflDirLS_dist.xyz;
+				midf4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, probe );
+				midf3 reflDirLS = reflDirLS_dist.xyz;
 			@else
-				float3 reflDirLS = localCorrect( pixelData.reflDir, posInProbSpace, probe ).xyz;
+				midf3 reflDirLS = localCorrect( pixelData.reflDir, posInProbSpace, probe ).xyz;
 			@end
-			float3 normalLS = localCorrect( pixelData.normal, posInProbSpace, probe ).xyz;
+			midf3 normalLS = localCorrect( pixelData.normal, posInProbSpace, probe ).xyz;
 
 			midf4 pccSingleEnvS;
 
@@ -207,7 +207,7 @@
 
 			@property( !hlms_cubemaps_use_dpm )
 				pccSingleEnvS = OGRE_SampleArrayCubeLevelF16(
-					texEnvProbeMap, samplerState@value(envMapRegSampler), reflDirLS,
+					texEnvProbeMap, samplerState@value(envMapRegSampler), float3( reflDirLS ),
 					probeCubemapIdx, @insertpiece( envSpecularRoughness ) );
 				@property( cubemaps_as_diffuse_gi )
 					pccEnvD += OGRE_SampleArrayCubeLevelF16(
@@ -218,7 +218,7 @@
 
 				@property( clear_coat )
 					clearCoatPccSingleEnvS = OGRE_SampleArrayCubeLevel( texEnvProbeMap, samplerState@value( envMapRegSampler ),
-																		reflDirLS,
+																		float3( reflDirLS ),
 																		probeCubemapIdx,
 																		@insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 					clearCoatPccSingleEnvS *= probeFade;

--- a/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ForwardPlus_DecalsCubemaps_piece_ps.any
@@ -8,10 +8,10 @@
 	@insertpiece( forward3dHeader )
 
 	@property( hlms_decals_normals && normal_map )
-		float3 finalDecalTsNormal = float3( 0.0f, 0.0f, 1.0f );
+		half3 finalDecalTsNormal = half3_c( 0.0f, 0.0f, 1.0f );
 	@end
 	@property( hlms_decals_emissive )
-		float3 finalDecalEmissive = float3( 0.0f, 0.0f, 0.0f );
+		half3 finalDecalEmissive = half3_c( 0.0f, 0.0f, 0.0f );
 	@end
 
 	ushort numLightsInGrid = bufferFetch1( f3dGrid, int(sampleOffset + @value(hlms_forwardplus_decals_slot_offset)u) );
@@ -47,18 +47,18 @@
 
 		@property( hlms_decals_diffuse )
 			ushort decalDiffuseIdx = floatBitsToUint( texIndices.x ) & 0xFFFFu;
-			float4 decalDiffuse = OGRE_SampleArray2DGrad( decalsDiffuseTex, decalsSampler, decalUV.xy,
-														  decalDiffuseIdx, decalUvDdx, decalUvDdy ).xyzw;
+			half4 decalDiffuse = OGRE_SampleArray2DGradF16( decalsDiffuseTex, decalsSampler, decalUV.xy,
+															decalDiffuseIdx, decalUvDdx, decalUvDdy ).xyzw;
 		@end
 		@property( hlms_decals_normals && normal_map )
 			ushort decalNormalsIdx = floatBitsToUint( texIndices.x ) >> 16u;
-			float2 decalNormals = OGRE_SampleArray2DGrad( decalsNormalsTex, decalsSampler, decalUV.xy,
-														  decalNormalsIdx, decalUvDdx, decalUvDdy ).xy;
+			half2 decalNormals = OGRE_SampleArray2DGradF16( decalsNormalsTex, decalsSampler, decalUV.xy,
+															decalNormalsIdx, decalUvDdx, decalUvDdy ).xy;
 		@end
 		@property( hlms_decals_emissive )
 			ushort decalEmissiveIdx = floatBitsToUint( texIndices.y ) & 0xFFFFu;
-			float3 decalEmissive = OGRE_SampleArray2DGrad( decalsEmissiveTex, decalsSampler, decalUV.xy,
-														   decalEmissiveIdx, decalUvDdx, decalUvDdy ).xyz;
+			half3 decalEmissive = OGRE_SampleArray2DGradF16( decalsEmissiveTex, decalsSampler, decalUV.xy,
+															 decalEmissiveIdx, decalUvDdx, decalUvDdy ).xyz;
 		@end
 
 		@property( hlms_decals_diffuse && (hlms_decals_normals || hlms_decals_emissive) )
@@ -77,27 +77,27 @@
 		//
 		//Use a smooth fade to avoid flickering due to floating point precision when the normal
 		//and the decal are perpendicular to each other. (tolerance set to 0.0002)
-		float3 decalDir = normalize( float3( invWorldView1.xyz ) );
+		half3 decalDir = normalize( half3_c( invWorldView1.xyz ) );
 		//isOutsideDecal = dot( decalDir.xyz, inPs.normal.xyz ) <= 0.0 ? true : isOutsideDecal;
-		float normalAway = saturate( (dot( decalDir.xyz, inPs.normal.xyz ) + 0.0002) / 0.0002 );
-		normalAway = isOutsideDecal ? 0.0f : normalAway;
+		half normalAway = saturate( (dot( decalDir.xyz, inPs.normal.xyz ) + _h( 0.0002 ) ) / _h( 0.0002 ) );
+		normalAway = isOutsideDecal ? _h( 0.0f ) : normalAway;
 
-		float decalMask = normalAway;
+		half decalMask = normalAway;
 
 		@property( hlms_decals_diffuse )
 			decalMask *= decalDiffuse.w;
-			float decalMetalness = texIndices.z;
-			float3 decalF0 = lerp( float3( 0.03f, 0.03f, 0.03f ), decalDiffuse.xyz, decalMetalness );
+			half decalMetalness = half_c( texIndices.z );
+			half3 decalF0 = lerp( half3_c( 0.03f, 0.03f, 0.03f ), decalDiffuse.xyz, decalMetalness );
 			decalDiffuse.xyz = decalDiffuse.xyz - decalDiffuse.xyz * decalMetalness;
 
-			pixelData.diffuse.xyz	= lerp( pixelData.diffuse.xyz, decalDiffuse.xyz * 0.318309886f, decalMask );
-			pixelData.roughness		= lerp( pixelData.roughness, texIndices.w, decalMask );
+			pixelData.diffuse.xyz	= lerp( pixelData.diffuse.xyz, decalDiffuse.xyz * _h( 0.318309886f ), decalMask );
+			pixelData.roughness		= lerp( pixelData.roughness, half_c( texIndices.w ), decalMask );
 
 			@property( !metallic_workflow && !fresnel_workflow && !fresnel_scalar )
 				pixelData.specular	= lerp( pixelData.specular.xyz, decalF0, decalMask );
 				pixelData.F0		= lerp( pixelData.F0, decalMetalness, decalMask );
 			@else
-				pixelData.specular	= lerp( pixelData.specular.xyz, float3( 1.0f, 1.0f, 1.0f ), decalMask );
+				pixelData.specular	= lerp( pixelData.specular.xyz, half3_c( 1.0f, 1.0f, 1.0f ), decalMask );
 				pixelData.F0.xyz	= lerp( pixelData.F0.xyz, decalF0.xyz, decalMask );
 			@end
 
@@ -111,7 +111,7 @@
 		@end
 		@property( hlms_decals_emissive )
 			finalDecalEmissive	+= (absLocalPos.x > 0.5f || absLocalPos.y > 0.5f ||
-									absLocalPos.z > 0.5f) ? float3( 0.0f, 0.0f, 0.0f ) :
+									absLocalPos.z > 0.5f) ? half3_c( 0.0f, 0.0f, 0.0f ) :
 															(decalEmissive.xyz * decalMask);
 		@end
 
@@ -140,13 +140,13 @@
 
 	@property( hlms_forwardplus_debug )totalNumLightsInGrid += numLightsInGrid;@end
 
-	float cubemapAccumWeight = 0;
+	half cubemapAccumWeight = _h( 0 );
 
-	float3 pccEnvS = float3( 0, 0, 0 );
-	float3 pccEnvD = float3( 0, 0, 0 );
+	half3 pccEnvS = half3_c( 0, 0, 0 );
+	half3 pccEnvD = half3_c( 0, 0, 0 );
 
 	@property( clear_coat )
-		float3 clearCoatPccEnvS = float3( 0, 0, 0 );
+		half3 clearCoatPccEnvS = half3_c( 0, 0, 0 );
 	@end
 
 	@property( vct_num_probes )
@@ -171,25 +171,25 @@
 		float4 probeInnerRange = readOnlyFetch( f3dLightList, int(idx + 6u) ).xyzw;
 		float4 probeOuterRange = readOnlyFetch( f3dLightList, int(idx + 7u) ).xyzw;
 
-		float3 posInProbSpace = toProbeLocalSpace( inPs.pos, probe );
-		float probeFade = getProbeFade( posInProbSpace, probe );
+		half3 posInProbSpace = half3_c( toProbeLocalSpace( inPs.pos, probe ) );
+		half probeFade = getProbeFade( posInProbSpace, probe );
 
-		if( probeFade > 0 )
+		if( probeFade > _h( 0 ) )
 		{
 			float2 cubemapIdx_priority = unpackUshort2ToFloat2( floatBitsToUint( probe.halfSize.w ) );
 			float probeCubemapIdx   = cubemapIdx_priority.x;
 			float probePriority     = cubemapIdx_priority.y;
 
-			float3 probeToAreaCenterOffsetLS = float3( probe.cubemapPosLS.w,
+			half3 probeToAreaCenterOffsetLS = half3_c( probe.cubemapPosLS.w,
 													   probe.cubemapPosVS.w,
 													   probeInnerRange.w );
-			float ndf = getProbeNDF( posInProbSpace.xyz, probeToAreaCenterOffsetLS.xyz,
-									 probeInnerRange.xyz, probeOuterRange.xyz );
+			half ndf = getProbeNDF( posInProbSpace.xyz, probeToAreaCenterOffsetLS.xyz,
+									half3_c( probeInnerRange.xyz ), half3_c( probeOuterRange.xyz ) );
 			ndf = saturate( ndf );
-			probeFade = 1.0 - ndf;
+			probeFade = _h( 1.0 ) - ndf;
 			probeFade = probeFade * probeFade;
 			probeFade = probeFade * probeFade;
-			probeFade *= probePriority;
+			probeFade *= half_c( probePriority );
 
 			@property( vct_num_probes )
 				float4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, probe );
@@ -199,18 +199,18 @@
 			@end
 			float3 normalLS = localCorrect( pixelData.normal, posInProbSpace, probe ).xyz;
 
-			float4 pccSingleEnvS;
+			half4 pccSingleEnvS;
 
 			@property( clear_coat )
-				float3 clearCoatPccSingleEnvS;
+				half3 clearCoatPccSingleEnvS;
 			@end
 
 			@property( !hlms_cubemaps_use_dpm )
-				pccSingleEnvS = OGRE_SampleArrayCubeLevel(
+				pccSingleEnvS = OGRE_SampleArrayCubeLevelF16(
 					texEnvProbeMap, samplerState@value(envMapRegSampler), reflDirLS,
 					probeCubemapIdx, @insertpiece( envSpecularRoughness ) );
 				@property( cubemaps_as_diffuse_gi )
-					pccEnvD += OGRE_SampleArrayCubeLevel(
+					pccEnvD += OGRE_SampleArrayCubeLevelF16(
 						texEnvProbeMap, samplerState@value(envMapRegSampler), normalLS,
 						probeCubemapIdx, 11.0 ).xyz
 						@insertpiece( ApplyEnvMapScale ) * probeFade;
@@ -224,28 +224,28 @@
 					clearCoatPccSingleEnvS *= probeFade;
 				@end
 			@else
-				pccSingleEnvS = OGRE_SampleArray2DLevel(
+				pccSingleEnvS = OGRE_SampleArray2DLevelF16(
 					texEnvProbeMap, samplerState@value(envMapRegSampler), mapCubemapToDpm( reflDirLS ),
 					probeCubemapIdx, @insertpiece( envSpecularRoughness ) );
 				@property( cubemaps_as_diffuse_gi )
-					pccEnvD += OGRE_SampleArray2DLevel(
+					pccEnvD += OGRE_SampleArray2DLevelF16(
 						texEnvProbeMap, samplerState@value(envMapRegSampler), mapCubemapToDpm( normalLS ),
 						probeCubemapIdx, 11.0 ).xyz
 						@insertpiece( ApplyEnvMapScale ) * probeFade;
 				@end
 
 				@property( clear_coat )
-					clearCoatPccSingleEnvS = OGRE_SampleArray2DLevel( texEnvProbeMap, samplerState@value( envMapRegSampler ),
-																	  mapCubemapToDpm( reflDirLS ),
-																	  probeCubemapIdx,
-																	  @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
+					clearCoatPccSingleEnvS = OGRE_SampleArray2DLevelF16( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+																		 mapCubemapToDpm( reflDirLS ),
+																		 probeCubemapIdx,
+																		 @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 					clearCoatPccSingleEnvS *= probeFade;
 				@end
 			@end
 
 			pccSingleEnvS.xyz *= probeFade;
 			@property( envmap_scale )
-				pccSingleEnvS.xyz *= passBuf.ambientUpperHemi.w;
+				pccSingleEnvS.xyz *= half_c( passBuf.ambientUpperHemi.w );
 			@end
 
 			@property( vct_num_probes )
@@ -278,9 +278,9 @@
 	}
 
 	@property( cubemaps_as_diffuse_gi )
-		pccEnvD.xyz *= cubemapAccumWeight == 0.0f ? 1.0f : (1.0f / cubemapAccumWeight);
+		pccEnvD.xyz *= cubemapAccumWeight == _h( 0.0f ) ? _h( 1.0f ) : (_h( 1.0f ) / cubemapAccumWeight);
 	@end
-	pccEnvS.xyz *= cubemapAccumWeight == 0.0f ? 1.0f : (1.0f / cubemapAccumWeight);
+	pccEnvS.xyz *= cubemapAccumWeight == _h( 0.0f ) ? _h( 1.0f ) : (_h( 1.0f ) / cubemapAccumWeight);
 
 	@property( clear_coat )
 		clearCoatPccEnvS *= cubemapAccumWeight == 0.0f ? 1.0f : ( 1.0f / cubemapAccumWeight );
@@ -292,7 +292,7 @@
 									 pixelData.envColourS * (numProbesVctLerp - accumVctLerp) ) /
 								   numProbesVctLerp;
 		@property( cubemaps_as_diffuse_gi )
-			pixelData.envColourD += vctSpecular.w > 0 ? float3( 0, 0, 0 ) : pccEnvD;
+			pixelData.envColourD += vctSpecular.w > 0 ? half3_c( 0, 0, 0 ) : pccEnvD;
 		@end
 
 		@property( clear_coat )

--- a/Samples/Media/Hlms/Pbs/Any/LightProfiles_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/LightProfiles_piece_ps.any
@@ -44,12 +44,12 @@
 		return (inX >= 0) ? res : 3.14159265359f - res; // Undo range reduction
 	}
 
-	float getPhotometricAttenuation( float cosAngle, float profileIdx OGRE_PHOTOMETRIC_ARG_DECL )
+	half getPhotometricAttenuation( float cosAngle, float profileIdx OGRE_PHOTOMETRIC_ARG_DECL )
 	{
 		//float angle = acos( clamp( cosAngle, -1.0, 1.0 ) ) * ( 1.0 / 3.14159265359f );
 		float angle = fast_acos( clamp( cosAngle, -1.0, 1.0 ) ) * ( 1.0 / 3.14159265359f );
-		return OGRE_SampleLevel( lightProfiles, lightProfilesSampler,
-								 float2( angle, profileIdx ), 0.0 ).r;
+		return OGRE_SampleLevelF16( lightProfiles, lightProfilesSampler,
+									float2( angle, profileIdx ), 0.0 ).r;
 	}
 @end
 

--- a/Samples/Media/Hlms/Pbs/Any/LightProfiles_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/LightProfiles_piece_ps.any
@@ -44,7 +44,7 @@
 		return (inX >= 0) ? res : 3.14159265359f - res; // Undo range reduction
 	}
 
-	half getPhotometricAttenuation( float cosAngle, float profileIdx OGRE_PHOTOMETRIC_ARG_DECL )
+	midf getPhotometricAttenuation( float cosAngle, float profileIdx OGRE_PHOTOMETRIC_ARG_DECL )
 	{
 		//float angle = acos( clamp( cosAngle, -1.0, 1.0 ) ) * ( 1.0 / 3.14159265359f );
 		float angle = fast_acos( clamp( cosAngle, -1.0, 1.0 ) ) * ( 1.0 / 3.14159265359f );

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -84,16 +84,31 @@ INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, Pixe
 	//	Where alpha = NdotH and m = roughness
 	//	R = [ 1 / (m^2 x cos(alpha)^4 ] x [ e^( -tan(alpha)^2 / m^2 ) ]
 	//	R = [ 1 / (m^2 x cos(alpha)^4 ] x [ e^( ( cos(alpha)^2 - 1 )  /  (m^2 cos(alpha)^2 ) ]
+@property( precision_mode == full32 )
 	midf NdotH_sq = NdotH * NdotH;
-	midf roughness_a = _h( 1.0 ) / ( _h( 3.141592654 ) * sqR * NdotH_sq * NdotH_sq );//( 1 / (m^2 x cos(alpha)^4 )
 	midf roughness_b = NdotH_sq - _h( 1.0 );	//( cos(alpha)^2 - 1 )
+@else
+	// Use Lagrange's identity to compute 1 - NdotH_sq with mediump
+	//      ||a x b||^2 = ||a||^2 ||b||^2 - (a . b)^2
+	// since N and H are unit vectors: ||N x H||^2 = 1.0 - NoH^2
+	//
+	// See https://github.com/google/filament/blob/f40b08d826c69df9fca2711841f1a9ecb77386e8/shaders/src/brdf.fs#L55
+	// for details
+	midf3 NcrossH = cross( pixelData.normal, halfWay );
+	midf roughness_b = -dot( NcrossH, NcrossH );//( cos(alpha)^2 - 1 )
+	midf NdotH_sq = roughness_b + _h( 1.0 );
+@end
+	midf roughness_a = _h( 1.0 ) / ( _h( 3.141592654 ) * sqR * NdotH_sq * NdotH_sq );//( 1 / (m^2 x cos(alpha)^4 )
 	midf roughness_c = sqR * NdotH_sq;			//( m^2 cos(alpha)^2 )
 
 	//Avoid Inf * 0 = NaN; we need Inf * 0 = 0
 	midf R = min( roughness_a, _h( 65504.0 ) ) * exp( roughness_b / roughness_c );
 
+	ensureValidRangeF16( R );
+
 	//Geometric/Visibility term (Cook Torrance)
 	midf shared_geo = _h( 2.0 ) * NdotH / VdotH;
+	ensureValidRangeF16( shared_geo );
 	midf geo_b	= shared_geo * pixelData.NdotV;
 	midf geo_c	= shared_geo * NdotL;
 	midf G	 	= min( _h( 1.0 ), min( geo_b, geo_c ) );
@@ -102,18 +117,18 @@ INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, Pixe
 	//Formula:
 	//	fresnelS = lerp( (1 - V*H)^5, 1, F0 )
 	//	fresnelD = lerp( (1 - N*L)^5, 1, 1 - F0 ) [See s2010_course_note_practical_implementation_at_triace.pdf]
-    float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
-    @property( fresnel_separate_diffuse )
-        float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
-    @else
+	float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
+	@property( fresnel_separate_diffuse )
+		float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
+	@else
 		midf fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
-    @end
+	@end
 
 	//Avoid very small denominators, they go to NaN or cause aliasing artifacts
 	float_fresnel Rs = ( fresnelS * (R * G)  ) / max( _h( 4.0 ) * pixelData.NdotV * NdotL, _h( 0.01 ) );
 
-    return NdotL * (pixelData.specular.xyz * lightSpecular * Rs +
-                    pixelData.diffuse.xyz * lightDiffuse * fresnelD);
+	return NdotL * (pixelData.specular.xyz * lightSpecular * Rs +
+					pixelData.diffuse.xyz * lightDiffuse * fresnelD);
 }
 @end
 @end
@@ -130,13 +145,6 @@ INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, Pixe
 
 	midf sqR = pixelData.roughness * pixelData.roughness;
 
-	//Roughness/Distribution/NDF term (GGX)
-	//Formula:
-	//	Where alpha = roughness
-	//	R = alpha^2 / [ PI * [ ( NdotH^2 * (alpha^2 - 1) ) + 1 ]^2 ]
-	midf f = ( NdotH * sqR - NdotH ) * NdotH + _h( 1.0 );
-	midf R = sqR / (f * f); // f is guaranteed to not be 0 because we clamped pixelData.roughness
-
 	//Geometric/Visibility term (Smith GGX Height-Correlated)
 @property( GGX_height_correlated )
 	midf Lambda_GGXV = NdotL * sqrt( (-pixelData.NdotV * sqR + pixelData.NdotV) * pixelData.NdotV + sqR );
@@ -146,7 +154,31 @@ INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, Pixe
 @else
 	midf gL = NdotL * ( _h( 1 ) - sqR ) + sqR;
 	midf gV = pixelData.NdotV * ( _h( 1 ) - sqR ) + sqR;
-	midf G = 1.0 / (( gL * gV + _h( 1e-4f ) ) * _h( 4 * 3.141592654 ) );
+	midf G = _h( 1.0 ) / (( gL * gV + _h( 1e-4f ) ) * _h( 4 * 3.141592654 ) );
+@end
+
+@property( precision_mode == full32 )
+	//Roughness/Distribution/NDF term (GGX)
+	//Formula:
+	//	Where alpha = roughness
+	//	R = alpha^2 / [ PI * [ ( NdotH^2 * (alpha^2 - 1) ) + 1 ]^2 ]
+	const midf f = ( NdotH * sqR - NdotH ) * NdotH + _h( 1.0 );
+	midf R = sqR / (f * f); // f is guaranteed to not be 0 because we clamped pixelData.roughness
+
+	const midf RG = R * G;
+@else
+	// Lagrange identity
+	const midf3 NcrossH = cross( pixelData.normal, halfWay );
+	const midf roughness_b = dot( NcrossH, NcrossH ); // 1.0 - NdotH * NdotH
+
+	// We need to do 10000 / (100 * 100) because otherwise it flushes to 0, loosing a lot of info
+	const midf f = (-roughness_b * sqR + sqR + roughness_b) * _h( 100.0 ) ;
+	midf R = sqR * _h( 10000.0 ) / (f * f);
+
+	// Avoid INF and NaNs
+	R = min( R, _h( 128.0 ) );
+	G = min( G, _h( 128.0 ) );
+	const midf RG = R * G;
 @end
 
 	//Formula:
@@ -154,7 +186,7 @@ INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, Pixe
     float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 
 	//We should divide Rs by PI, but it was done inside G for performance
-	midf3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz;
+	midf3 Rs = ( fresnelS * RG ) * pixelData.specular.xyz;
 
 	//Diffuse BRDF (*Normalized* Disney, see course_notes_moving_frostbite_to_pbr.pdf
 	//"Moving Frostbite to Physically Based Rendering" Sebastien Lagarde & Charles de Rousiers)

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -6,10 +6,10 @@
 //	getDiffuseFresnel	= 1.0 - F0 + pow( 1.0 - NdotL, 5.0 ) * F0
 //	getSpecularFresnelWithRoughness = F0 + pow( 1.0 - VdotH, 5.0 ) * (max(roughness, (1.0 - F0)) - F0)
 //	getDiffuseFresnelWithRoughness = max(roughness, (1.0 - F0) - F0 + pow( 1.0 - NdotL, 5.0 ) * F0
-@piece( getSpecularFresnel )pixelData.F0 + pow( 1.0 - VdotH, 5.0 ) * (1.0 - pixelData.F0)@end
-@piece( getDiffuseFresnel )1.0 - pixelData.F0 + pow( 1.0 - NdotL, 5.0 ) * pixelData.F0@end
-@piece( getSpecularFresnelWithRoughness )pixelData.F0 + pow( 1.0 - pixelData.NdotV, 5.0 ) * (max( make_float_fresnel( 1.0 - pixelData.roughness ), pixelData.F0 ) - pixelData.F0)@end
-@piece( getDiffuseFresnelWithRoughness )max( make_float_fresnel( 1.0 - pixelData.roughness ), pixelData.F0 ) - pixelData.F0 + pow( 1.0 - NdotL, 5.0 ) * pixelData.F0@end
+@piece( getSpecularFresnel )pixelData.F0 + pow( _h( 1.0 ) - VdotH, _h( 5.0 ) ) * (_h( 1.0 ) - pixelData.F0)@end
+@piece( getDiffuseFresnel )1.0 - pixelData.F0 + pow( _h( 1.0 ) - NdotL, 5.0 ) * pixelData.F0@end
+@piece( getSpecularFresnelWithRoughness )pixelData.F0 + pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) ) * (max( make_float_fresnel( _h( 1.0 ) - pixelData.roughness ), pixelData.F0 ) - pixelData.F0)@end
+@piece( getDiffuseFresnelWithRoughness )max( make_float_fresnel( _h( 1.0 ) - pixelData.roughness ), pixelData.F0 ) - pixelData.F0 + pow( _h( 1.0 ) - NdotL, _h( 5.0 ) ) * pixelData.F0@end
 
 @property( !fresnel_scalar )
 	@piece( getMaxFresnelS )fresnelS@end
@@ -22,7 +22,7 @@
 //Blinn-Phong
 INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, PixelData pixelData )
 {
-    float3 halfWay = normalize( lightDir + pixelData.viewDir );
+	float3 halfWay = normalize( lightDir + pixelData.viewDir );
     float NdotL = saturate( dot( pixelData.normal, lightDir ) );			//Diffuse (Lambert)
     float NdotH = clamp( dot( pixelData.normal, halfWay ), 0.001, 1.0 );	//Specular
 	@property( !legacy_math_brdf )
@@ -121,32 +121,32 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
 @property( BRDF_Default )
 @piece( DeclareBRDF )
 //Default BRDF
-INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, PixelData pixelData )
+INLINE half3 BRDF( half3 lightDir, half3 lightDiffuse, half3 lightSpecular, PixelData pixelData )
 {
-    float3 halfWay = normalize( lightDir + pixelData.viewDir );
-    float NdotL = saturate( dot( pixelData.normal, lightDir ) );
-    float NdotH = saturate( dot( pixelData.normal, halfWay ) );
-    float VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
+	half3 halfWay = normalize( lightDir + pixelData.viewDir );
+	half NdotL = saturate( dot( pixelData.normal, lightDir ) );
+	half NdotH = saturate( dot( pixelData.normal, halfWay ) );
+	half VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
 
-    float sqR = pixelData.roughness * pixelData.roughness;
+	half sqR = pixelData.roughness * pixelData.roughness;
 
 	//Roughness/Distribution/NDF term (GGX)
 	//Formula:
 	//	Where alpha = roughness
 	//	R = alpha^2 / [ PI * [ ( NdotH^2 * (alpha^2 - 1) ) + 1 ]^2 ]
-	float f = ( NdotH * sqR - NdotH ) * NdotH + 1.0;
-	float R = sqR / (f * f); // f is guaranteed to not be 0 because we clamped pixelData.roughness
+	half f = ( NdotH * sqR - NdotH ) * NdotH + _h( 1.0 );
+	half R = sqR / (f * f); // f is guaranteed to not be 0 because we clamped pixelData.roughness
 
 	//Geometric/Visibility term (Smith GGX Height-Correlated)
 @property( GGX_height_correlated )
-    float Lambda_GGXV = NdotL * sqrt( (-pixelData.NdotV * sqR + pixelData.NdotV) * pixelData.NdotV + sqR );
-    float Lambda_GGXL = pixelData.NdotV * sqrt( (-NdotL * sqR + NdotL) * NdotL + sqR );
+	half Lambda_GGXV = NdotL * sqrt( (-pixelData.NdotV * sqR + pixelData.NdotV) * pixelData.NdotV + sqR );
+	half Lambda_GGXL = pixelData.NdotV * sqrt( (-NdotL * sqR + NdotL) * NdotL + sqR );
 
-	float G = 0.5 / (( Lambda_GGXV + Lambda_GGXL + 1e-6f ) * 3.141592654);
+	half G = _h( 0.5 ) / (( Lambda_GGXV + Lambda_GGXL + _h( 1e-6f ) ) * _h( 3.141592654 ));
 @else
-	float gL = NdotL * (1-sqR) + sqR;
-    float gV = pixelData.NdotV * (1-sqR) + sqR;
-	float G = 1.0 / (( gL * gV + 1e-4f ) * 4 * 3.141592654);
+	half gL = NdotL * ( _h( 1 ) - sqR ) + sqR;
+	half gV = pixelData.NdotV * ( _h( 1 ) - sqR ) + sqR;
+	half G = 1.0 / (( gL * gV + _h( 1e-4f ) ) * _h( 4 * 3.141592654 ) );
 @end
 
 	//Formula:
@@ -154,38 +154,38 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
     float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 
 	//We should divide Rs by PI, but it was done inside G for performance
-    float3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz;
+	half3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz;
 
 	//Diffuse BRDF (*Normalized* Disney, see course_notes_moving_frostbite_to_pbr.pdf
 	//"Moving Frostbite to Physically Based Rendering" Sebastien Lagarde & Charles de Rousiers)
-    float energyBias	= pixelData.perceptualRoughness * 0.5;
-    float energyFactor	= lerp( 1.0, 1.0 / 1.51, pixelData.perceptualRoughness );
-    float fd90			= energyBias + 2.0 * VdotH * VdotH * pixelData.perceptualRoughness;
-	float lightScatter	= 1.0 + (fd90 - 1.0) * pow( 1.0 - NdotL, 5.0 );
-    float viewScatter	= 1.0 + (fd90 - 1.0) * pow( 1.0 - pixelData.NdotV, 5.0 );
+	half energyBias	= pixelData.perceptualRoughness * _h( 0.5 );
+	half energyFactor	= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.perceptualRoughness );
+	half fd90			= energyBias + _h( 2.0 ) * VdotH * VdotH * pixelData.perceptualRoughness;
+	half lightScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - NdotL, _h( 5.0 ) );
+	half viewScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) );
 
     @property( fresnel_separate_diffuse )
         float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
     @else
-        float fresnelD = 1.0f - @insertpiece( getMaxFresnelS );
+		half fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
     @end
 
 	//We should divide Rd by PI, but it is already included in kD
-    float3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz;
+	half3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz;
 
 	@property( clear_coat )
-		float3 color = Rd + Rs;
+		half3 color = Rd + Rs;
 
-		float Fcc;
-		float clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
-		float attenuation = 1.0 - Fcc;
+		half Fcc;
+		half clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
+		half attenuation = _h( 1.0 ) - Fcc;
 
 		@property( normal_map )
 			color *= attenuation * NdotL;
 
 			// If the material has a normal map, we want to use the geometric normal
 			// instead to avoid applying the normal map details to the clear coat layer
-			float clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
+			half clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
 			color += clearCoat * clearCoatNoL;
 
 			return color * lightSpecular;
@@ -196,7 +196,7 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
 			return color * lightSpecular * NdotL;
 		@end
 	@else
-	return NdotL * (Rs * lightSpecular + Rd * lightDiffuse);
+		return NdotL * (Rs * lightSpecular + Rd * lightDiffuse);
 	@end
 }
 @end
@@ -239,22 +239,22 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
 
 	@property( ltc_texture_available )
 		#define brdfLUT ltcMatrix
-		float2 envBRDF = OGRE_SampleArray2D( brdfLUT, ltcSampler,
-											 float2( pixelData.NdotV,
-													 1.0 - pixelData.perceptualRoughness ), 2 ).xy;
+		half2 envBRDF = OGRE_SampleArray2DF16( brdfLUT, ltcSampler,
+											   float2( pixelData.NdotV,
+													   1.0 - pixelData.perceptualRoughness ), 2 ).xy;
 	@else
-		float2 envBRDF = float2( 1.0f, 0.0f );
+		half2 envBRDF = half2( 1.0f, 0.0f );
 	@end
 
 	@property( fresnel_separate_diffuse )
-		float NdotL = saturate( dot( pixelData.normal, pixelData.reflDir ) );
+		half NdotL = saturate( dot( pixelData.normal, pixelData.reflDir ) );
 		float_fresnel fresnelD = @insertpiece( getDiffuseFresnelWithRoughness );
 	@else
-		float fresnelD = 1.0f - @insertpiece( getMaxFresnelS );
+		half fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
 	@end
 
-	float3 Rd = pixelData.envColourD * pixelData.diffuse.xyz * fresnelD;
-	float3 Rs = pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
+	half3 Rd = pixelData.envColourD * pixelData.diffuse.xyz * fresnelD;
+	half3 Rs = pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
 
 	@property( clear_coat )
 		@property( normal_map )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -121,32 +121,32 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
 @property( BRDF_Default )
 @piece( DeclareBRDF )
 //Default BRDF
-INLINE half3 BRDF( half3 lightDir, half3 lightDiffuse, half3 lightSpecular, PixelData pixelData )
+INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, PixelData pixelData )
 {
-	half3 halfWay = normalize( lightDir + pixelData.viewDir );
-	half NdotL = saturate( dot( pixelData.normal, lightDir ) );
-	half NdotH = saturate( dot( pixelData.normal, halfWay ) );
-	half VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
+	midf3 halfWay = normalize( lightDir + pixelData.viewDir );
+	midf NdotL = saturate( dot( pixelData.normal, lightDir ) );
+	midf NdotH = saturate( dot( pixelData.normal, halfWay ) );
+	midf VdotH = saturate( dot( pixelData.viewDir, halfWay ) );
 
-	half sqR = pixelData.roughness * pixelData.roughness;
+	midf sqR = pixelData.roughness * pixelData.roughness;
 
 	//Roughness/Distribution/NDF term (GGX)
 	//Formula:
 	//	Where alpha = roughness
 	//	R = alpha^2 / [ PI * [ ( NdotH^2 * (alpha^2 - 1) ) + 1 ]^2 ]
-	half f = ( NdotH * sqR - NdotH ) * NdotH + _h( 1.0 );
-	half R = sqR / (f * f); // f is guaranteed to not be 0 because we clamped pixelData.roughness
+	midf f = ( NdotH * sqR - NdotH ) * NdotH + _h( 1.0 );
+	midf R = sqR / (f * f); // f is guaranteed to not be 0 because we clamped pixelData.roughness
 
 	//Geometric/Visibility term (Smith GGX Height-Correlated)
 @property( GGX_height_correlated )
-	half Lambda_GGXV = NdotL * sqrt( (-pixelData.NdotV * sqR + pixelData.NdotV) * pixelData.NdotV + sqR );
-	half Lambda_GGXL = pixelData.NdotV * sqrt( (-NdotL * sqR + NdotL) * NdotL + sqR );
+	midf Lambda_GGXV = NdotL * sqrt( (-pixelData.NdotV * sqR + pixelData.NdotV) * pixelData.NdotV + sqR );
+	midf Lambda_GGXL = pixelData.NdotV * sqrt( (-NdotL * sqR + NdotL) * NdotL + sqR );
 
-	half G = _h( 0.5 ) / (( Lambda_GGXV + Lambda_GGXL + _h( 1e-6f ) ) * _h( 3.141592654 ));
+	midf G = _h( 0.5 ) / (( Lambda_GGXV + Lambda_GGXL + _h( 1e-6f ) ) * _h( 3.141592654 ));
 @else
-	half gL = NdotL * ( _h( 1 ) - sqR ) + sqR;
-	half gV = pixelData.NdotV * ( _h( 1 ) - sqR ) + sqR;
-	half G = 1.0 / (( gL * gV + _h( 1e-4f ) ) * _h( 4 * 3.141592654 ) );
+	midf gL = NdotL * ( _h( 1 ) - sqR ) + sqR;
+	midf gV = pixelData.NdotV * ( _h( 1 ) - sqR ) + sqR;
+	midf G = 1.0 / (( gL * gV + _h( 1e-4f ) ) * _h( 4 * 3.141592654 ) );
 @end
 
 	//Formula:
@@ -154,38 +154,38 @@ INLINE half3 BRDF( half3 lightDir, half3 lightDiffuse, half3 lightSpecular, Pixe
     float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 
 	//We should divide Rs by PI, but it was done inside G for performance
-	half3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz;
+	midf3 Rs = ( fresnelS * (R * G) ) * pixelData.specular.xyz;
 
 	//Diffuse BRDF (*Normalized* Disney, see course_notes_moving_frostbite_to_pbr.pdf
 	//"Moving Frostbite to Physically Based Rendering" Sebastien Lagarde & Charles de Rousiers)
-	half energyBias	= pixelData.perceptualRoughness * _h( 0.5 );
-	half energyFactor	= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.perceptualRoughness );
-	half fd90			= energyBias + _h( 2.0 ) * VdotH * VdotH * pixelData.perceptualRoughness;
-	half lightScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - NdotL, _h( 5.0 ) );
-	half viewScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) );
+	midf energyBias	= pixelData.perceptualRoughness * _h( 0.5 );
+	midf energyFactor	= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.perceptualRoughness );
+	midf fd90			= energyBias + _h( 2.0 ) * VdotH * VdotH * pixelData.perceptualRoughness;
+	midf lightScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - NdotL, _h( 5.0 ) );
+	midf viewScatter	= _h( 1.0 ) + (fd90 - _h( 1.0 )) * pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) );
 
     @property( fresnel_separate_diffuse )
         float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
     @else
-		half fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
+		midf fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
     @end
 
 	//We should divide Rd by PI, but it is already included in kD
-	half3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz;
+	midf3 Rd = (lightScatter * viewScatter * energyFactor * fresnelD) * pixelData.diffuse.xyz;
 
 	@property( clear_coat )
-		half3 color = Rd + Rs;
+		midf3 color = Rd + Rs;
 
-		half Fcc;
-		half clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
-		half attenuation = _h( 1.0 ) - Fcc;
+		midf Fcc;
+		midf clearCoat = clearCoatLobe(pixelData, halfWay, NdotH, VdotH, Fcc);
+		midf attenuation = _h( 1.0 ) - Fcc;
 
 		@property( normal_map )
 			color *= attenuation * NdotL;
 
 			// If the material has a normal map, we want to use the geometric normal
 			// instead to avoid applying the normal map details to the clear coat layer
-			half clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
+			midf clearCoatNoL = saturate(dot(pixelData.geomNormal, lightDir));
 			color += clearCoat * clearCoatNoL;
 
 			return color * lightSpecular;
@@ -205,9 +205,9 @@ INLINE half3 BRDF( half3 lightDir, half3 lightDiffuse, half3 lightSpecular, Pixe
 @property( hlms_enable_vpls )
 @piece( DeclareBRDF_InstantRadiosity )
 //Simplified cheap BRDF for Instant Radiosity.
-half3 BRDF_IR( half3 lightDir, half3 lightDiffuse, PixelData pixelData )
+midf3 BRDF_IR( midf3 lightDir, midf3 lightDiffuse, PixelData pixelData )
 {
-	half NdotL = saturate( dot( pixelData.normal, lightDir ) );
+	midf NdotL = saturate( dot( pixelData.normal, lightDir ) );
     float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
 
 	//We should divide Rd by PI, but it is already included in kD
@@ -239,22 +239,22 @@ half3 BRDF_IR( half3 lightDir, half3 lightDiffuse, PixelData pixelData )
 
 	@property( ltc_texture_available )
 		#define brdfLUT ltcMatrix
-		half2 envBRDF = OGRE_SampleArray2DF16( brdfLUT, ltcSampler,
+		midf2 envBRDF = OGRE_SampleArray2DF16( brdfLUT, ltcSampler,
 											   float2( pixelData.NdotV,
 													   1.0 - pixelData.perceptualRoughness ), 2 ).xy;
 	@else
-		half2 envBRDF = half2_c( 1.0f, 0.0f );
+		midf2 envBRDF = midf2_c( 1.0f, 0.0f );
 	@end
 
 	@property( fresnel_separate_diffuse )
-		half NdotL = saturate( dot( pixelData.normal, pixelData.reflDir ) );
+		midf NdotL = saturate( dot( pixelData.normal, pixelData.reflDir ) );
 		float_fresnel fresnelD = @insertpiece( getDiffuseFresnelWithRoughness );
 	@else
-		half fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
+		midf fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
 	@end
 
-	half3 Rd = pixelData.envColourD * pixelData.diffuse.xyz * fresnelD;
-	half3 Rs = pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
+	midf3 Rd = pixelData.envColourD * pixelData.diffuse.xyz * fresnelD;
+	midf3 Rs = pixelData.envColourS * pixelData.specular.xyz * ( fresnelS * envBRDF.x + envBRDF.y );
 
 	@property( clear_coat )
 		@property( normal_map )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -20,45 +20,45 @@
 @property( BRDF_BlinnPhong )
 @piece( DeclareBRDF )
 //Blinn-Phong
-INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, PixelData pixelData )
+INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, PixelData pixelData )
 {
-	float3 halfWay = normalize( lightDir + pixelData.viewDir );
-    float NdotL = saturate( dot( pixelData.normal, lightDir ) );			//Diffuse (Lambert)
-    float NdotH = clamp( dot( pixelData.normal, halfWay ), 0.001, 1.0 );	//Specular
+	midf3 halfWay = normalize( lightDir + pixelData.viewDir );
+	midf NdotL = saturate( dot( pixelData.normal, lightDir ) );						//Diffuse (Lambert)
+	midf NdotH = clamp( dot( pixelData.normal, halfWay ), _h( 0.001 ), _h( 1.0 ) );	//Specular
 	@property( !legacy_math_brdf )
-        float VdotH = clamp( dot( pixelData.viewDir, halfWay ), 0.001, 1.0 ); //Fresnel
+		midf VdotH = clamp( dot( pixelData.viewDir, halfWay ), _h( 0.001 ), _h( 1.0 ) ); //Fresnel
 
 		//Fresnel term (Schlick's approximation)
         float_fresnel fresnelS = @insertpiece( getSpecularFresnel );
 		@property( fresnel_separate_diffuse )
             float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
         @else
-			float fresnelD = 1.0f - @insertpiece( getMaxFresnelS );
+			midf fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
 		@end
 	@end
 
 	@property( !roughness_is_shininess )
-        float shininess = exp2( 10.0 * (1.0 - pixelData.roughness) + 1.0 ) * 0.25;
+		midf shininess = exp2( _h( 10.0 ) * (_h( 1.0 ) - pixelData.roughness) + _h( 1.0 ) ) * _h( 0.25 );
     @else
-        float shininess = pixelData.roughness;
+		midf shininess = pixelData.roughness;
 	@end
-	float blinnPhong = pow( NdotH, shininess );
+	midf blinnPhong = pow( NdotH, shininess );
 
 	@property( !legacy_math_brdf )
 		//Normalize Blinn-Phong using (n + 8) / (8 * pi)
 		//Note this factor is an approximation. The real normalization is
 		//*much* more expensive. See:
 		//http://www.rorydriscoll.com/2009/01/25/energy-conservation-in-games/
-		blinnPhong *= (shininess + 8.0) / (8.0 * 3.141592654);
+		blinnPhong *= ( shininess + _h( 8.0 ) ) / _h( 8.0 * 3.141592654 );
 
 		//Avoid very small denominators, they go to NaN or cause aliasing artifacts
 		//Note: For blinn-phong we use larger denominators otherwise specular blows out of proportion
-        float_fresnel Rs = ( fresnelS * blinnPhong ) / max( 4.0 * pixelData.NdotV * NdotL, 0.75 );
+		float_fresnel Rs = ( fresnelS * blinnPhong ) / max( _h( 4.0 ) * pixelData.NdotV * NdotL, _h( 0.75 ) );
 		//Make diffuse look closer to Default.
-        fresnelD *= lerp( 1.0, 1.0 / 1.51, pixelData.roughness );
+		fresnelD *= lerp( _h( 1.0 ), _h( 1.0 / 1.51 ), pixelData.roughness );
     @else
-		float Rs = blinnPhong;
-		float fresnelD = 1.0;
+		midf Rs = blinnPhong;
+		midf fresnelD = _h( 1.0 );
 	@end
 
     return NdotL * (pixelData.specular.xyz * lightSpecular * Rs +
@@ -70,33 +70,33 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
 @property( BRDF_CookTorrance )
 @piece( DeclareBRDF )
 //Cook-Torrance
-INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, PixelData pixelData )
+INLINE midf3 BRDF( midf3 lightDir, midf3 lightDiffuse, midf3 lightSpecular, PixelData pixelData )
 {
-    float3 halfWay = normalize( lightDir + pixelData.viewDir );
-    float NdotL = saturate( dot( pixelData.normal, lightDir ) );
-    float NdotH = clamp( dot( pixelData.normal, halfWay ), 0.001, 1.0 );
-    float VdotH = clamp( dot( pixelData.viewDir, halfWay ), 0.001, 1.0 );
+	midf3 halfWay = normalize( lightDir + pixelData.viewDir );
+	midf NdotL = saturate( dot( pixelData.normal, lightDir ) );
+	midf NdotH = clamp( dot( pixelData.normal, halfWay ), _h( 0.001 ), _h( 1.0 ) );
+	midf VdotH = clamp( dot( pixelData.viewDir, halfWay ), _h( 0.001 ), _h( 1.0 ) );
 
-    float sqR = pixelData.roughness * pixelData.roughness;
+	midf sqR = pixelData.roughness * pixelData.roughness;
 
 	//Roughness/Distribution/NDF term (Beckmann distribution)
 	//Formula:
 	//	Where alpha = NdotH and m = roughness
 	//	R = [ 1 / (m^2 x cos(alpha)^4 ] x [ e^( -tan(alpha)^2 / m^2 ) ]
 	//	R = [ 1 / (m^2 x cos(alpha)^4 ] x [ e^( ( cos(alpha)^2 - 1 )  /  (m^2 cos(alpha)^2 ) ]
-	float NdotH_sq = NdotH * NdotH;
-	float roughness_a = 1.0 / ( 3.141592654 * sqR * NdotH_sq * NdotH_sq );//( 1 / (m^2 x cos(alpha)^4 )
-	float roughness_b = NdotH_sq - 1.0;	//( cos(alpha)^2 - 1 )
-	float roughness_c = sqR * NdotH_sq;		//( m^2 cos(alpha)^2 )
+	midf NdotH_sq = NdotH * NdotH;
+	midf roughness_a = _h( 1.0 ) / ( _h( 3.141592654 ) * sqR * NdotH_sq * NdotH_sq );//( 1 / (m^2 x cos(alpha)^4 )
+	midf roughness_b = NdotH_sq - _h( 1.0 );	//( cos(alpha)^2 - 1 )
+	midf roughness_c = sqR * NdotH_sq;			//( m^2 cos(alpha)^2 )
 
 	//Avoid Inf * 0 = NaN; we need Inf * 0 = 0
-	float R = min( roughness_a, 65504.0 ) * exp( roughness_b / roughness_c );
+	midf R = min( roughness_a, _h( 65504.0 ) ) * exp( roughness_b / roughness_c );
 
 	//Geometric/Visibility term (Cook Torrance)
-	float shared_geo = 2.0 * NdotH / VdotH;
-    float geo_b	= shared_geo * pixelData.NdotV;
-	float geo_c	= shared_geo * NdotL;
-	float G	 	= min( 1.0, min( geo_b, geo_c ) );
+	midf shared_geo = _h( 2.0 ) * NdotH / VdotH;
+	midf geo_b	= shared_geo * pixelData.NdotV;
+	midf geo_c	= shared_geo * NdotL;
+	midf G	 	= min( _h( 1.0 ), min( geo_b, geo_c ) );
 
 	//Fresnel term (Schlick's approximation)
 	//Formula:
@@ -106,11 +106,11 @@ INLINE float3 BRDF( float3 lightDir, float3 lightDiffuse, float3 lightSpecular, 
     @property( fresnel_separate_diffuse )
         float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
     @else
-        float fresnelD = 1.0f - @insertpiece( getMaxFresnelS );
+		midf fresnelD = _h( 1.0f ) - @insertpiece( getMaxFresnelS );
     @end
 
 	//Avoid very small denominators, they go to NaN or cause aliasing artifacts
-    float_fresnel Rs = ( fresnelS * (R * G)  ) / max( 4.0 * pixelData.NdotV * NdotL, 0.01 );
+	float_fresnel Rs = ( fresnelS * (R * G)  ) / max( _h( 4.0 ) * pixelData.NdotV * NdotL, _h( 0.01 ) );
 
     return NdotL * (pixelData.specular.xyz * lightSpecular * Rs +
                     pixelData.diffuse.xyz * lightDiffuse * fresnelD);

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -7,7 +7,7 @@
 //	getSpecularFresnelWithRoughness = F0 + pow( 1.0 - VdotH, 5.0 ) * (max(roughness, (1.0 - F0)) - F0)
 //	getDiffuseFresnelWithRoughness = max(roughness, (1.0 - F0) - F0 + pow( 1.0 - NdotL, 5.0 ) * F0
 @piece( getSpecularFresnel )pixelData.F0 + pow( _h( 1.0 ) - VdotH, _h( 5.0 ) ) * (_h( 1.0 ) - pixelData.F0)@end
-@piece( getDiffuseFresnel )1.0 - pixelData.F0 + pow( _h( 1.0 ) - NdotL, 5.0 ) * pixelData.F0@end
+@piece( getDiffuseFresnel )_h( 1.0 ) - pixelData.F0 + pow( _h( 1.0 ) - NdotL, _h( 5.0 ) ) * pixelData.F0@end
 @piece( getSpecularFresnelWithRoughness )pixelData.F0 + pow( _h( 1.0 ) - pixelData.NdotV, _h( 5.0 ) ) * (max( make_float_fresnel( _h( 1.0 ) - pixelData.roughness ), pixelData.F0 ) - pixelData.F0)@end
 @piece( getDiffuseFresnelWithRoughness )max( make_float_fresnel( _h( 1.0 ) - pixelData.roughness ), pixelData.F0 ) - pixelData.F0 + pow( _h( 1.0 ) - NdotL, _h( 5.0 ) ) * pixelData.F0@end
 
@@ -205,9 +205,9 @@ INLINE half3 BRDF( half3 lightDir, half3 lightDiffuse, half3 lightSpecular, Pixe
 @property( hlms_enable_vpls )
 @piece( DeclareBRDF_InstantRadiosity )
 //Simplified cheap BRDF for Instant Radiosity.
-float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
+half3 BRDF_IR( half3 lightDir, half3 lightDiffuse, PixelData pixelData )
 {
-    float NdotL = clamp( dot( pixelData.normal, lightDir ), 0.0, 1.0 );
+	half NdotL = saturate( dot( pixelData.normal, lightDir ) );
     float_fresnel fresnelD = @insertpiece( getDiffuseFresnel );
 
 	//We should divide Rd by PI, but it is already included in kD
@@ -243,7 +243,7 @@ float3 BRDF_IR( float3 lightDir, float3 lightDiffuse, PixelData pixelData )
 											   float2( pixelData.NdotV,
 													   1.0 - pixelData.perceptualRoughness ), 2 ).xy;
 	@else
-		half2 envBRDF = half2( 1.0f, 0.0f );
+		half2 envBRDF = half2_c( 1.0f, 0.0f );
 	@end
 
 	@property( fresnel_separate_diffuse )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BlendModes_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BlendModes_piece_ps.any
@@ -20,14 +20,14 @@
 @piece( Add )
 	//Add @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  min( pixelData.diffuse.xyz + detailCol@value(t).xyz, half3(1.0, 1.0, 1.0) ),
+						  min( pixelData.diffuse.xyz + detailCol@value(t).xyz, half3_c(1.0, 1.0, 1.0) ),
 						  detailCol@value(t).a );
 @end
 
 @piece( Subtract )
 	//Subtract @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  max( pixelData.diffuse.xyz - detailCol@value(t).xyz, half3(0.0, 0.0, 0.0) ),
+						  max( pixelData.diffuse.xyz - detailCol@value(t).xyz, half3_c(0.0, 0.0, 0.0) ),
 						  detailCol@value(t).a );
 @end
 
@@ -41,7 +41,7 @@
 @piece( Multiply2x )
 	//Multiply2x @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  min( pixelData.diffuse.xyz * detailCol@value(t).xyz * 2.0, half3(1.0, 1.0, 1.0) ),
+						  min( pixelData.diffuse.xyz * detailCol@value(t).xyz * 2.0, half3_c(1.0, 1.0, 1.0) ),
 						  detailCol@value(t).a );
 @end
 
@@ -97,12 +97,12 @@
 
 @piece( NormalNonPremul )
 	//Normal Non Premultiplied @value(t)
-	pixelData.diffuse = lerp( pixelData.diffuse, half4( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
+	pixelData.diffuse = lerp( pixelData.diffuse, half4_c( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
 @end
 
 @piece( NormalPremul )
 	//Normal Premultiplied @value(t)
-	pixelData.diffuse = lerp( pixelData.diffuse, half4( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
+	pixelData.diffuse = lerp( pixelData.diffuse, half4_c( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
 @end
 
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BlendModes_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BlendModes_piece_ps.any
@@ -8,26 +8,26 @@
 @piece( NormalNonPremul )
 	//Normal Non Premultiplied @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz, detailCol@value(t).xyz, detailCol@value(t).a );
-	pixelData.diffuse.w = lerp( pixelData.diffuse.w, 1.0, detailCol@value(t).w );
+	pixelData.diffuse.w = lerp( pixelData.diffuse.w, _h( 1.0 ), detailCol@value(t).w );
 @end
 
 @piece( NormalPremul )
 	//Normal Premultiplied @value(t)
-	pixelData.diffuse.xyz = (1.0 - detailCol@value(t).a) * pixelData.diffuse.xyz + detailCol@value(t).xyz;
-	pixelData.diffuse.w = lerp( pixelData.diffuse.w, 1.0, detailCol@value(t).w );
+	pixelData.diffuse.xyz = (_h( 1.0 ) - detailCol@value(t).a) * pixelData.diffuse.xyz + detailCol@value(t).xyz;
+	pixelData.diffuse.w = lerp( pixelData.diffuse.w, _h( 1.0 ), detailCol@value(t).w );
 @end
 
 @piece( Add )
 	//Add @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  min( pixelData.diffuse.xyz + detailCol@value(t).xyz, float3(1.0, 1.0, 1.0) ),
+						  min( pixelData.diffuse.xyz + detailCol@value(t).xyz, half3(1.0, 1.0, 1.0) ),
 						  detailCol@value(t).a );
 @end
 
 @piece( Subtract )
 	//Subtract @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  max( pixelData.diffuse.xyz - detailCol@value(t).xyz, float3(0.0, 0.0, 0.0) ),
+						  max( pixelData.diffuse.xyz - detailCol@value(t).xyz, half3(0.0, 0.0, 0.0) ),
 						  detailCol@value(t).a );
 @end
 
@@ -41,21 +41,21 @@
 @piece( Multiply2x )
 	//Multiply2x @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  min( pixelData.diffuse.xyz * detailCol@value(t).xyz * 2.0, float3(1.0, 1.0, 1.0) ),
+						  min( pixelData.diffuse.xyz * detailCol@value(t).xyz * 2.0, half3(1.0, 1.0, 1.0) ),
 						  detailCol@value(t).a );
 @end
 
 @piece( Screen )
 	//Screen @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  1.0 - (1.0 - pixelData.diffuse.xyz) * (1.0 - detailCol@value(t).xyz),
+						  _h( 1.0 ) - (_h( 1.0 ) - pixelData.diffuse.xyz) * (_h( 1.0 ) - detailCol@value(t).xyz),
 						  detailCol@value(t).a );
 @end
 
 @piece( Overlay )
 	//Overlay @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  pixelData.diffuse.xyz * ( pixelData.diffuse.xyz + 2.0 * detailCol@value(t).xyz * (1.0 - pixelData.diffuse.xyz) ),
+						  pixelData.diffuse.xyz * ( pixelData.diffuse.xyz + _h( 2.0 ) * detailCol@value(t).xyz * (_h( 1.0 ) - pixelData.diffuse.xyz) ),
 						  detailCol@value(t).a );
 @end
 
@@ -76,14 +76,14 @@
 @piece( GrainExtract )
 	//GrainExtract @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  (pixelData.diffuse.xyz - detailCol@value(t).xyz) + 0.5f,
+						  (pixelData.diffuse.xyz - detailCol@value(t).xyz) + _h( 0.5f ),
 						  detailCol@value(t).a );
 @end
 
 @piece( GrainMerge )
 	//GrainMerge @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  (pixelData.diffuse.xyz + detailCol@value(t).xyz) - 0.5f,
+						  (pixelData.diffuse.xyz + detailCol@value(t).xyz) - _h( 0.5f ),
 						  detailCol@value(t).a );
 @end
 
@@ -97,12 +97,12 @@
 
 @piece( NormalNonPremul )
 	//Normal Non Premultiplied @value(t)
-	pixelData.diffuse = lerp( pixelData.diffuse, float4( 1.0, 1.0, 1.0,1.0 ), detailCol@value(t) );
+	pixelData.diffuse = lerp( pixelData.diffuse, half4( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
 @end
 
 @piece( NormalPremul )
 	//Normal Premultiplied @value(t)
-	pixelData.diffuse = lerp( pixelData.diffuse, float4( 1.0, 1.0, 1.0,1.0 ), detailCol@value(t) );
+	pixelData.diffuse = lerp( pixelData.diffuse, half4( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
 @end
 
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BlendModes_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BlendModes_piece_ps.any
@@ -20,14 +20,14 @@
 @piece( Add )
 	//Add @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  min( pixelData.diffuse.xyz + detailCol@value(t).xyz, half3_c(1.0, 1.0, 1.0) ),
+						  min( pixelData.diffuse.xyz + detailCol@value(t).xyz, midf3_c(1.0, 1.0, 1.0) ),
 						  detailCol@value(t).a );
 @end
 
 @piece( Subtract )
 	//Subtract @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  max( pixelData.diffuse.xyz - detailCol@value(t).xyz, half3_c(0.0, 0.0, 0.0) ),
+						  max( pixelData.diffuse.xyz - detailCol@value(t).xyz, midf3_c(0.0, 0.0, 0.0) ),
 						  detailCol@value(t).a );
 @end
 
@@ -41,7 +41,7 @@
 @piece( Multiply2x )
 	//Multiply2x @value(t)
 	pixelData.diffuse.xyz = lerp( pixelData.diffuse.xyz,
-						  min( pixelData.diffuse.xyz * detailCol@value(t).xyz * 2.0, half3_c(1.0, 1.0, 1.0) ),
+						  min( pixelData.diffuse.xyz * detailCol@value(t).xyz * 2.0, midf3_c(1.0, 1.0, 1.0) ),
 						  detailCol@value(t).a );
 @end
 
@@ -97,12 +97,12 @@
 
 @piece( NormalNonPremul )
 	//Normal Non Premultiplied @value(t)
-	pixelData.diffuse = lerp( pixelData.diffuse, half4_c( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
+	pixelData.diffuse = lerp( pixelData.diffuse, midf4_c( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
 @end
 
 @piece( NormalPremul )
 	//Normal Premultiplied @value(t)
-	pixelData.diffuse = lerp( pixelData.diffuse, half4_c( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
+	pixelData.diffuse = lerp( pixelData.diffuse, midf4_c( 1.0, 1.0, 1.0, 1.0 ), detailCol@value(t) );
 @end
 
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.ForwardPlus_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.ForwardPlus_piece_ps.any
@@ -121,11 +121,11 @@
 		float4 posAndType = readOnlyFetch( f3dLightList, int(idx) );
 
 	@property( !hlms_forwardplus_fine_light_mask )
-		float3 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz;
+		half3 lightDiffuse	= half3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
 	@else
 		float4 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyzw;
 	@end
-		float3 lightSpecular= readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz;
+		half3 lightSpecular	= half3_c( readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz );
 		float4 attenuation	= readOnlyFetch( f3dLightList, int(idx + 3u) ).xyzw;
 	@property( light_profiles_texture )
 		float4 spotDirection= readOnlyFetch( f3dLightList, int(idx + 4u) ).xyzw;
@@ -137,19 +137,20 @@
 		if( fDistance <= attenuation.x @insertpiece( andObjLightMaskFwdPlusCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			float atten = 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance );
+			half atten = half_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
 			@property( hlms_forward_fade_attenuation_range )
-				atten *= max( (attenuation.x - fDistance) * attenuation.w, 0.0f );
+				atten *= half_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
 			@end
 
 			@property( light_profiles_texture )
-				float spotCosAngle = dot( -lightDir, spotDirection.xyz );
+				half spotCosAngle = dot( half3_c( -lightDir ), half3_c( spotDirection.xyz ) );
 				atten *= getPhotometricAttenuation( spotCosAngle, spotDirection.w
 													OGRE_PHOTOMETRIC_ARG );
 			@end
 
 			//Point light
-			float3 tmpColour = BRDF( lightDir, lightDiffuse.xyz, lightSpecular, pixelData );
+			half3 tmpColour =
+				BRDF( half3_c( lightDir ), half3_c( lightDiffuse.xyz ), lightSpecular, pixelData );
 			finalColour += tmpColour * atten;
 		}
 	}
@@ -168,18 +169,18 @@
 		float4 posAndType = readOnlyFetch( f3dLightList, int(idx) );
 
 	@property( !hlms_forwardplus_fine_light_mask )
-		float3 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz;
+		half3 lightDiffuse	= half3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
 	@else
 		float4 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyzw;
 	@end
-		float3 lightSpecular	= readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz;
+		half3 lightSpecular		= half3_c( readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz );
 		float4 attenuation      = readOnlyFetch( f3dLightList, int(idx + 3u) ).xyzw;
 	@property( !light_profiles_texture )
 		float3 spotDirection	= readOnlyFetch( f3dLightList, int(idx + 4u) ).xyz;
 	@else
 		float4 spotDirection	= readOnlyFetch( f3dLightList, int(idx + 4u) ).xyzw;
 	@end
-		float3 spotParams		= readOnlyFetch( f3dLightList, int(idx + 5u) ).xyz;
+		half3 spotParams		= half3_c( readOnlyFetch( f3dLightList, int(idx + 5u) ).xyz );
 
 		float3 lightDir	= posAndType.xyz - inPs.pos;
 		float fDistance	= length( lightDir );
@@ -187,9 +188,9 @@
 		if( fDistance <= attenuation.x @insertpiece( andObjLightMaskFwdPlusCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			float atten = 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance );
+			half atten = half_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
 			@property( hlms_forward_fade_attenuation_range )
-				atten *= max( (attenuation.x - fDistance) * attenuation.w, 0.0f );
+				atten *= half_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
 			@end
 
 			//spotParams.x = 1.0 / cos( InnerAngle ) - cos( OuterAngle )
@@ -197,9 +198,9 @@
 			//spotParams.z = falloff
 
 			//Spot light
-			float spotCosAngle = dot( -lightDir, spotDirection.xyz );
+			half spotCosAngle = dot( half3_c( -lightDir ), half3_c( spotDirection.xyz ) );
 
-			float spotAtten = saturate( (spotCosAngle - spotParams.y) * spotParams.x );
+			half spotAtten = saturate( (spotCosAngle - spotParams.y) * spotParams.x );
 			spotAtten = pow( spotAtten, spotParams.z );
 			atten *= spotAtten;
 
@@ -210,7 +211,8 @@
 
 			if( spotCosAngle >= spotParams.y )
 			{
-				float3 tmpColour = BRDF( lightDir, lightDiffuse.xyz, lightSpecular, pixelData );
+				half3 tmpColour =
+					BRDF( half3_c( lightDir ), half3_c( lightDiffuse.xyz ), lightSpecular, pixelData );
 				finalColour += tmpColour * atten;
 			}
 		}
@@ -230,7 +232,7 @@
 		//Get the light
 		float4 posAndType = readOnlyFetch( f3dLightList, int(idx) );
 
-		float3 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz;
+		half3 lightDiffuse	= half3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
 		float4 attenuation	= readOnlyFetch( f3dLightList, int(idx + 3u) ).xyzw;
 
 		float3 lightDir	= posAndType.xyz - inPs.pos;
@@ -239,35 +241,35 @@
 		if( fDistance <= attenuation.x )
 		{
 			//lightDir *= 1.0 / fDistance;
-			float atten = 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance );
+			half atten = half_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
 			@property( hlms_forward_fade_attenuation_range )
-				atten *= max( (attenuation.x - fDistance) * attenuation.w, 0.0f );
+				atten *= half_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
 			@end
 
 			//float3 lightDir2	= posAndType.xyz - inPs.pos;
 			//lightDir2 *= 1.0 / max( 1, fDistance );
 			//lightDir2 *= 1.0 / fDistance;
 
-			finalColour += BRDF_IR( lightDir, lightDiffuse, pixelData ) * atten;
+			finalColour += BRDF_IR( half3_c( lightDir ), lightDiffuse, pixelData ) * atten;
 		}
 	}
 @end
 
 	@property( hlms_forwardplus_debug )
 		@property( hlms_forwardplus == forward3d )
-			float occupancy = (totalNumLightsInGrid / passBuf.f3dGridHWW[0].w);
+			half occupancy = half_c(totalNumLightsInGrid / passBuf.f3dGridHWW[0].w);
 		@else
-			float occupancy = (totalNumLightsInGrid / float( @value( fwd_clustered_lights_per_cell ) ));
+			half occupancy = half_c(totalNumLightsInGrid / float( @value( fwd_clustered_lights_per_cell ) ));
 		@end
-		float3 occupCol = float3( 0.0, 0.0, 0.0 );
-		if( occupancy < 1.0 / 3.0 )
+		half3 occupCol = half3_c( 0.0, 0.0, 0.0 );
+		if( occupancy < _h( 1.0 / 3.0 ) )
 			occupCol.z = occupancy;
-		else if( occupancy < 2.0 / 3.0 )
+		else if( occupancy < _h( 2.0 / 3.0 ) )
 			occupCol.y = occupancy;
 		else
 			occupCol.x = occupancy;
 
-		finalColour.xyz = lerp( finalColour.xyz, occupCol.xyz, 0.55f ) * 2;
+		finalColour.xyz = lerp( finalColour.xyz, occupCol.xyz, _h( 0.55f ) ) * _h( 2 );
 	@end
 @end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.ForwardPlus_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.ForwardPlus_piece_ps.any
@@ -121,11 +121,11 @@
 		float4 posAndType = readOnlyFetch( f3dLightList, int(idx) );
 
 	@property( !hlms_forwardplus_fine_light_mask )
-		half3 lightDiffuse	= half3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
+		midf3 lightDiffuse	= midf3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
 	@else
 		float4 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyzw;
 	@end
-		half3 lightSpecular	= half3_c( readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz );
+		midf3 lightSpecular	= midf3_c( readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz );
 		float4 attenuation	= readOnlyFetch( f3dLightList, int(idx + 3u) ).xyzw;
 	@property( light_profiles_texture )
 		float4 spotDirection= readOnlyFetch( f3dLightList, int(idx + 4u) ).xyzw;
@@ -137,20 +137,20 @@
 		if( fDistance <= attenuation.x @insertpiece( andObjLightMaskFwdPlusCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			half atten = half_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
 			@property( hlms_forward_fade_attenuation_range )
-				atten *= half_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
+				atten *= midf_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
 			@end
 
 			@property( light_profiles_texture )
-				half spotCosAngle = dot( half3_c( -lightDir ), half3_c( spotDirection.xyz ) );
+				midf spotCosAngle = dot( midf3_c( -lightDir ), midf3_c( spotDirection.xyz ) );
 				atten *= getPhotometricAttenuation( spotCosAngle, spotDirection.w
 													OGRE_PHOTOMETRIC_ARG );
 			@end
 
 			//Point light
-			half3 tmpColour =
-				BRDF( half3_c( lightDir ), half3_c( lightDiffuse.xyz ), lightSpecular, pixelData );
+			midf3 tmpColour =
+				BRDF( midf3_c( lightDir ), midf3_c( lightDiffuse.xyz ), lightSpecular, pixelData );
 			finalColour += tmpColour * atten;
 		}
 	}
@@ -169,18 +169,18 @@
 		float4 posAndType = readOnlyFetch( f3dLightList, int(idx) );
 
 	@property( !hlms_forwardplus_fine_light_mask )
-		half3 lightDiffuse	= half3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
+		midf3 lightDiffuse	= midf3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
 	@else
 		float4 lightDiffuse	= readOnlyFetch( f3dLightList, int(idx + 1u) ).xyzw;
 	@end
-		half3 lightSpecular		= half3_c( readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz );
+		midf3 lightSpecular		= midf3_c( readOnlyFetch( f3dLightList, int(idx + 2u) ).xyz );
 		float4 attenuation      = readOnlyFetch( f3dLightList, int(idx + 3u) ).xyzw;
 	@property( !light_profiles_texture )
 		float3 spotDirection	= readOnlyFetch( f3dLightList, int(idx + 4u) ).xyz;
 	@else
 		float4 spotDirection	= readOnlyFetch( f3dLightList, int(idx + 4u) ).xyzw;
 	@end
-		half3 spotParams		= half3_c( readOnlyFetch( f3dLightList, int(idx + 5u) ).xyz );
+		midf3 spotParams		= midf3_c( readOnlyFetch( f3dLightList, int(idx + 5u) ).xyz );
 
 		float3 lightDir	= posAndType.xyz - inPs.pos;
 		float fDistance	= length( lightDir );
@@ -188,9 +188,9 @@
 		if( fDistance <= attenuation.x @insertpiece( andObjLightMaskFwdPlusCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			half atten = half_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
 			@property( hlms_forward_fade_attenuation_range )
-				atten *= half_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
+				atten *= midf_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
 			@end
 
 			//spotParams.x = 1.0 / cos( InnerAngle ) - cos( OuterAngle )
@@ -198,9 +198,9 @@
 			//spotParams.z = falloff
 
 			//Spot light
-			half spotCosAngle = dot( half3_c( -lightDir ), half3_c( spotDirection.xyz ) );
+			midf spotCosAngle = dot( midf3_c( -lightDir ), midf3_c( spotDirection.xyz ) );
 
-			half spotAtten = saturate( (spotCosAngle - spotParams.y) * spotParams.x );
+			midf spotAtten = saturate( (spotCosAngle - spotParams.y) * spotParams.x );
 			spotAtten = pow( spotAtten, spotParams.z );
 			atten *= spotAtten;
 
@@ -211,8 +211,8 @@
 
 			if( spotCosAngle >= spotParams.y )
 			{
-				half3 tmpColour =
-					BRDF( half3_c( lightDir ), half3_c( lightDiffuse.xyz ), lightSpecular, pixelData );
+				midf3 tmpColour =
+					BRDF( midf3_c( lightDir ), midf3_c( lightDiffuse.xyz ), lightSpecular, pixelData );
 				finalColour += tmpColour * atten;
 			}
 		}
@@ -232,7 +232,7 @@
 		//Get the light
 		float4 posAndType = readOnlyFetch( f3dLightList, int(idx) );
 
-		half3 lightDiffuse	= half3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
+		midf3 lightDiffuse	= midf3_c( readOnlyFetch( f3dLightList, int(idx + 1u) ).xyz );
 		float4 attenuation	= readOnlyFetch( f3dLightList, int(idx + 3u) ).xyzw;
 
 		float3 lightDir	= posAndType.xyz - inPs.pos;
@@ -241,27 +241,27 @@
 		if( fDistance <= attenuation.x )
 		{
 			//lightDir *= 1.0 / fDistance;
-			half atten = half_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (attenuation.y + attenuation.z * fDistance) * fDistance ) );
 			@property( hlms_forward_fade_attenuation_range )
-				atten *= half_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
+				atten *= midf_c( max( (attenuation.x - fDistance) * attenuation.w, 0.0f ) );
 			@end
 
 			//float3 lightDir2	= posAndType.xyz - inPs.pos;
 			//lightDir2 *= 1.0 / max( 1, fDistance );
 			//lightDir2 *= 1.0 / fDistance;
 
-			finalColour += BRDF_IR( half3_c( lightDir ), lightDiffuse, pixelData ) * atten;
+			finalColour += BRDF_IR( midf3_c( lightDir ), lightDiffuse, pixelData ) * atten;
 		}
 	}
 @end
 
 	@property( hlms_forwardplus_debug )
 		@property( hlms_forwardplus == forward3d )
-			half occupancy = half_c(totalNumLightsInGrid / passBuf.f3dGridHWW[0].w);
+			midf occupancy = midf_c(totalNumLightsInGrid / passBuf.f3dGridHWW[0].w);
 		@else
-			half occupancy = half_c(totalNumLightsInGrid / float( @value( fwd_clustered_lights_per_cell ) ));
+			midf occupancy = midf_c(totalNumLightsInGrid / float( @value( fwd_clustered_lights_per_cell ) ));
 		@end
-		half3 occupCol = half3_c( 0.0, 0.0, 0.0 );
+		midf3 occupCol = midf3_c( 0.0, 0.0, 0.0 );
 		if( occupancy < _h( 1.0 / 3.0 ) )
 			occupCol.z = occupancy;
 		else if( occupancy < _h( 2.0 / 3.0 ) )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
@@ -7,7 +7,7 @@
 			uniform sampler2DArray ltcMatrix;
 		@end
         @property( syntax == glslvk )
-            layout( ogre_t@value(ltcMatrix) ) uniform texture2DArray ltcMatrix;
+			layout( ogre_t@value(ltcMatrix) ) uniform texture2DArray ltcMatrix;
             layout( ogre_s@value(ltcMatrix) ) uniform sampler ltcSampler;
         @end
 		@property( syntax == hlsl )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
@@ -22,7 +22,7 @@
 @end
 
 @property( envmap_scale )
-	@piece( ApplyEnvMapScale )* passBuf.ambientUpperHemi.w@end
+	@piece( ApplyEnvMapScale )* half_c( passBuf.ambientUpperHemi.w )@end
 @end
 
 @property( use_envprobe_map )

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
@@ -15,7 +15,7 @@
 			SamplerState ltcSampler				: register(s@value(ltcMatrix));
 		@end
 		@property( syntax == metal )
-			, texture2d_array<float> ltcMatrix	[[texture(@value(ltcMatrix))]]
+			, texture2d_array<midf> ltcMatrix	[[texture(@value(ltcMatrix))]]
 			, sampler ltcSampler				[[sampler(@value(ltcMatrix))]]
 		@end
 	@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.Textures_piece_ps.any
@@ -22,7 +22,7 @@
 @end
 
 @property( envmap_scale )
-	@piece( ApplyEnvMapScale )* half_c( passBuf.ambientUpperHemi.w )@end
+	@piece( ApplyEnvMapScale )* midf_c( passBuf.ambientUpperHemi.w )@end
 @end
 
 @property( use_envprobe_map )

--- a/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
@@ -405,10 +405,10 @@ struct Material
 	@property( !hlms_shadowcaster )
 		@property( hlms_normal || hlms_qtangent )
 			INTERPOLANT( float3 pos, @counter(texcoord) );
-			INTERPOLANT( float3 normal, @counter(texcoord) );
+			INTERPOLANT( half3 normal, @counter(texcoord) );
 			@property( normal_map )
-				INTERPOLANT( float3 tangent, @counter(texcoord) );
-				@property( hlms_qtangent || hlms_tangent4 )FLAT_INTERPOLANT( float biNormalReflection, @counter(texcoord) );@end
+				INTERPOLANT( half3 tangent, @counter(texcoord) );
+				@property( hlms_qtangent || hlms_tangent4 )FLAT_INTERPOLANT( half biNormalReflection, @counter(texcoord) );@end
 			@end
 		@end
 		@foreach( hlms_uv_count, n )
@@ -424,7 +424,7 @@ struct Material
 			@property( hlms_num_shadow_map_lights && !hlms_all_point_lights )
 				INTERPOLANT( float3 worldPos, @counter(texcoord) );
 				@property( hlms_normal || hlms_qtangent )
-					INTERPOLANT( float3 worldNorm, @counter(texcoord) );
+					INTERPOLANT( half3 worldNorm, @counter(texcoord) );
 				@end
 			@end
 		@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/500.Structs_piece_vs_piece_ps.any
@@ -405,10 +405,10 @@ struct Material
 	@property( !hlms_shadowcaster )
 		@property( hlms_normal || hlms_qtangent )
 			INTERPOLANT( float3 pos, @counter(texcoord) );
-			INTERPOLANT( half3 normal, @counter(texcoord) );
+			INTERPOLANT( midf3 normal, @counter(texcoord) );
 			@property( normal_map )
-				INTERPOLANT( half3 tangent, @counter(texcoord) );
-				@property( hlms_qtangent || hlms_tangent4 )FLAT_INTERPOLANT( half biNormalReflection, @counter(texcoord) );@end
+				INTERPOLANT( midf3 tangent, @counter(texcoord) );
+				@property( hlms_qtangent || hlms_tangent4 )FLAT_INTERPOLANT( midf biNormalReflection, @counter(texcoord) );@end
 			@end
 		@end
 		@foreach( hlms_uv_count, n )
@@ -424,7 +424,7 @@ struct Material
 			@property( hlms_num_shadow_map_lights && !hlms_all_point_lights )
 				INTERPOLANT( float3 worldPos, @counter(texcoord) );
 				@property( hlms_normal || hlms_qtangent )
-					INTERPOLANT( half3 worldNorm, @counter(texcoord) );
+					INTERPOLANT( midf3 worldNorm, @counter(texcoord) );
 				@end
 			@end
 		@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -14,11 +14,11 @@
 	// END UNIFORM DECLARATION
 
 	@property( !fresnel_scalar )
-		#define float_fresnel float
+		#define float_fresnel half
 		#define make_float_fresnel( x ) x
 	@else
-		#define float_fresnel float3
-		#define make_float_fresnel( x ) float3( x, x, x )
+		#define float_fresnel half3
+		#define make_float_fresnel( x ) half3( x, x, x )
 	@end
 
 	@insertpiece( DeclReverseDepthMacros )
@@ -38,66 +38,66 @@
 	struct PixelData
 	{
 		@property( !hlms_shadowcaster )
-			float3 normal;
+			half3 normal;
 			@property( normal_map )
-				float3 geomNormal;
+				half3 geomNormal;
 			@else
 				#define geomNormal normal
 			@end
-			float4	diffuse;
-			float3	specular;
+			half4	diffuse;
+			half3	specular;
 
 			@property( clear_coat )
-				float clearCoat;
-				float clearCoatPerceptualRoughness;
-				float clearCoatRoughness;
+				half clearCoat;
+				half clearCoatPerceptualRoughness;
+				half clearCoatRoughness;
 			@end
 
-			float	perceptualRoughness;
-			float	roughness;
+			half	perceptualRoughness;
+			half	roughness;
 			float_fresnel	F0;
 
 			@property( needs_view_dir )
-				float3	viewDir;
-				float	NdotV;
+				half3	viewDir;
+				half	NdotV;
 			@end
 
 			@property( needs_refl_dir )
-				float3 reflDir;
+				half3 reflDir;
 				@property( needs_env_brdf )
-					float3 envColourS;
-					float3 envColourD;
+					half3 envColourS;
+					half3 envColourD;
 
 					@property( clear_coat )
-						float3 clearCoatEnvColourS;
+						half3 clearCoatEnvColourS;
 					@end
 				@end
 			@end
 		@else
-			float4 diffuse; //We only use the .w component, Alpha
+			half4 diffuse; //We only use the .w component, Alpha
 		@end
 
 		@insertpiece( custom_ps_pixelData )
 	};
 
-	#define SampleDetailWeightMap( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
+	#define SampleDetailWeightMap( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
 	@foreach( detail_maps_diffuse, n )
-		@property( detail_map@n )#define SampleDetailCol@n( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )@end
+		@property( detail_map@n )#define SampleDetailCol@n( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )@end
 	@end
 	@property( diffuse_map )
-		#define SampleDiffuse( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx ) @property( diffuse_map_grayscale ).rrra@end
+		#define SampleDiffuse( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) @property( diffuse_map_grayscale ).rrra@end
 	@end
 	@property( specular_map )
-		#define SampleSpecular( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
+		#define SampleSpecular( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
 	@end
 	@property( roughness_map )
-		#define SampleRoughness( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
+		#define SampleRoughness( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
 	@end
 	@property( emissive_map )
-		#define SampleEmissive( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx ) @property( emissive_map_grayscale ).rrr@end
+		#define SampleEmissive( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) @property( emissive_map_grayscale ).rrr@end
 	@end
 	@property( use_envprobe_map )
-        #define SampleEnvProbe( tex, sampler, uv, lod ) OGRE_SampleLevel( tex, sampler, uv, lod )
+		#define SampleEnvProbe( tex, sampler, uv, lod ) OGRE_SampleLevelF16( tex, sampler, uv, lod )
 	@end
 
 	@property( hlms_lights_spot_textured )
@@ -109,29 +109,29 @@
 	@end
 
 	@property( normal_map_tex || detail_maps_normal )
-		INLINE float3 reconstructZfromTSNormal( float2 tsNormal2 )
+		INLINE half3 reconstructZfromTSNormal( half2 tsNormal2 )
 		{
-			float3 tsNormal;
+			half3 tsNormal;
 			tsNormal.xy = tsNormal2.xy;
-			tsNormal.z	= sqrt( max( 0.0f, 1.0f - tsNormal.x * tsNormal.x - tsNormal.y * tsNormal.y ) );
+			tsNormal.z	= sqrt( max( _h(0.0f), _h(1.0f) - tsNormal.x * tsNormal.x - tsNormal.y * tsNormal.y ) );
 			return tsNormal.xyz;
 		}
 
 		@property( normal_sampling_format == normal_rg_snorm )
 			//Normal texture must be in UV8/RG8_SNORM or BC5S format!
-			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2D( normalMap, samplerState, uv, normalIdx ).xy )
+			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2DF16( normalMap, samplerState, uv, normalIdx ).xy )
 		@end
 		@property( normal_sampling_format == normal_rg_unorm )
 			//Normal texture must be in RG8_UNORM or similar format!
-			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2D( normalMap, samplerState, uv, normalIdx ).xy * 2.0 - 1.0 )
+			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2DF16( normalMap, samplerState, uv, normalIdx ).xy * 2.0 - 1.0 )
 		@end
 		@property( normal_sampling_format == normal_bc3_unorm )
 			//Normal texture must be in BC3 or similar format!
-			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2D( normalMap, samplerState, uv, normalIdx ).yw * 2.0 - 1.0 )
+			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2DF16( normalMap, samplerState, uv, normalIdx ).yw * 2.0 - 1.0 )
 		@end
 		@property( normal_sampling_format == normal_la )
 			//Normal texture must be in LA format!
-			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2D( normalMap, samplerState, uv, normalIdx ).xw * 2.0 - 1.0 )
+			#define getTSNormal( normalMap, samplerState, uv, normalIdx ) reconstructZfromTSNormal( OGRE_SampleArray2DF16( normalMap, samplerState, uv, normalIdx ).xw * 2.0 - 1.0 )
 		@end
 	@end
 
@@ -231,16 +231,16 @@
 	@property( detail_maps_diffuse || detail_maps_normal )
 		//Prepare weight map for the detail maps.
 		@property( detail_weight_map )
-			float4 detailWeights = SampleDetailWeightMap( textureMaps@value(detail_weight_map_idx),
+			half4 detailWeights = SampleDetailWeightMap( textureMaps@value(detail_weight_map_idx),
 														  samplerState@value(detail_weight_map_sampler),
 														  UV_DETAIL_WEIGHT( inPs.uv@value(uv_detail_weight).xy ),
 														  texIndex_weightMapIdx );
-			@property( detail_weights )detailWeights *= material.cDetailWeights;@end
+			@property( detail_weights )detailWeights *= half4( material.cDetailWeights );@end
 		@else
 			@property( detail_weights )
-				float4 detailWeights = material.cDetailWeights;
+				half4 detailWeights = half4( material.cDetailWeights );
 			@else
-				float4 detailWeights = float4( 1.0, 1.0, 1.0, 1.0 );
+				half4 detailWeights = half4( 1.0, 1.0, 1.0, 1.0 );
 			@end
 		@end
 	@end
@@ -250,7 +250,7 @@
 	/// Sample detail maps and weight them against the weight map in the next foreach loop.
 	@foreach( detail_maps_diffuse, n )
 		@property( detail_map@n )
-			float4 detailCol@n = SampleDetailCol@n( textureMaps@value(detail_map@n_idx),
+			half4 detailCol@n = SampleDetailCol@n( textureMaps@value(detail_map@n_idx),
 													samplerState@value(detail_map@n_sampler),
                                                     UV_DETAIL@n( inPs.uv@value(uv_detail@n).xy@insertpiece( offsetDetail@n ) ),
                                                     texIndex_detailMapIdx@n );
@@ -269,7 +269,7 @@
 										   texIndex_diffuseIdx );
 	@else
 		/// If there are no diffuse maps, we must initialize it to some value.
-		pixelData.diffuse.xyzw = material.bgDiffuse.xyzw;
+		pixelData.diffuse.xyzw = half4( material.bgDiffuse.xyzw );
 	@end
 
 	/// Blend the detail diffuse maps with the main diffuse.
@@ -277,7 +277,7 @@
 		@insertpiece( blend_mode_idx@n ) @add( t, 1 ) @end
 
 	/// Apply the material's diffuse over the textures
-	pixelData.diffuse.xyz *= material.kD.xyz;
+	pixelData.diffuse.xyz *= half3( material.kD.xyz );
 	@property( transparent_mode || hlms_screen_space_refractions )
 		pixelData.diffuse.xyz *= (pixelData.diffuse.w * pixelData.diffuse.w);
 	@end
@@ -290,9 +290,9 @@
 
 @piece( SampleSpecularMap )
 	/// SPECUlAR MAP
-	pixelData.specular.xyz = material.kS.xyz;
+	pixelData.specular.xyz = half3( material.kS.xyz );
 	@property( !metallic_workflow )
-		pixelData.F0 = material.F0.@insertpiece( FresnelSwizzle );
+		pixelData.F0 = float_fresnel( material.F0.@insertpiece( FresnelSwizzle ) );
 		@property( specular_map && !fresnel_workflow )
 			pixelData.specular.xyz *= SampleSpecular( textureMaps@value( specular_map_idx ),
 													  samplerState@value(specular_map_sampler),
@@ -306,17 +306,17 @@
 											texIndex_specularIdx ).@insertpiece( FresnelSwizzle );
 		@end
 	@else
-		float metalness = material.F0.x;
+		half metalness = half( material.F0.x );
 		@property( specular_map )
 			metalness *= SampleSpecular( textureMaps@value( specular_map_idx ),
 										 samplerState@value(specular_map_sampler),
 										 UV_SPECULAR( inPs.uv@value(uv_specular).xy ),
 										 texIndex_specularIdx ).x;
 		@end
-		pixelData.F0 = lerp( make_float_fresnel( 0.03f ), pixelData.diffuse.xyz * 3.14159f, metalness );
+		pixelData.F0 = lerp( make_float_fresnel( 0.03f ), pixelData.diffuse.xyz * _h( 3.14159f ), metalness );
 		pixelData.diffuse.xyz = pixelData.diffuse.xyz - pixelData.diffuse.xyz * metalness;
 		@property( hlms_alphablend || hlms_screen_space_refractions )
-			pixelData.F0 *= material.F0.w; ///Should this be done for non-metallic as well???
+			pixelData.F0 *= half( material.F0.w ); ///Should this be done for non-metallic as well???
 		@end
 	@end
 	@property( transparent_mode || hlms_screen_space_refractions )
@@ -326,7 +326,7 @@
 
 @piece( SampleRoughnessMap )
 	/// ROUGHNESS MAP
-	pixelData.perceptualRoughness = material.kS.w;
+	pixelData.perceptualRoughness = half( material.kS.w );
 	@property( roughness_map )
 		pixelData.perceptualRoughness *=
 			SampleRoughness( textureMaps@value( roughness_map_idx ),
@@ -345,9 +345,9 @@
 @end
 
 	@property( perceptual_roughness )
-		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, 0.001f );
+		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, _h( 0.001f ) );
 	@else
-		pixelData.roughness = max( pixelData.perceptualRoughness, 0.001f );
+		pixelData.roughness = max( pixelData.perceptualRoughness, _h( 0.001f ) );
 	@end
 @end
 
@@ -365,15 +365,15 @@
 	@else
 		//Normal mapping.
 		pixelData.geomNormal = normalize( inPs.normal ) @insertpiece( two_sided_flip_normal );
-		float3 vTangent		= normalize( inPs.tangent );
+		half3 vTangent		= normalize( inPs.tangent );
 
 		@property( hlms_qtangent || hlms_tangent4 )
 			@piece( tbnApplyReflection ) * inPs.biNormalReflection@end
 		@end
 
 		//Get the TBN matrix
-		float3 vBinormal	= normalize( cross( pixelData.geomNormal, vTangent )@insertpiece( tbnApplyReflection ) );
-		float3x3 TBN		= buildFloat3x3( vTangent, vBinormal, pixelData.geomNormal );
+		half3 vBinormal	= normalize( cross( pixelData.geomNormal, vTangent )@insertpiece( tbnApplyReflection ) );
+		half3x3 TBN		= buildHalf3x3( vTangent, vBinormal, pixelData.geomNormal );
 
 		@property( normal_map_tex )
 			pixelData.normal = getTSNormal( textureMaps@value( normal_map_tex_idx ),
@@ -381,11 +381,11 @@
 											UV_NORMAL( inPs.uv@value(uv_normal).xy ),
 											texIndex_normalIdx );
 		@else
-			pixelData.normal = float3( 0.0, 0.0, 1.0 );
+			pixelData.normal = half3( 0.0, 0.0, 1.0 );
 		@end
 		@property( normal_weight_tex )
 			// Apply the weight to the main normal map
-			pixelData.normal = lerp( float3( 0.0, 0.0, 1.0 ), pixelData.normal, normalMapWeight );
+			pixelData.normal = lerp( half3( 0.0, 0.0, 1.0 ), pixelData.normal, normalMapWeight );
 		@end
 	@end
 @end
@@ -435,27 +435,27 @@
 	//Everything's in Camera space
 	@property( needs_view_dir )
 		@property( !hlms_instanced_stereo )
-			pixelData.viewDir	= normalize( -inPs.pos );
+			pixelData.viewDir	= half3( normalize( -inPs.pos ) );
 		@else
-			pixelData.viewDir = -inPs.pos;
 			if( gl_FragCoord.x > passBuf.rightEyePixelStartX )
-				pixelData.viewDir += passBuf.leftToRightView.xyz;
-			pixelData.viewDir = normalize( pixelData.viewDir );
+				pixelData.viewDir += half3( -inPs.pos + passBuf.leftToRightView.xyz );
+			else
+				pixelData.viewDir += half3( -inPs.pos );
 		@end
 		pixelData.NdotV		= saturate( dot( pixelData.normal, pixelData.viewDir ) );
 	@end
 
 	@property( !ambient_fixed || vct_num_probes )
-		float3 finalColour = float3(0, 0, 0);
+		half3 finalColour = half3(0, 0, 0);
 	@else
-		float3 finalColour = passBuf.ambientUpperHemi.xyz * pixelData.diffuse.xyz;
+		half3 finalColour = half3( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz;
 	@end
 
 	@property( hlms_static_branch_shadow_map_lights || hlms_lights_point || hlms_lights_spot || hlms_lights_area_approx || hlms_lights_area_ltc )
 		float3 lightDir;
 		float fDistance;
-		float3 tmpColour;
-		float spotCosAngle;
+		half3 tmpColour;
+		half spotCosAngle;
 	@end
 
 	@property( hlms_static_branch_shadow_map_lights )
@@ -480,7 +480,8 @@
 	@end
 
 	@property( needs_refl_dir )
-		pixelData.reflDir = 2.0 * dot( pixelData.viewDir, pixelData.normal ) * pixelData.normal - pixelData.viewDir;
+		pixelData.reflDir = _h( 2.0 ) * dot( pixelData.viewDir, pixelData.normal ) * pixelData.normal -
+							pixelData.viewDir;
 	@end
 
 	@insertpiece( DoAmbientHeader )
@@ -489,22 +490,30 @@
 @piece( DoDirectionalLights )
 	@property( hlms_lights_directional )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( light0Buf.lights[0].position.xyz, light0Buf.lights[0].diffuse.xyz, light0Buf.lights[0].specular, pixelData ) @insertpiece( DarkenWithShadowFirstLight );
+			finalColour += BRDF( half3( light0Buf.lights[0].position.xyz ),
+								 half3( light0Buf.lights[0].diffuse.xyz ),
+								 half3( light0Buf.lights[0].specular ), pixelData ) @insertpiece( DarkenWithShadowFirstLight );
 	@end
 	@foreach( hlms_lights_directional, n, 1 )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( light0Buf.lights[@n].position.xyz, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadow );@end
+			finalColour += BRDF( half3( light0Buf.lights[@n].position.xyz ),
+								 half3( light0Buf.lights[@n].diffuse.xyz ),
+								 half3( light0Buf.lights[@n].specular, pixelData ) )@insertpiece( DarkenWithShadow );@end
 
 	@property( !hlms_static_branch_lights )
 		@foreach( hlms_lights_directional_non_caster, n, hlms_lights_directional )
 			@insertpiece( ObjLightMaskCmp )
-				finalColour += BRDF( light0Buf.lights[@n].position.xyz, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData );@end
+				finalColour += BRDF( half3( light0Buf.lights[@n].position.xyz ),
+									 half3( light0Buf.lights[@n].diffuse.xyz ),
+									 half3( light0Buf.lights[@n].specular ), pixelData );@end
 	@else
 		for( int n=0; n<floatBitsToInt( light0Buf.numNonCasterDirectionalLights ); ++n )
 		{
 			int i = @value( hlms_lights_directional ) + n;
 			@insertpiece( ObjLightMaskCmpNonCasterLoop )
-				finalColour += BRDF( light0Buf.lights[i].position.xyz, light0Buf.lights[i].diffuse.xyz, light0Buf.lights[i].specular, pixelData );
+				finalColour += BRDF( half3( light0Buf.lights[i].position.xyz ),
+									half3( light0Buf.lights[i].diffuse.xyz ),
+									half3( light0Buf.lights[i].specular ), pixelData );
 		}
 		/// Increase fineMaskLightIdx to keep it working with spot/point lights
 		@insertpiece( ObjLightMaskCmpNonCasterLoopEnd )
@@ -525,8 +534,10 @@
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( lightDir, light0Buf.lights[light_idx].diffuse.xyz, light0Buf.lights[light_idx].specular, pixelData )@insertpiece( DarkenWithShadowPoint_cur_shadow_map );
-			float atten = 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance );
+			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[light_idx].diffuse.xyz ),
+							  half3( light0Buf.lights[light_idx].specular ),
+							  pixelData )@insertpiece( DarkenWithShadowPoint_cur_shadow_map );
+			half atten = half( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * atten;
 		}
 		cur_shadow_map++;
@@ -538,8 +549,10 @@
 		if( fDistance <= light0Buf.lights[@n].attenuation.x @insertpiece( andObjLightMaskCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( lightDir, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadowPoint );
-			float atten = 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance );
+			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[@n].diffuse.xyz ),
+							  half3( light0Buf.lights[@n].specular ),
+							  pixelData )@insertpiece( DarkenWithShadowPoint );
+			half atten = half( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * atten;
 		}
 	@end
@@ -559,10 +572,10 @@
 		lightDir = light0Buf.lights[light_idx].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
-		spotCosAngle = dot( -lightDir, light0Buf.lights[light_idx].spotDirection.xyz );
+		spotCosAngle = dot( half3( -lightDir ), half3( light0Buf.lights[light_idx].spotDirection.xyz ) );
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x && spotCosAngle >= light0Buf.lights[light_idx].spotParams.y @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
-			float spotAtten = saturate( (spotCosAngle - light0Buf.lights[light_idx].spotParams.y) * light0Buf.lights[light_idx].spotParams.x );
+			half spotAtten = saturate( (spotCosAngle - half( light0Buf.lights[light_idx].spotParams.y )) * half( light0Buf.lights[light_idx].spotParams.x ) );
 			spotAtten = pow( spotAtten, light0Buf.lights[light_idx].spotParams.z );
 
 			@property( light_profiles_texture )
@@ -571,8 +584,10 @@
 														OGRE_PHOTOMETRIC_ARG );
 			@end
 
-			tmpColour = BRDF( lightDir, light0Buf.lights[light_idx].diffuse.xyz, light0Buf.lights[light_idx].specular, pixelData )@insertpiece( DarkenWithShadow_cur_shadow_map );
-			float atten = 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance );
+			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[light_idx].diffuse.xyz ),
+							  half3( light0Buf.lights[light_idx].specular ),
+							  pixelData )@insertpiece( DarkenWithShadow_cur_shadow_map );
+			half atten = half( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 		cur_shadow_map++;
@@ -583,18 +598,18 @@
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
 		@property( !hlms_lights_spot_textured )
-			spotCosAngle = dot( -lightDir, light0Buf.lights[@n].spotDirection.xyz );
+			spotCosAngle = dot( half3( -lightDir ), half3( light0Buf.lights[@n].spotDirection.xyz ) );
 		@else
-			spotCosAngle = dot( -lightDir, zAxis( light0Buf.lights[@n].spotQuaternion ) );
+			spotCosAngle = dot( half3( -lightDir ), half3( zAxis( light0Buf.lights[@n].spotQuaternion ) ) );
 		@end
 		if( fDistance <= light0Buf.lights[@n].attenuation.x && spotCosAngle >= light0Buf.lights[@n].spotParams.y @insertpiece( andObjLightMaskCmp ) )
 		{
 			@property( hlms_lights_spot_textured )
 				float3 posInLightSpace = qmul( spotQuaternion[@value(spot_params)], inPs.pos );
-				float spotAtten = texture( texSpotLight, normalize( posInLightSpace ).xy ).x; //TODO
+				half spotAtten = texture( texSpotLight, normalize( posInLightSpace ).xy ).x; //TODO
 			@else
-				float spotAtten = saturate( (spotCosAngle - light0Buf.lights[@n].spotParams.y) * light0Buf.lights[@n].spotParams.x );
-				spotAtten = pow( spotAtten, light0Buf.lights[@n].spotParams.z );
+				half spotAtten = saturate( (spotCosAngle - half( light0Buf.lights[@n].spotParams.y )) * half( light0Buf.lights[@n].spotParams.x ) );
+				spotAtten = pow( spotAtten, half( light0Buf.lights[@n].spotParams.z ) );
 			@end
 
 			@property( light_profiles_texture )
@@ -603,8 +618,10 @@
 														OGRE_PHOTOMETRIC_ARG );
 			@end
 
-			tmpColour = BRDF( lightDir, light0Buf.lights[@n].diffuse.xyz, light0Buf.lights[@n].specular, pixelData )@insertpiece( DarkenWithShadow );
-			float atten = 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance );
+			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[@n].diffuse.xyz ),
+							 half3( light0Buf.lights[@n].specular ),
+							 pixelData )@insertpiece( DarkenWithShadow );
+			half atten = half( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 	@end
@@ -836,11 +853,11 @@
 			@insertpiece( forward3dLighting )
 
 			@property( needs_env_brdf )
-				pixelData.envColourS = float3( 0, 0, 0 );
-				pixelData.envColourD = float3( 0, 0, 0 );
+				pixelData.envColourS = half3( 0, 0, 0 );
+				pixelData.envColourD = half3( 0, 0, 0 );
 
 				@property( clear_coat )
-					pixelData.clearCoatEnvColourS = float3( 0, 0, 0 );
+					pixelData.clearCoatEnvColourS = half3( 0, 0, 0 );
 				@end
 			@end
 

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -438,9 +438,9 @@
 			pixelData.viewDir	= half3_c( normalize( -inPs.pos ) );
 		@else
 			if( gl_FragCoord.x > passBuf.rightEyePixelStartX )
-				pixelData.viewDir += half3_c( -inPs.pos + passBuf.leftToRightView.xyz );
+				pixelData.viewDir = half3_c( normalize( -inPs.pos + passBuf.leftToRightView.xyz ) );
 			else
-				pixelData.viewDir += half3_c( -inPs.pos );
+				pixelData.viewDir = half3_c( normalize( -inPs.pos ) );
 		@end
 		pixelData.NdotV		= saturate( dot( pixelData.normal, pixelData.viewDir ) );
 	@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -404,7 +404,7 @@
 	@property( detail_maps_normal )
 	   @foreach( 4, n )
 		   @property( normal_weight_detail@n )
-			   @piece( detail@n_nm_weight_mul ) * material.normalWeights.@insertpiece( detail_swizzle@n )@end
+			   @piece( detail@n_nm_weight_mul ) * half_c( material.normalWeights.@insertpiece( detail_swizzle@n ) )@end
 		   @end
 	   @end
 	@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -1,5 +1,5 @@
-@piece( envSpecularRoughness ) pixelData.perceptualRoughness * half_c( passBuf.envMapNumMipmaps ) @end
-@piece( envSpecularRoughnessClearCoat ) pixelData.clearCoatPerceptualRoughness * half_c( passBuf.envMapNumMipmaps ) @end
+@piece( envSpecularRoughness ) pixelData.perceptualRoughness * midf_c( passBuf.envMapNumMipmaps ) @end
+@piece( envSpecularRoughnessClearCoat ) pixelData.clearCoatPerceptualRoughness * midf_c( passBuf.envMapNumMipmaps ) @end
 
 @piece( DefaultHeaderPS )
 	// START UNIFORM DECLARATION
@@ -14,11 +14,11 @@
 	// END UNIFORM DECLARATION
 
 	@property( !fresnel_scalar )
-		#define float_fresnel half
-		#define make_float_fresnel( x ) half_c( x )
+		#define float_fresnel midf
+		#define make_float_fresnel( x ) midf_c( x )
 	@else
-		#define float_fresnel half3
-		#define make_float_fresnel( x ) half3_c( x, x, x )
+		#define float_fresnel midf3
+		#define make_float_fresnel( x ) midf3_c( x, x, x )
 	@end
 
 	@insertpiece( DeclReverseDepthMacros )
@@ -38,43 +38,43 @@
 	struct PixelData
 	{
 		@property( !hlms_shadowcaster )
-			half3 normal;
+			midf3 normal;
 			@property( normal_map )
-				half3 geomNormal;
+				midf3 geomNormal;
 			@else
 				#define geomNormal normal
 			@end
-			half4	diffuse;
-			half3	specular;
+			midf4	diffuse;
+			midf3	specular;
 
 			@property( clear_coat )
-				half clearCoat;
-				half clearCoatPerceptualRoughness;
-				half clearCoatRoughness;
+				midf clearCoat;
+				midf clearCoatPerceptualRoughness;
+				midf clearCoatRoughness;
 			@end
 
-			half	perceptualRoughness;
-			half	roughness;
+			midf	perceptualRoughness;
+			midf	roughness;
 			float_fresnel	F0;
 
 			@property( needs_view_dir )
-				half3	viewDir;
-				half	NdotV;
+				midf3	viewDir;
+				midf	NdotV;
 			@end
 
 			@property( needs_refl_dir )
-				half3 reflDir;
+				midf3 reflDir;
 				@property( needs_env_brdf )
-					half3 envColourS;
-					half3 envColourD;
+					midf3 envColourS;
+					midf3 envColourD;
 
 					@property( clear_coat )
-						half3 clearCoatEnvColourS;
+						midf3 clearCoatEnvColourS;
 					@end
 				@end
 			@end
 		@else
-			half4 diffuse; //We only use the .w component, Alpha
+			midf4 diffuse; //We only use the .w component, Alpha
 		@end
 
 		@insertpiece( custom_ps_pixelData )
@@ -109,9 +109,9 @@
 	@end
 
 	@property( normal_map_tex || detail_maps_normal )
-		INLINE half3 reconstructZfromTSNormal( half2 tsNormal2 )
+		INLINE midf3 reconstructZfromTSNormal( midf2 tsNormal2 )
 		{
-			half3 tsNormal;
+			midf3 tsNormal;
 			tsNormal.xy = tsNormal2.xy;
 			tsNormal.z	= sqrt( max( _h(0.0f), _h(1.0f) - tsNormal.x * tsNormal.x - tsNormal.y * tsNormal.y ) );
 			return tsNormal.xyz;
@@ -138,7 +138,7 @@
 	@property( obb_restraint_approx || obb_restraint_ltc )
 		/// Returns value in range [-inf; 1]
 		/// Values <= 0 means 'pos' is outside the obb
-		half getObbRestraintFade( @property( syntax == metal )constant@end  float4 obbRestraint[3],
+		midf getObbRestraintFade( @property( syntax == metal )constant@end  float4 obbRestraint[3],
 								  float3 pos, float3 obbFadeFactors )
 		{
 			float3 obbDistToBounds;
@@ -149,7 +149,7 @@
 			obbDistToBounds = abs( obbDistToBounds );
 
 			float3 obbFade = (1.0 - obbDistToBounds) * obbFadeFactors;
-			return min( half_c( min3( obbFade.x, obbFade.y, obbFade.z ) ), _h( 1.0 ) );
+			return min( midf_c( min3( obbFade.x, obbFade.y, obbFade.z ) ), _h( 1.0 ) );
 		}
 	@end
 
@@ -231,16 +231,16 @@
 	@property( detail_maps_diffuse || detail_maps_normal )
 		//Prepare weight map for the detail maps.
 		@property( detail_weight_map )
-			half4 detailWeights = SampleDetailWeightMap( textureMaps@value(detail_weight_map_idx),
+			midf4 detailWeights = SampleDetailWeightMap( textureMaps@value(detail_weight_map_idx),
 														  samplerState@value(detail_weight_map_sampler),
 														  UV_DETAIL_WEIGHT( inPs.uv@value(uv_detail_weight).xy ),
 														  texIndex_weightMapIdx );
-			@property( detail_weights )detailWeights *= half4_c( material.cDetailWeights );@end
+			@property( detail_weights )detailWeights *= midf4_c( material.cDetailWeights );@end
 		@else
 			@property( detail_weights )
-				half4 detailWeights = half4_c( material.cDetailWeights );
+				midf4 detailWeights = midf4_c( material.cDetailWeights );
 			@else
-				half4 detailWeights = half4_c( 1.0, 1.0, 1.0, 1.0 );
+				midf4 detailWeights = midf4_c( 1.0, 1.0, 1.0, 1.0 );
 			@end
 		@end
 	@end
@@ -250,7 +250,7 @@
 	/// Sample detail maps and weight them against the weight map in the next foreach loop.
 	@foreach( detail_maps_diffuse, n )
 		@property( detail_map@n )
-			half4 detailCol@n = SampleDetailCol@n( textureMaps@value(detail_map@n_idx),
+			midf4 detailCol@n = SampleDetailCol@n( textureMaps@value(detail_map@n_idx),
 													samplerState@value(detail_map@n_sampler),
                                                     UV_DETAIL@n( inPs.uv@value(uv_detail@n).xy@insertpiece( offsetDetail@n ) ),
                                                     texIndex_detailMapIdx@n );
@@ -269,7 +269,7 @@
 										   texIndex_diffuseIdx );
 	@else
 		/// If there are no diffuse maps, we must initialize it to some value.
-		pixelData.diffuse.xyzw = half4_c( material.bgDiffuse.xyzw );
+		pixelData.diffuse.xyzw = midf4_c( material.bgDiffuse.xyzw );
 	@end
 
 	/// Blend the detail diffuse maps with the main diffuse.
@@ -277,7 +277,7 @@
 		@insertpiece( blend_mode_idx@n ) @add( t, 1 ) @end
 
 	/// Apply the material's diffuse over the textures
-	pixelData.diffuse.xyz *= half3_c( material.kD.xyz );
+	pixelData.diffuse.xyz *= midf3_c( material.kD.xyz );
 	@property( transparent_mode || hlms_screen_space_refractions )
 		pixelData.diffuse.xyz *= (pixelData.diffuse.w * pixelData.diffuse.w);
 	@end
@@ -290,7 +290,7 @@
 
 @piece( SampleSpecularMap )
 	/// SPECUlAR MAP
-	pixelData.specular.xyz = half3_c( material.kS.xyz );
+	pixelData.specular.xyz = midf3_c( material.kS.xyz );
 	@property( !metallic_workflow )
 		pixelData.F0 = make_float_fresnel( material.F0.@insertpiece( FresnelSwizzle ) );
 		@property( specular_map && !fresnel_workflow )
@@ -306,7 +306,7 @@
 											texIndex_specularIdx ).@insertpiece( FresnelSwizzle );
 		@end
 	@else
-		half metalness = half_c( material.F0.x );
+		midf metalness = midf_c( material.F0.x );
 		@property( specular_map )
 			metalness *= SampleSpecular( textureMaps@value( specular_map_idx ),
 										 samplerState@value(specular_map_sampler),
@@ -316,7 +316,7 @@
 		pixelData.F0 = lerp( make_float_fresnel( 0.03f ), pixelData.diffuse.xyz * _h( 3.14159f ), metalness );
 		pixelData.diffuse.xyz = pixelData.diffuse.xyz - pixelData.diffuse.xyz * metalness;
 		@property( hlms_alphablend || hlms_screen_space_refractions )
-			pixelData.F0 *= half_c( material.F0.w ); ///Should this be done for non-metallic as well???
+			pixelData.F0 *= midf_c( material.F0.w ); ///Should this be done for non-metallic as well???
 		@end
 	@end
 	@property( transparent_mode || hlms_screen_space_refractions )
@@ -326,7 +326,7 @@
 
 @piece( SampleRoughnessMap )
 	/// ROUGHNESS MAP
-	pixelData.perceptualRoughness = half_c( material.kS.w );
+	pixelData.perceptualRoughness = midf_c( material.kS.w );
 	@property( roughness_map )
 		pixelData.perceptualRoughness *=
 			SampleRoughness( textureMaps@value( roughness_map_idx ),
@@ -365,15 +365,15 @@
 	@else
 		//Normal mapping.
 		pixelData.geomNormal = normalize( inPs.normal ) @insertpiece( two_sided_flip_normal );
-		half3 vTangent		= normalize( inPs.tangent );
+		midf3 vTangent		= normalize( inPs.tangent );
 
 		@property( hlms_qtangent || hlms_tangent4 )
 			@piece( tbnApplyReflection ) * inPs.biNormalReflection@end
 		@end
 
 		//Get the TBN matrix
-		half3 vBinormal	= normalize( cross( pixelData.geomNormal, vTangent )@insertpiece( tbnApplyReflection ) );
-		half3x3 TBN		= buildHalf3x3( vTangent, vBinormal, pixelData.geomNormal );
+		midf3 vBinormal	= normalize( cross( pixelData.geomNormal, vTangent )@insertpiece( tbnApplyReflection ) );
+		midf3x3 TBN		= buildMidf3x3( vTangent, vBinormal, pixelData.geomNormal );
 
 		@property( normal_map_tex )
 			pixelData.normal = getTSNormal( textureMaps@value( normal_map_tex_idx ),
@@ -381,11 +381,11 @@
 											UV_NORMAL( inPs.uv@value(uv_normal).xy ),
 											texIndex_normalIdx );
 		@else
-			pixelData.normal = half3_c( 0.0, 0.0, 1.0 );
+			pixelData.normal = midf3_c( 0.0, 0.0, 1.0 );
 		@end
 		@property( normal_weight_tex )
 			// Apply the weight to the main normal map
-			pixelData.normal = lerp( half3_c( 0.0, 0.0, 1.0 ), pixelData.normal, normalMapWeight );
+			pixelData.normal = lerp( midf3_c( 0.0, 0.0, 1.0 ), pixelData.normal, normalMapWeight );
 		@end
 	@end
 @end
@@ -404,7 +404,7 @@
 	@property( detail_maps_normal )
 	   @foreach( 4, n )
 		   @property( normal_weight_detail@n )
-			   @piece( detail@n_nm_weight_mul ) * half_c( material.normalWeights.@insertpiece( detail_swizzle@n ) )@end
+			   @piece( detail@n_nm_weight_mul ) * midf_c( material.normalWeights.@insertpiece( detail_swizzle@n ) )@end
 		   @end
 	   @end
 	@end
@@ -435,27 +435,27 @@
 	//Everything's in Camera space
 	@property( needs_view_dir )
 		@property( !hlms_instanced_stereo )
-			pixelData.viewDir	= half3_c( normalize( -inPs.pos ) );
+			pixelData.viewDir	= midf3_c( normalize( -inPs.pos ) );
 		@else
 			if( gl_FragCoord.x > passBuf.rightEyePixelStartX )
-				pixelData.viewDir = half3_c( normalize( -inPs.pos + passBuf.leftToRightView.xyz ) );
+				pixelData.viewDir = midf3_c( normalize( -inPs.pos + passBuf.leftToRightView.xyz ) );
 			else
-				pixelData.viewDir = half3_c( normalize( -inPs.pos ) );
+				pixelData.viewDir = midf3_c( normalize( -inPs.pos ) );
 		@end
 		pixelData.NdotV		= saturate( dot( pixelData.normal, pixelData.viewDir ) );
 	@end
 
 	@property( !ambient_fixed || vct_num_probes )
-		half3 finalColour = half3_c(0, 0, 0);
+		midf3 finalColour = midf3_c(0, 0, 0);
 	@else
-		half3 finalColour = half3_c( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz;
+		midf3 finalColour = midf3_c( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz;
 	@end
 
 	@property( hlms_static_branch_shadow_map_lights || hlms_lights_point || hlms_lights_spot || hlms_lights_area_approx || hlms_lights_area_ltc )
 		float3 lightDir;
 		float fDistance;
-		half3 tmpColour;
-		half spotCosAngle;
+		midf3 tmpColour;
+		midf spotCosAngle;
 	@end
 
 	@property( hlms_static_branch_shadow_map_lights )
@@ -490,30 +490,30 @@
 @piece( DoDirectionalLights )
 	@property( hlms_lights_directional )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( half3_c( light0Buf.lights[0].position.xyz ),
-								 half3_c( light0Buf.lights[0].diffuse.xyz ),
-								 half3_c( light0Buf.lights[0].specular ), pixelData ) @insertpiece( DarkenWithShadowFirstLight );
+			finalColour += BRDF( midf3_c( light0Buf.lights[0].position.xyz ),
+								 midf3_c( light0Buf.lights[0].diffuse.xyz ),
+								 midf3_c( light0Buf.lights[0].specular ), pixelData ) @insertpiece( DarkenWithShadowFirstLight );
 	@end
 	@foreach( hlms_lights_directional, n, 1 )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( half3_c( light0Buf.lights[@n].position.xyz ),
-								 half3_c( light0Buf.lights[@n].diffuse.xyz ),
-								 half3_c( light0Buf.lights[@n].specular ), pixelData )@insertpiece( DarkenWithShadow );@end
+			finalColour += BRDF( midf3_c( light0Buf.lights[@n].position.xyz ),
+								 midf3_c( light0Buf.lights[@n].diffuse.xyz ),
+								 midf3_c( light0Buf.lights[@n].specular ), pixelData )@insertpiece( DarkenWithShadow );@end
 
 	@property( !hlms_static_branch_lights )
 		@foreach( hlms_lights_directional_non_caster, n, hlms_lights_directional )
 			@insertpiece( ObjLightMaskCmp )
-				finalColour += BRDF( half3_c( light0Buf.lights[@n].position.xyz ),
-									 half3_c( light0Buf.lights[@n].diffuse.xyz ),
-									 half3_c( light0Buf.lights[@n].specular ), pixelData );@end
+				finalColour += BRDF( midf3_c( light0Buf.lights[@n].position.xyz ),
+									 midf3_c( light0Buf.lights[@n].diffuse.xyz ),
+									 midf3_c( light0Buf.lights[@n].specular ), pixelData );@end
 	@else
 		for( int n=0; n<floatBitsToInt( light0Buf.numNonCasterDirectionalLights ); ++n )
 		{
 			int i = @value( hlms_lights_directional ) + n;
 			@insertpiece( ObjLightMaskCmpNonCasterLoop )
-				finalColour += BRDF( half3_c( light0Buf.lights[i].position.xyz ),
-									 half3_c( light0Buf.lights[i].diffuse.xyz ),
-									 half3_c( light0Buf.lights[i].specular ), pixelData );
+				finalColour += BRDF( midf3_c( light0Buf.lights[i].position.xyz ),
+									 midf3_c( light0Buf.lights[i].diffuse.xyz ),
+									 midf3_c( light0Buf.lights[i].specular ), pixelData );
 		}
 		/// Increase fineMaskLightIdx to keep it working with spot/point lights
 		@insertpiece( ObjLightMaskCmpNonCasterLoopEnd )
@@ -534,10 +534,10 @@
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[light_idx].diffuse.xyz ),
-							  half3_c( light0Buf.lights[light_idx].specular ),
+			tmpColour = BRDF( midf3_c( lightDir ), midf3_c( light0Buf.lights[light_idx].diffuse.xyz ),
+							  midf3_c( light0Buf.lights[light_idx].specular ),
 							  pixelData )@insertpiece( DarkenWithShadowPoint_cur_shadow_map );
-			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * atten;
 		}
 		cur_shadow_map++;
@@ -549,10 +549,10 @@
 		if( fDistance <= light0Buf.lights[@n].attenuation.x @insertpiece( andObjLightMaskCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[@n].diffuse.xyz ),
-							  half3_c( light0Buf.lights[@n].specular ),
+			tmpColour = BRDF( midf3_c( lightDir ), midf3_c( light0Buf.lights[@n].diffuse.xyz ),
+							  midf3_c( light0Buf.lights[@n].specular ),
 							  pixelData )@insertpiece( DarkenWithShadowPoint );
-			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * atten;
 		}
 	@end
@@ -572,11 +572,11 @@
 		lightDir = light0Buf.lights[light_idx].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
-		spotCosAngle = dot( half3_c( -lightDir ), half3_c( light0Buf.lights[light_idx].spotDirection.xyz ) );
+		spotCosAngle = dot( midf3_c( -lightDir ), midf3_c( light0Buf.lights[light_idx].spotDirection.xyz ) );
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x && spotCosAngle >= light0Buf.lights[light_idx].spotParams.y @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
-			half spotAtten = saturate( (spotCosAngle - half_c( light0Buf.lights[light_idx].spotParams.y )) * half_c( light0Buf.lights[light_idx].spotParams.x ) );
-			spotAtten = pow( spotAtten, half_c( light0Buf.lights[light_idx].spotParams.z ) );
+			midf spotAtten = saturate( (spotCosAngle - midf_c( light0Buf.lights[light_idx].spotParams.y )) * midf_c( light0Buf.lights[light_idx].spotParams.x ) );
+			spotAtten = pow( spotAtten, midf_c( light0Buf.lights[light_idx].spotParams.z ) );
 
 			@property( light_profiles_texture )
 				spotAtten *= getPhotometricAttenuation( spotCosAngle,
@@ -584,10 +584,10 @@
 														OGRE_PHOTOMETRIC_ARG );
 			@end
 
-			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[light_idx].diffuse.xyz ),
-							  half3_c( light0Buf.lights[light_idx].specular ),
+			tmpColour = BRDF( midf3_c( lightDir ), midf3_c( light0Buf.lights[light_idx].diffuse.xyz ),
+							  midf3_c( light0Buf.lights[light_idx].specular ),
 							  pixelData )@insertpiece( DarkenWithShadow_cur_shadow_map );
-			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 		cur_shadow_map++;
@@ -598,18 +598,18 @@
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
 		@property( !hlms_lights_spot_textured )
-			spotCosAngle = dot( half3_c( -lightDir ), half3_c( light0Buf.lights[@n].spotDirection.xyz ) );
+			spotCosAngle = dot( midf3_c( -lightDir ), midf3_c( light0Buf.lights[@n].spotDirection.xyz ) );
 		@else
-			spotCosAngle = dot( half3_c( -lightDir ), zAxis( half4_c( light0Buf.lights[@n].spotQuaternion ) ) );
+			spotCosAngle = dot( midf3_c( -lightDir ), zAxis( midf4_c( light0Buf.lights[@n].spotQuaternion ) ) );
 		@end
 		if( fDistance <= light0Buf.lights[@n].attenuation.x && spotCosAngle >= light0Buf.lights[@n].spotParams.y @insertpiece( andObjLightMaskCmp ) )
 		{
 			@property( hlms_lights_spot_textured )
 				float3 posInLightSpace = qmul( spotQuaternion[@value(spot_params)], inPs.pos );
-				half spotAtten = texture( texSpotLight, normalize( posInLightSpace ).xy ).x; //TODO
+				midf spotAtten = texture( texSpotLight, normalize( posInLightSpace ).xy ).x; //TODO
 			@else
-				half spotAtten = saturate( (spotCosAngle - half_c( light0Buf.lights[@n].spotParams.y )) * half_c( light0Buf.lights[@n].spotParams.x ) );
-				spotAtten = pow( spotAtten, half_c( light0Buf.lights[@n].spotParams.z ) );
+				midf spotAtten = saturate( (spotCosAngle - midf_c( light0Buf.lights[@n].spotParams.y )) * midf_c( light0Buf.lights[@n].spotParams.x ) );
+				spotAtten = pow( spotAtten, midf_c( light0Buf.lights[@n].spotParams.z ) );
 			@end
 
 			@property( light_profiles_texture )
@@ -618,10 +618,10 @@
 														OGRE_PHOTOMETRIC_ARG );
 			@end
 
-			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[@n].diffuse.xyz ),
-							  half3_c( light0Buf.lights[@n].specular ),
+			tmpColour = BRDF( midf3_c( lightDir ), midf3_c( light0Buf.lights[@n].diffuse.xyz ),
+							  midf3_c( light0Buf.lights[@n].specular ),
 							  pixelData )@insertpiece( DarkenWithShadow );
-			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
+			midf atten = midf_c( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 	@end
@@ -632,26 +632,26 @@
 	@property( emissive_map || emissive_constant )
 		///Emissive is not part of PixelData because emissive can just be accumulated to finalColour
 		@property( emissive_map )
-			half3 emissiveCol = SampleEmissive( textureMaps@value( emissive_map_idx ),
+			midf3 emissiveCol = SampleEmissive( textureMaps@value( emissive_map_idx ),
 												samplerState@value(emissive_map_sampler),
 												UV_EMISSIVE( inPs.uv@value(uv_emissive).xy ),
 												texIndex_emissiveMapIdx ).xyz;
 			@property( emissive_constant )
-				emissiveCol *= half3_c( material.emissive.xyz );
+				emissiveCol *= midf3_c( material.emissive.xyz );
 			@end
 			@property( emissive_as_lightmap )
 				emissiveCol *= pixelData.diffuse.xyz;
 			@end
 			finalColour += emissiveCol;
 		@else
-			finalColour += half3_c( material.emissive.xyz );
+			finalColour += midf3_c( material.emissive.xyz );
 		@end
 	@end
 @end
 
 @piece( CubemapManualPcc )
-	half3 posInProbSpace = half3_c( toProbeLocalSpace( inPs.pos, @insertpiece( pccProbeSource ) ) );
-	half probeFade = getProbeFade( posInProbSpace, @insertpiece( pccProbeSource ) );
+	midf3 posInProbSpace = midf3_c( toProbeLocalSpace( inPs.pos, @insertpiece( pccProbeSource ) ) );
+	midf probeFade = getProbeFade( posInProbSpace, @insertpiece( pccProbeSource ) );
 @property( vct_num_probes )
 	if( probeFade > _h( 0 ) && (pixelData.roughness < _h( 1.0f ) || vctSpecular.w == 0) )
 @else
@@ -666,13 +666,13 @@
 			float3 reflDirLS = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
 		@end
 		float3 nNormalLS = localCorrect( pixelData.normal, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
-		half4 envS = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
+		midf4 envS = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
 									 reflDirLS, @insertpiece( envSpecularRoughness ) );
 		@property( envmap_scale )
-			envS.xyz *= half3_c( passBuf.ambientUpperHemi.w );
+			envS.xyz *= midf3_c( passBuf.ambientUpperHemi.w );
 		@end
 		@property( cubemaps_as_diffuse_gi )
-			half3 envD = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
+			midf3 envD = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
 										 nNormalLS, 11.0 ).xyz @insertpiece( ApplyEnvMapScale );
 			envD.xyz *= probeFade;
 		@end
@@ -680,7 +680,7 @@
 		envS.xyz *= probeFade;
 
 		@property( clear_coat )
-			half3 clearCoatEnvS = SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+			midf3 clearCoatEnvS = SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
 												  reflDirLS,
 												  @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 			clearCoatEnvS *= probeFade;
@@ -697,7 +697,7 @@
 
 			pixelData.envColourS = lerp( envS.xyz, pixelData.envColourS, vctLerp );
 			@property( cubemaps_as_diffuse_gi )
-				pixelData.envColourD += vctSpecular.w > 0 ? half3_c( 0, 0, 0 ) : envD;
+				pixelData.envColourD += vctSpecular.w > 0 ? midf3_c( 0, 0, 0 ) : envD;
 			@end
 
 			@property( clear_coat )
@@ -718,17 +718,17 @@
 
 @piece( CubemapGlobal )
 	pixelData.envColourS += SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
-											mul( pixelData.reflDir, half3x3_c( passBuf.invViewMatCubemap ) ),
+											mul( pixelData.reflDir, midf3x3_c( passBuf.invViewMatCubemap ) ),
 											@insertpiece( envSpecularRoughness ) ).xyz @insertpiece( ApplyEnvMapScale );
 	@property( cubemaps_as_diffuse_gi )
 		pixelData.envColourD += SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
-												mul( pixelData.normal, half3x3_c( passBuf.invViewMatCubemap ) ),
+												mul( pixelData.normal, midf3x3_c( passBuf.invViewMatCubemap ) ),
 												11.0 ).xyz @insertpiece( ApplyEnvMapScale );
 	@end
 
 	@property( clear_coat )
 		pixelData.clearCoatEnvColourS += SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
-														 mul( pixelData.reflDir, half3x3_c( passBuf.invViewMatCubemap ) ),
+														 mul( pixelData.reflDir, midf3x3_c( passBuf.invViewMatCubemap ) ),
 														 @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 	@end
 @end
@@ -853,11 +853,11 @@
 			@insertpiece( forward3dLighting )
 
 			@property( needs_env_brdf )
-				pixelData.envColourS = half3_c( 0, 0, 0 );
-				pixelData.envColourD = half3_c( 0, 0, 0 );
+				pixelData.envColourS = midf3_c( 0, 0, 0 );
+				pixelData.envColourD = midf3_c( 0, 0, 0 );
 
 				@property( clear_coat )
-					pixelData.clearCoatEnvColourS = half3_c( 0, 0, 0 );
+					pixelData.clearCoatEnvColourS = midf3_c( 0, 0, 0 );
 				@end
 			@end
 
@@ -912,9 +912,9 @@
 
 				@property( hlms_alphablend || hlms_alpha_to_coverage )
 					@property( use_texture_alpha )
-						outPs_colour0.w	= half_c( material.F0.w * pixelData.diffuse.w );
+						outPs_colour0.w	= midf_c( material.F0.w * pixelData.diffuse.w );
 					@else
-						outPs_colour0.w	= half_c( material.F0.w );
+						outPs_colour0.w	= midf_c( material.F0.w );
 					@end
 				@else
 					outPs_colour0.w		= _h( 1.0 );

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -15,10 +15,10 @@
 
 	@property( !fresnel_scalar )
 		#define float_fresnel half
-		#define make_float_fresnel( x ) x
+		#define make_float_fresnel( x ) half_c( x )
 	@else
 		#define float_fresnel half3
-		#define make_float_fresnel( x ) half3( x, x, x )
+		#define make_float_fresnel( x ) half3_c( x, x, x )
 	@end
 
 	@insertpiece( DeclReverseDepthMacros )
@@ -235,12 +235,12 @@
 														  samplerState@value(detail_weight_map_sampler),
 														  UV_DETAIL_WEIGHT( inPs.uv@value(uv_detail_weight).xy ),
 														  texIndex_weightMapIdx );
-			@property( detail_weights )detailWeights *= half4( material.cDetailWeights );@end
+			@property( detail_weights )detailWeights *= half4_c( material.cDetailWeights );@end
 		@else
 			@property( detail_weights )
-				half4 detailWeights = half4( material.cDetailWeights );
+				half4 detailWeights = half4_c( material.cDetailWeights );
 			@else
-				half4 detailWeights = half4( 1.0, 1.0, 1.0, 1.0 );
+				half4 detailWeights = half4_c( 1.0, 1.0, 1.0, 1.0 );
 			@end
 		@end
 	@end
@@ -269,7 +269,7 @@
 										   texIndex_diffuseIdx );
 	@else
 		/// If there are no diffuse maps, we must initialize it to some value.
-		pixelData.diffuse.xyzw = half4( material.bgDiffuse.xyzw );
+		pixelData.diffuse.xyzw = half4_c( material.bgDiffuse.xyzw );
 	@end
 
 	/// Blend the detail diffuse maps with the main diffuse.
@@ -277,7 +277,7 @@
 		@insertpiece( blend_mode_idx@n ) @add( t, 1 ) @end
 
 	/// Apply the material's diffuse over the textures
-	pixelData.diffuse.xyz *= half3( material.kD.xyz );
+	pixelData.diffuse.xyz *= half3_c( material.kD.xyz );
 	@property( transparent_mode || hlms_screen_space_refractions )
 		pixelData.diffuse.xyz *= (pixelData.diffuse.w * pixelData.diffuse.w);
 	@end
@@ -290,9 +290,9 @@
 
 @piece( SampleSpecularMap )
 	/// SPECUlAR MAP
-	pixelData.specular.xyz = half3( material.kS.xyz );
+	pixelData.specular.xyz = half3_c( material.kS.xyz );
 	@property( !metallic_workflow )
-		pixelData.F0 = float_fresnel( material.F0.@insertpiece( FresnelSwizzle ) );
+		pixelData.F0 = make_float_fresnel( material.F0.@insertpiece( FresnelSwizzle ) );
 		@property( specular_map && !fresnel_workflow )
 			pixelData.specular.xyz *= SampleSpecular( textureMaps@value( specular_map_idx ),
 													  samplerState@value(specular_map_sampler),
@@ -306,7 +306,7 @@
 											texIndex_specularIdx ).@insertpiece( FresnelSwizzle );
 		@end
 	@else
-		half metalness = half( material.F0.x );
+		half metalness = half_c( material.F0.x );
 		@property( specular_map )
 			metalness *= SampleSpecular( textureMaps@value( specular_map_idx ),
 										 samplerState@value(specular_map_sampler),
@@ -316,7 +316,7 @@
 		pixelData.F0 = lerp( make_float_fresnel( 0.03f ), pixelData.diffuse.xyz * _h( 3.14159f ), metalness );
 		pixelData.diffuse.xyz = pixelData.diffuse.xyz - pixelData.diffuse.xyz * metalness;
 		@property( hlms_alphablend || hlms_screen_space_refractions )
-			pixelData.F0 *= half( material.F0.w ); ///Should this be done for non-metallic as well???
+			pixelData.F0 *= half_c( material.F0.w ); ///Should this be done for non-metallic as well???
 		@end
 	@end
 	@property( transparent_mode || hlms_screen_space_refractions )
@@ -326,7 +326,7 @@
 
 @piece( SampleRoughnessMap )
 	/// ROUGHNESS MAP
-	pixelData.perceptualRoughness = half( material.kS.w );
+	pixelData.perceptualRoughness = half_c( material.kS.w );
 	@property( roughness_map )
 		pixelData.perceptualRoughness *=
 			SampleRoughness( textureMaps@value( roughness_map_idx ),
@@ -381,11 +381,11 @@
 											UV_NORMAL( inPs.uv@value(uv_normal).xy ),
 											texIndex_normalIdx );
 		@else
-			pixelData.normal = half3( 0.0, 0.0, 1.0 );
+			pixelData.normal = half3_c( 0.0, 0.0, 1.0 );
 		@end
 		@property( normal_weight_tex )
 			// Apply the weight to the main normal map
-			pixelData.normal = lerp( half3( 0.0, 0.0, 1.0 ), pixelData.normal, normalMapWeight );
+			pixelData.normal = lerp( half3_c( 0.0, 0.0, 1.0 ), pixelData.normal, normalMapWeight );
 		@end
 	@end
 @end
@@ -435,20 +435,20 @@
 	//Everything's in Camera space
 	@property( needs_view_dir )
 		@property( !hlms_instanced_stereo )
-			pixelData.viewDir	= half3( normalize( -inPs.pos ) );
+			pixelData.viewDir	= half3_c( normalize( -inPs.pos ) );
 		@else
 			if( gl_FragCoord.x > passBuf.rightEyePixelStartX )
-				pixelData.viewDir += half3( -inPs.pos + passBuf.leftToRightView.xyz );
+				pixelData.viewDir += half3_c( -inPs.pos + passBuf.leftToRightView.xyz );
 			else
-				pixelData.viewDir += half3( -inPs.pos );
+				pixelData.viewDir += half3_c( -inPs.pos );
 		@end
 		pixelData.NdotV		= saturate( dot( pixelData.normal, pixelData.viewDir ) );
 	@end
 
 	@property( !ambient_fixed || vct_num_probes )
-		half3 finalColour = half3(0, 0, 0);
+		half3 finalColour = half3_c(0, 0, 0);
 	@else
-		half3 finalColour = half3( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz;
+		half3 finalColour = half3_c( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz;
 	@end
 
 	@property( hlms_static_branch_shadow_map_lights || hlms_lights_point || hlms_lights_spot || hlms_lights_area_approx || hlms_lights_area_ltc )
@@ -490,30 +490,30 @@
 @piece( DoDirectionalLights )
 	@property( hlms_lights_directional )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( half3( light0Buf.lights[0].position.xyz ),
-								 half3( light0Buf.lights[0].diffuse.xyz ),
-								 half3( light0Buf.lights[0].specular ), pixelData ) @insertpiece( DarkenWithShadowFirstLight );
+			finalColour += BRDF( half3_c( light0Buf.lights[0].position.xyz ),
+								 half3_c( light0Buf.lights[0].diffuse.xyz ),
+								 half3_c( light0Buf.lights[0].specular ), pixelData ) @insertpiece( DarkenWithShadowFirstLight );
 	@end
 	@foreach( hlms_lights_directional, n, 1 )
 		@insertpiece( ObjLightMaskCmp )
-			finalColour += BRDF( half3( light0Buf.lights[@n].position.xyz ),
-								 half3( light0Buf.lights[@n].diffuse.xyz ),
-								 half3( light0Buf.lights[@n].specular, pixelData ) )@insertpiece( DarkenWithShadow );@end
+			finalColour += BRDF( half3_c( light0Buf.lights[@n].position.xyz ),
+								 half3_c( light0Buf.lights[@n].diffuse.xyz ),
+								 half3_c( light0Buf.lights[@n].specular, pixelData ) )@insertpiece( DarkenWithShadow );@end
 
 	@property( !hlms_static_branch_lights )
 		@foreach( hlms_lights_directional_non_caster, n, hlms_lights_directional )
 			@insertpiece( ObjLightMaskCmp )
-				finalColour += BRDF( half3( light0Buf.lights[@n].position.xyz ),
-									 half3( light0Buf.lights[@n].diffuse.xyz ),
-									 half3( light0Buf.lights[@n].specular ), pixelData );@end
+				finalColour += BRDF( half3_c( light0Buf.lights[@n].position.xyz ),
+									 half3_c( light0Buf.lights[@n].diffuse.xyz ),
+									 half3_c( light0Buf.lights[@n].specular ), pixelData );@end
 	@else
 		for( int n=0; n<floatBitsToInt( light0Buf.numNonCasterDirectionalLights ); ++n )
 		{
 			int i = @value( hlms_lights_directional ) + n;
 			@insertpiece( ObjLightMaskCmpNonCasterLoop )
-				finalColour += BRDF( half3( light0Buf.lights[i].position.xyz ),
-									half3( light0Buf.lights[i].diffuse.xyz ),
-									half3( light0Buf.lights[i].specular ), pixelData );
+				finalColour += BRDF( half3_c( light0Buf.lights[i].position.xyz ),
+									 half3_c( light0Buf.lights[i].diffuse.xyz ),
+									 half3_c( light0Buf.lights[i].specular ), pixelData );
 		}
 		/// Increase fineMaskLightIdx to keep it working with spot/point lights
 		@insertpiece( ObjLightMaskCmpNonCasterLoopEnd )
@@ -534,10 +534,10 @@
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[light_idx].diffuse.xyz ),
-							  half3( light0Buf.lights[light_idx].specular ),
+			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[light_idx].diffuse.xyz ),
+							  half3_c( light0Buf.lights[light_idx].specular ),
 							  pixelData )@insertpiece( DarkenWithShadowPoint_cur_shadow_map );
-			half atten = half( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
+			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * atten;
 		}
 		cur_shadow_map++;
@@ -549,10 +549,10 @@
 		if( fDistance <= light0Buf.lights[@n].attenuation.x @insertpiece( andObjLightMaskCmp ) )
 		{
 			lightDir *= 1.0 / fDistance;
-			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[@n].diffuse.xyz ),
-							  half3( light0Buf.lights[@n].specular ),
+			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[@n].diffuse.xyz ),
+							  half3_c( light0Buf.lights[@n].specular ),
 							  pixelData )@insertpiece( DarkenWithShadowPoint );
-			half atten = half( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
+			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * atten;
 		}
 	@end
@@ -572,10 +572,10 @@
 		lightDir = light0Buf.lights[light_idx].position.xyz - inPs.pos;
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
-		spotCosAngle = dot( half3( -lightDir ), half3( light0Buf.lights[light_idx].spotDirection.xyz ) );
+		spotCosAngle = dot( half3_c( -lightDir ), half3_c( light0Buf.lights[light_idx].spotDirection.xyz ) );
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x && spotCosAngle >= light0Buf.lights[light_idx].spotParams.y @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
-			half spotAtten = saturate( (spotCosAngle - half( light0Buf.lights[light_idx].spotParams.y )) * half( light0Buf.lights[light_idx].spotParams.x ) );
+			half spotAtten = saturate( (spotCosAngle - half_c( light0Buf.lights[light_idx].spotParams.y )) * half_c( light0Buf.lights[light_idx].spotParams.x ) );
 			spotAtten = pow( spotAtten, light0Buf.lights[light_idx].spotParams.z );
 
 			@property( light_profiles_texture )
@@ -584,10 +584,10 @@
 														OGRE_PHOTOMETRIC_ARG );
 			@end
 
-			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[light_idx].diffuse.xyz ),
-							  half3( light0Buf.lights[light_idx].specular ),
+			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[light_idx].diffuse.xyz ),
+							  half3_c( light0Buf.lights[light_idx].specular ),
 							  pixelData )@insertpiece( DarkenWithShadow_cur_shadow_map );
-			half atten = half( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
+			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[light_idx].attenuation.y + light0Buf.lights[light_idx].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 		cur_shadow_map++;
@@ -598,9 +598,9 @@
 		fDistance= length( lightDir );
 		lightDir *= 1.0 / fDistance;
 		@property( !hlms_lights_spot_textured )
-			spotCosAngle = dot( half3( -lightDir ), half3( light0Buf.lights[@n].spotDirection.xyz ) );
+			spotCosAngle = dot( half3_c( -lightDir ), half3_c( light0Buf.lights[@n].spotDirection.xyz ) );
 		@else
-			spotCosAngle = dot( half3( -lightDir ), half3( zAxis( light0Buf.lights[@n].spotQuaternion ) ) );
+			spotCosAngle = dot( half3_c( -lightDir ), zAxis( half4_c( light0Buf.lights[@n].spotQuaternion ) ) );
 		@end
 		if( fDistance <= light0Buf.lights[@n].attenuation.x && spotCosAngle >= light0Buf.lights[@n].spotParams.y @insertpiece( andObjLightMaskCmp ) )
 		{
@@ -608,8 +608,8 @@
 				float3 posInLightSpace = qmul( spotQuaternion[@value(spot_params)], inPs.pos );
 				half spotAtten = texture( texSpotLight, normalize( posInLightSpace ).xy ).x; //TODO
 			@else
-				half spotAtten = saturate( (spotCosAngle - half( light0Buf.lights[@n].spotParams.y )) * half( light0Buf.lights[@n].spotParams.x ) );
-				spotAtten = pow( spotAtten, half( light0Buf.lights[@n].spotParams.z ) );
+				half spotAtten = saturate( (spotCosAngle - half_c( light0Buf.lights[@n].spotParams.y )) * half_c( light0Buf.lights[@n].spotParams.x ) );
+				spotAtten = pow( spotAtten, half_c( light0Buf.lights[@n].spotParams.z ) );
 			@end
 
 			@property( light_profiles_texture )
@@ -618,10 +618,10 @@
 														OGRE_PHOTOMETRIC_ARG );
 			@end
 
-			tmpColour = BRDF( half3( lightDir ), half3( light0Buf.lights[@n].diffuse.xyz ),
-							 half3( light0Buf.lights[@n].specular ),
-							 pixelData )@insertpiece( DarkenWithShadow );
-			half atten = half( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
+			tmpColour = BRDF( half3_c( lightDir ), half3_c( light0Buf.lights[@n].diffuse.xyz ),
+							  half3_c( light0Buf.lights[@n].specular ),
+							  pixelData )@insertpiece( DarkenWithShadow );
+			half atten = half_c( 1.0 / (0.5 + (light0Buf.lights[@n].attenuation.y + light0Buf.lights[@n].attenuation.z * fDistance) * fDistance ) );
 			finalColour += tmpColour * (atten * spotAtten);
 		}
 	@end
@@ -637,14 +637,14 @@
 												 UV_EMISSIVE( inPs.uv@value(uv_emissive).xy ),
 												 texIndex_emissiveMapIdx ).xyz;
 			@property( emissive_constant )
-				emissiveCol *= material.emissive.xyz;
+				emissiveCol *= half3_c( material.emissive.xyz );
 			@end
 			@property( emissive_as_lightmap )
 				emissiveCol *= pixelData.diffuse.xyz;
 			@end
 			finalColour += emissiveCol;
 		@else
-			finalColour += material.emissive.xyz;
+			finalColour += half3_c( material.emissive.xyz );
 		@end
 	@end
 @end
@@ -853,11 +853,11 @@
 			@insertpiece( forward3dLighting )
 
 			@property( needs_env_brdf )
-				pixelData.envColourS = half3( 0, 0, 0 );
-				pixelData.envColourD = half3( 0, 0, 0 );
+				pixelData.envColourS = half3_c( 0, 0, 0 );
+				pixelData.envColourD = half3_c( 0, 0, 0 );
 
 				@property( clear_coat )
-					pixelData.clearCoatEnvColourS = half3( 0, 0, 0 );
+					pixelData.clearCoatEnvColourS = half3_c( 0, 0, 0 );
 				@end
 			@end
 
@@ -912,12 +912,12 @@
 
 				@property( hlms_alphablend || hlms_alpha_to_coverage )
 					@property( use_texture_alpha )
-						outPs_colour0.w	= material.F0.w * pixelData.diffuse.w;
+						outPs_colour0.w	= half_c( material.F0.w * pixelData.diffuse.w );
 					@else
-						outPs_colour0.w	= material.F0.w;
+						outPs_colour0.w	= half_c( material.F0.w );
 					@end
 				@else
-					outPs_colour0.w		= 1.0;
+					outPs_colour0.w		= _h( 1.0 );
 				@end
 
 				@property( debug_pssm_splits )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -97,7 +97,11 @@
 		#define SampleEmissive( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx ) @property( emissive_map_grayscale ).rrr@end
 	@end
 	@property( use_envprobe_map )
-		#define SampleEnvProbe( tex, sampler, uv, lod ) OGRE_SampleLevelF16( tex, sampler, uv, lod )
+		@property( syntax == metal )
+			#define SampleEnvProbe( tex, sampler, uv, lod ) OGRE_SampleLevelF16( tex, sampler, float3( uv ), lod )
+		@else
+			#define SampleEnvProbe( tex, sampler, uv, lod ) OGRE_SampleLevelF16( tex, sampler, uv, lod )
+		@end
 	@end
 
 	@property( hlms_lights_spot_textured )
@@ -660,12 +664,12 @@
 	{
 		probeFade = saturate( probeFade * _h( 200.0 ) );
 		@property( vct_num_probes )
-			float4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) );
-			float3 reflDirLS = reflDirLS_dist.xyz;
+			midf4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) );
+			midf3 reflDirLS = reflDirLS_dist.xyz;
 		@else
-			float3 reflDirLS = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
+			midf3 reflDirLS = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
 		@end
-		float3 nNormalLS = localCorrect( pixelData.normal, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
+		midf3 nNormalLS = localCorrect( pixelData.normal, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
 		midf4 envS = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
 									 reflDirLS, @insertpiece( envSpecularRoughness ) );
 		@property( envmap_scale )
@@ -821,17 +825,17 @@
 
 				int gBufSubsample = int( findLSB( sampleMask ) );
 
-				pixelData.normal = normalize( OGRE_Load2DMS( gBuf_normals, iFragCoord, gBufSubsample ).xyz * 2.0 - 1.0 );
-				float2 shadowRoughness = OGRE_Load2DMS( gBuf_shadowRoughness, iFragCoord, gBufSubsample ).xy;
+				pixelData.normal = normalize( OGRE_Load2DMSF16( gBuf_normals, iFragCoord, gBufSubsample ).xyz * _h( 2.0 ) - _h( 1.0 ) );
+				midf2 shadowRoughness = OGRE_Load2DMSF16( gBuf_shadowRoughness, iFragCoord, gBufSubsample ).xy;
 			@else
-				pixelData.normal = normalize( OGRE_Load2D( gBuf_normals, iFragCoord, 0 ).xyz * 2.0 - 1.0 );
-				float2 shadowRoughness = OGRE_Load2D( gBuf_shadowRoughness, iFragCoord, 0 ).xy;
+				pixelData.normal = normalize( OGRE_Load2DF16( gBuf_normals, iFragCoord, 0 ).xyz * _h( 2.0 ) - _h( 1.0 ) );
+				midf2 shadowRoughness = OGRE_Load2DF16( gBuf_shadowRoughness, iFragCoord, 0 ).xy;
 			@end
 
-			float fShadow = shadowRoughness.x;
+			midf fShadow = shadowRoughness.x;
 
 			@property( roughness_map )
-				pixelData.roughness = shadowRoughness.y * 0.98 + 0.02;
+				pixelData.roughness = shadowRoughness.y * _h( 0.98 ) + _h( 0.02 );
 			@end
 		@end
 
@@ -912,7 +916,7 @@
 
 				@property( hlms_alphablend || hlms_alpha_to_coverage )
 					@property( use_texture_alpha )
-						outPs_colour0.w	= midf_c( material.F0.w * pixelData.diffuse.w );
+						outPs_colour0.w	= midf_c( material.F0.w ) * pixelData.diffuse.w;
 					@else
 						outPs_colour0.w	= midf_c( material.F0.w );
 					@end
@@ -921,23 +925,23 @@
 				@end
 
 				@property( debug_pssm_splits )
-					outPs_colour0.xyz = mix( outPs_colour0.xyz, debugPssmSplit.xyz, 0.2f );
+					outPs_colour0.xyz = mix( outPs_colour0.xyz, debugPssmSplit.xyz, _h( 0.2f ) );
 				@end				
 				@property( hlms_gen_normals_gbuffer )
-					outPs_normals = float4( pixelData.normal * 0.5 + 0.5, 1.0 );
+					outPs_normals = midf4_c( pixelData.normal * _h( 0.5 ) + _h( 0.5 ), 1.0 );
 				@end
 			@else
-				outPs_colour0 = float4( 1.0, 1.0, 1.0, 1.0 );
+				outPs_colour0 = midf4_c( 1.0, 1.0, 1.0, 1.0 );
 				@property( hlms_gen_normals_gbuffer )
-					outPs_normals = float4( 0.5, 0.5, 1.0, 1.0 );
+					outPs_normals = midf4_c( 0.5, 0.5, 1.0, 1.0 );
 				@end
 			@end
 		@else
-			outPs_normals			= float4( pixelData.normal * 0.5 + 0.5, 1.0 );
+			outPs_normals = midf4_c( pixelData.normal * _h( 0.5 ) + _h( 0.5 ), 1.0 );
 			@property( hlms_pssm_splits )
-				outPs_shadowRoughness	= float2( fShadow, (pixelData.roughness - 0.02) * 1.02040816 );
+				outPs_shadowRoughness	= midf2_c( fShadow, (pixelData.roughness - 0.02) * 1.02040816 );
 			@end @property( !hlms_pssm_splits )
-				outPs_shadowRoughness	= float2( 1.0, (pixelData.roughness - 0.02) * 1.02040816 );
+				outPs_shadowRoughness	= midf2_c( 1.0, (pixelData.roughness - 0.02) * 1.02040816 );
 			@end
 		@end
 	@end

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.PixelShader_piece_ps.any
@@ -1,5 +1,5 @@
-@piece( envSpecularRoughness ) pixelData.perceptualRoughness * passBuf.envMapNumMipmaps @end
-@piece( envSpecularRoughnessClearCoat ) pixelData.clearCoatPerceptualRoughness * passBuf.envMapNumMipmaps @end
+@piece( envSpecularRoughness ) pixelData.perceptualRoughness * half_c( passBuf.envMapNumMipmaps ) @end
+@piece( envSpecularRoughnessClearCoat ) pixelData.clearCoatPerceptualRoughness * half_c( passBuf.envMapNumMipmaps ) @end
 
 @piece( DefaultHeaderPS )
 	// START UNIFORM DECLARATION
@@ -138,8 +138,8 @@
 	@property( obb_restraint_approx || obb_restraint_ltc )
 		/// Returns value in range [-inf; 1]
 		/// Values <= 0 means 'pos' is outside the obb
-		float getObbRestraintFade( @property( syntax == metal )constant@end  float4 obbRestraint[3],
-								   float3 pos, float3 obbFadeFactors )
+		half getObbRestraintFade( @property( syntax == metal )constant@end  float4 obbRestraint[3],
+								  float3 pos, float3 obbFadeFactors )
 		{
 			float3 obbDistToBounds;
 			obbDistToBounds.x = dot( obbRestraint[0].xyzw, float4( pos.xyz, 1.0 ) );
@@ -149,7 +149,7 @@
 			obbDistToBounds = abs( obbDistToBounds );
 
 			float3 obbFade = (1.0 - obbDistToBounds) * obbFadeFactors;
-			return min( min3( obbFade.x, obbFade.y, obbFade.z ), 1.0 );
+			return min( half_c( min3( obbFade.x, obbFade.y, obbFade.z ) ), _h( 1.0 ) );
 		}
 	@end
 
@@ -498,7 +498,7 @@
 		@insertpiece( ObjLightMaskCmp )
 			finalColour += BRDF( half3_c( light0Buf.lights[@n].position.xyz ),
 								 half3_c( light0Buf.lights[@n].diffuse.xyz ),
-								 half3_c( light0Buf.lights[@n].specular, pixelData ) )@insertpiece( DarkenWithShadow );@end
+								 half3_c( light0Buf.lights[@n].specular ), pixelData )@insertpiece( DarkenWithShadow );@end
 
 	@property( !hlms_static_branch_lights )
 		@foreach( hlms_lights_directional_non_caster, n, hlms_lights_directional )
@@ -576,7 +576,7 @@
 		if( fDistance <= light0Buf.lights[light_idx].attenuation.x && spotCosAngle >= light0Buf.lights[light_idx].spotParams.y @insertpiece( andObjLightMaskCmp_light_idx ) )
 		{
 			half spotAtten = saturate( (spotCosAngle - half_c( light0Buf.lights[light_idx].spotParams.y )) * half_c( light0Buf.lights[light_idx].spotParams.x ) );
-			spotAtten = pow( spotAtten, light0Buf.lights[light_idx].spotParams.z );
+			spotAtten = pow( spotAtten, half_c( light0Buf.lights[light_idx].spotParams.z ) );
 
 			@property( light_profiles_texture )
 				spotAtten *= getPhotometricAttenuation( spotCosAngle,
@@ -632,10 +632,10 @@
 	@property( emissive_map || emissive_constant )
 		///Emissive is not part of PixelData because emissive can just be accumulated to finalColour
 		@property( emissive_map )
-			float3 emissiveCol = SampleEmissive( textureMaps@value( emissive_map_idx ),
-												 samplerState@value(emissive_map_sampler),
-												 UV_EMISSIVE( inPs.uv@value(uv_emissive).xy ),
-												 texIndex_emissiveMapIdx ).xyz;
+			half3 emissiveCol = SampleEmissive( textureMaps@value( emissive_map_idx ),
+												samplerState@value(emissive_map_sampler),
+												UV_EMISSIVE( inPs.uv@value(uv_emissive).xy ),
+												texIndex_emissiveMapIdx ).xyz;
 			@property( emissive_constant )
 				emissiveCol *= half3_c( material.emissive.xyz );
 			@end
@@ -650,15 +650,15 @@
 @end
 
 @piece( CubemapManualPcc )
-	float3 posInProbSpace = toProbeLocalSpace( inPs.pos, @insertpiece( pccProbeSource ) );
-	float probeFade = getProbeFade( posInProbSpace, @insertpiece( pccProbeSource ) );
+	half3 posInProbSpace = half3_c( toProbeLocalSpace( inPs.pos, @insertpiece( pccProbeSource ) ) );
+	half probeFade = getProbeFade( posInProbSpace, @insertpiece( pccProbeSource ) );
 @property( vct_num_probes )
-	if( probeFade > 0 && (pixelData.roughness < 1.0f || vctSpecular.w == 0) )
+	if( probeFade > _h( 0 ) && (pixelData.roughness < _h( 1.0f ) || vctSpecular.w == 0) )
 @else
-	if( probeFade > 0 )
+	if( probeFade > _h( 0 ) )
 @end
 	{
-		probeFade = saturate( probeFade * 200.0 );
+		probeFade = saturate( probeFade * _h( 200.0 ) );
 		@property( vct_num_probes )
 			float4 reflDirLS_dist = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) );
 			float3 reflDirLS = reflDirLS_dist.xyz;
@@ -666,23 +666,23 @@
 			float3 reflDirLS = localCorrect( pixelData.reflDir, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
 		@end
 		float3 nNormalLS = localCorrect( pixelData.normal, posInProbSpace, @insertpiece( pccProbeSource ) ).xyz;
-		float4 envS = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
-									  reflDirLS, @insertpiece( envSpecularRoughness ) );
+		half4 envS = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
+									 reflDirLS, @insertpiece( envSpecularRoughness ) );
 		@property( envmap_scale )
-			envS.xyz *= passBuf.ambientUpperHemi.w;
+			envS.xyz *= half3_c( passBuf.ambientUpperHemi.w );
 		@end
 		@property( cubemaps_as_diffuse_gi )
-			float3 envD = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
-										  nNormalLS, 11.0 ).xyz @insertpiece( ApplyEnvMapScale );
+			half3 envD = SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
+										 nNormalLS, 11.0 ).xyz @insertpiece( ApplyEnvMapScale );
 			envD.xyz *= probeFade;
 		@end
 
 		envS.xyz *= probeFade;
 
 		@property( clear_coat )
-			float3 clearCoatEnvS = SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
-												   reflDirLS,
-												   @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
+			half3 clearCoatEnvS = SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
+												  reflDirLS,
+												  @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 			clearCoatEnvS *= probeFade;
 		@end
 
@@ -697,7 +697,7 @@
 
 			pixelData.envColourS = lerp( envS.xyz, pixelData.envColourS, vctLerp );
 			@property( cubemaps_as_diffuse_gi )
-				pixelData.envColourD += vctSpecular.w > 0 ? float3( 0, 0, 0 ) : envD;
+				pixelData.envColourD += vctSpecular.w > 0 ? half3_c( 0, 0, 0 ) : envD;
 			@end
 
 			@property( clear_coat )
@@ -718,17 +718,17 @@
 
 @piece( CubemapGlobal )
 	pixelData.envColourS += SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
-											mul( pixelData.reflDir, passBuf.invViewMatCubemap ),
+											mul( pixelData.reflDir, half3x3_c( passBuf.invViewMatCubemap ) ),
 											@insertpiece( envSpecularRoughness ) ).xyz @insertpiece( ApplyEnvMapScale );
 	@property( cubemaps_as_diffuse_gi )
 		pixelData.envColourD += SampleEnvProbe( texEnvProbeMap, samplerState@value(envMapRegSampler),
-												mul( pixelData.normal, passBuf.invViewMatCubemap ),
+												mul( pixelData.normal, half3x3_c( passBuf.invViewMatCubemap ) ),
 												11.0 ).xyz @insertpiece( ApplyEnvMapScale );
 	@end
 
 	@property( clear_coat )
 		pixelData.clearCoatEnvColourS += SampleEnvProbe( texEnvProbeMap, samplerState@value( envMapRegSampler ),
-														 mul( pixelData.reflDir, passBuf.invViewMatCubemap ),
+														 mul( pixelData.reflDir, half3x3_c( passBuf.invViewMatCubemap ) ),
 														 @insertpiece( envSpecularRoughnessClearCoat ) ).xyz @insertpiece( ApplyEnvMapScale );
 	@end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
@@ -51,25 +51,25 @@
 	worldPos.z = dot( worldMat[2], inputPos );
 	worldPos.xyz *= inVs_blendWeights[0];
     @property( hlms_normal || hlms_qtangent )
-		half3 worldNorm;
-		worldNorm.x = dot( half3_c( worldMat[0].xyz ), inputNormal );
-		worldNorm.y = dot( half3_c( worldMat[1].xyz ), inputNormal );
-		worldNorm.z = dot( half3_c( worldMat[2].xyz ), inputNormal );
-		worldNorm *= half_c( inVs_blendWeights[0] );
+		midf3 worldNorm;
+		worldNorm.x = dot( midf3_c( worldMat[0].xyz ), inputNormal );
+		worldNorm.y = dot( midf3_c( worldMat[1].xyz ), inputNormal );
+		worldNorm.z = dot( midf3_c( worldMat[2].xyz ), inputNormal );
+		worldNorm *= midf_c( inVs_blendWeights[0] );
 	@end
 	@property( normal_map )
-		half3 worldTang;
-		worldTang.x = dot( half3_c( worldMat[0].xyz ), inputTangent );
-		worldTang.y = dot( half3_c( worldMat[1].xyz ), inputTangent );
-		worldTang.z = dot( half3_c( worldMat[2].xyz ), inputTangent );
-		worldTang *= half_c( inVs_blendWeights[0] );
+		midf3 worldTang;
+		worldTang.x = dot( midf3_c( worldMat[0].xyz ), inputTangent );
+		worldTang.y = dot( midf3_c( worldMat[1].xyz ), inputTangent );
+		worldTang.z = dot( midf3_c( worldMat[2].xyz ), inputTangent );
+		worldTang *= midf_c( inVs_blendWeights[0] );
 	@end
 
 	@psub( NeedsMoreThan1BonePerVertex, hlms_bones_per_vertex, 1 )
 	@property( NeedsMoreThan1BonePerVertex )
 		float4 tmp4;
 		tmp4.w = 1.0;
-		half3 tmp3;
+		midf3 tmp3;
 	@end //!NeedsMoreThan1BonePerVertex
 	@foreach( hlms_bones_per_vertex, n, 1 )
 		_idx = (inVs_blendIndices[@n] << 1u) + inVs_blendIndices[@n]; //inVs_blendIndices[@n] * 3; a 32-bit int multiply is 4 cycles on GCN! (and mul24 is not exposed to GLSL...)
@@ -81,16 +81,16 @@
 		tmp4.z = dot( worldMat[2], inputPos );
 		worldPos.xyz += (tmp4 * inVs_blendWeights[@n]).xyz;
 		@property( hlms_normal || hlms_qtangent )
-			tmp3.x = dot( half3_c( worldMat[0].xyz ), inputNormal );
-			tmp3.y = dot( half3_c( worldMat[1].xyz ), inputNormal );
-			tmp3.z = dot( half3_c( worldMat[2].xyz ), inputNormal );
-			worldNorm += tmp3.xyz * half_c( inVs_blendWeights[@n] );
+			tmp3.x = dot( midf3_c( worldMat[0].xyz ), inputNormal );
+			tmp3.y = dot( midf3_c( worldMat[1].xyz ), inputNormal );
+			tmp3.z = dot( midf3_c( worldMat[2].xyz ), inputNormal );
+			worldNorm += tmp3.xyz * midf_c( inVs_blendWeights[@n] );
 		@end
 		@property( normal_map )
-			tmp3.x = dot( half3_c( worldMat[0].xyz ), inputTangent );
-			tmp3.y = dot( half3_c( worldMat[1].xyz ), inputTangent );
-			tmp3.z = dot( half3_c( worldMat[2].xyz ), inputTangent );
-			worldTang += tmp3.xyz * half_c( inVs_blendWeights[@n] );
+			tmp3.x = dot( midf3_c( worldMat[0].xyz ), inputTangent );
+			tmp3.y = dot( midf3_c( worldMat[1].xyz ), inputTangent );
+			tmp3.z = dot( midf3_c( worldMat[2].xyz ), inputTangent );
+			worldTang += tmp3.xyz * midf_c( inVs_blendWeights[@n] );
 		@end
 	@end
 
@@ -138,7 +138,7 @@
 			@foreach( hlms_pose, n )
 				inputPos += bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) * poseWeights[@n];
 				@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
-				inputNormal += half3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@n] );
+				inputNormal += midf3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@n] );
 				@end
 			@end
 		@else
@@ -153,7 +153,7 @@
 			@foreach( hlms_pose, n )
 				inputPos += bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) * poseWeights[@n];
 				@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
-					inputNormal += half3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@nu] );
+					inputNormal += midf3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@nu] );
 				@end
 			@end
 		@end
@@ -191,8 +191,8 @@
 	@insertpiece( custom_vs_preTransform )
 	//Lighting is in view space
 	@property( hlms_normal || hlms_qtangent )	outVs.pos		= @insertpiece( CalculatePsPos );@end
-	@property( hlms_normal || hlms_qtangent )	outVs.normal	= mul( @insertpiece(local_normal), toHalf3x3( worldViewMat ) );@end
-	@property( normal_map )						outVs.tangent	= mul( @insertpiece(local_tangent), toHalf3x3( worldViewMat ) );@end
+	@property( hlms_normal || hlms_qtangent )	outVs.normal	= mul( @insertpiece(local_normal), toMidf3x3( worldViewMat ) );@end
+	@property( normal_map )						outVs.tangent	= mul( @insertpiece(local_tangent), toMidf3x3( worldViewMat ) );@end
 	@property( !hlms_dual_paraboloid_mapping )
         @property( !hlms_use_uv_baking )
 			@property( !hlms_instanced_stereo )
@@ -234,20 +234,20 @@
 	// Define inputNormal and inputTangent using inVs_normal, inVs_tangent, inVs_qtangent
 	@property( hlms_qtangent )
 		//Decode qTangent to TBN with reflection
-		const half4 qTangent = normalize( inVs_qtangent );
-		half3 inputNormal = xAxis( qTangent );
+		const midf4 qTangent = normalize( inVs_qtangent );
+		midf3 inputNormal = xAxis( qTangent );
 		@property( normal_map )
-			half3 inputTangent = yAxis( qTangent );
+			midf3 inputTangent = yAxis( qTangent );
 			outVs.biNormalReflection = sign( inVs_qtangent.w ); //We ensure in C++ qtangent.w is never 0
 		@end
 	@else
 		@property( hlms_normal )
-			half3 inputNormal = half3_c( inVs_normal ); // We need inputNormal as lvalue for PoseTransform
+			midf3 inputNormal = midf3_c( inVs_normal ); // We need inputNormal as lvalue for PoseTransform
 		@end
 		@property( normal_map )
-			half3 inputTangent = half3_c( inVs_tangent.xyz );
+			midf3 inputTangent = midf3_c( inVs_tangent.xyz );
 			@property( hlms_tangent4 )
-				outVs.biNormalReflection = sign( half( inVs_tangent.w ) );
+				outVs.biNormalReflection = sign( midf( inVs_tangent.w ) );
 			@end
 		@end
 	@end
@@ -261,7 +261,7 @@
 		float4 worldPos = float4( mul(inVs_vertex, worldMat).xyz, 1.0f );
 		@property( ( hlms_normal || hlms_qtangent) && hlms_num_shadow_map_lights )
 			// We need worldNorm for normal offset bias
-			half3 worldNorm = mul( inputNormal, toHalf3x3( worldMat ) ).xyz;
+			midf3 worldNorm = mul( inputNormal, toMidf3x3( worldMat ) ).xyz;
 		@end
 	@end
 
@@ -269,10 +269,10 @@
 
 	@property( !hlms_skeleton && hlms_pose && ( hlms_normal || hlms_qtangent) && hlms_num_shadow_map_lights )
 		// We need worldNorm for normal offset bias, special path when using poses
-		half3 worldNorm;
-		worldNorm.x = dot( half3_c( worldMat[0].xyz ), inputNormal );
-		worldNorm.y = dot( half3_c( worldMat[1].xyz ), inputNormal );
-		worldNorm.z = dot( half3_c( worldMat[2].xyz ), inputNormal );
+		midf3 worldNorm;
+		worldNorm.x = dot( midf3_c( worldMat[0].xyz ), inputNormal );
+		worldNorm.y = dot( midf3_c( worldMat[1].xyz ), inputNormal );
+		worldNorm.z = dot( midf3_c( worldMat[2].xyz ), inputNormal );
 	@end
 
 	@insertpiece( SkeletonTransform )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
@@ -234,24 +234,21 @@
 	// Define inputNormal and inputTangent using inVs_normal, inVs_tangent, inVs_qtangent
 	@property( hlms_qtangent )
 		//Decode qTangent to TBN with reflection
-		half3 inputNormal	= xAxis( normalize( inVs_qtangent ) );
+		const half4 qTangent = normalize( inVs_qtangent );
+		half3 inputNormal = xAxis( qTangent );
 		@property( normal_map )
-			half3 inputTangent	= yAxis( inVs_qtangent );
+			half3 inputTangent = yAxis( qTangent );
 			outVs.biNormalReflection = sign( inVs_qtangent.w ); //We ensure in C++ qtangent.w is never 0
 		@end
 	@else
-		@property( hlms_normal && hlms_pose && hlms_pose_normals )
-			half3 inputNormal = inVs_normal; // We need inputNormal as lvalue for PoseTransform
-		@else
-			#define inputNormal inVs_normal
+		@property( hlms_normal )
+			half3 inputNormal = half3_c( inVs_normal ); // We need inputNormal as lvalue for PoseTransform
 		@end
-		@property( hlms_tangent4 )
-			#define inputTangent inVs_tangent.xyz
-			@property( normal_map )
-				outVs.biNormalReflection = sign( inVs_tangent.w );
+		@property( normal_map )
+			half3 inputTangent = half3_c( inVs_tangent.xyz );
+			@property( hlms_tangent4 )
+				outVs.biNormalReflection = sign( half( inVs_tangent.w ) );
 			@end
-		@else
-			#define inputTangent inVs_tangent
 		@end
 	@end
 

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
@@ -51,45 +51,46 @@
 	worldPos.z = dot( worldMat[2], inputPos );
 	worldPos.xyz *= inVs_blendWeights[0];
     @property( hlms_normal || hlms_qtangent )
-        float3 worldNorm;
-		worldNorm.x = dot( worldMat[0].xyz, inputNormal );
-		worldNorm.y = dot( worldMat[1].xyz, inputNormal );
-		worldNorm.z = dot( worldMat[2].xyz, inputNormal );
-		worldNorm *= inVs_blendWeights[0];
+		half3 worldNorm;
+		worldNorm.x = dot( half3( worldMat[0].xyz ), inputNormal );
+		worldNorm.y = dot( half3( worldMat[1].xyz ), inputNormal );
+		worldNorm.z = dot( half3( worldMat[2].xyz ), inputNormal );
+		worldNorm *= half( inVs_blendWeights[0] );
 	@end
 	@property( normal_map )
-		float3 worldTang;
-		worldTang.x = dot( worldMat[0].xyz, inputTangent );
-		worldTang.y = dot( worldMat[1].xyz, inputTangent );
-		worldTang.z = dot( worldMat[2].xyz, inputTangent );
-		worldTang *= inVs_blendWeights[0];
+		half3 worldTang;
+		worldTang.x = dot( half3( worldMat[0].xyz ), inputTangent );
+		worldTang.y = dot( half3( worldMat[1].xyz ), inputTangent );
+		worldTang.z = dot( half3( worldMat[2].xyz ), inputTangent );
+		worldTang *= half( inVs_blendWeights[0] );
 	@end
 
 	@psub( NeedsMoreThan1BonePerVertex, hlms_bones_per_vertex, 1 )
 	@property( NeedsMoreThan1BonePerVertex )
-		float4 tmp;
-		tmp.w = 1.0;
+		float4 tmp4;
+		tmp4.w = 1.0;
 	@end //!NeedsMoreThan1BonePerVertex
 	@foreach( hlms_bones_per_vertex, n, 1 )
 		_idx = (inVs_blendIndices[@n] << 1u) + inVs_blendIndices[@n]; //inVs_blendIndices[@n] * 3; a 32-bit int multiply is 4 cycles on GCN! (and mul24 is not exposed to GLSL...)
 		worldMat[0] = readOnlyFetch( worldMatBuf, int(matStart + _idx + 0u) );
 		worldMat[1] = readOnlyFetch( worldMatBuf, int(matStart + _idx + 1u) );
 		worldMat[2] = readOnlyFetch( worldMatBuf, int(matStart + _idx + 2u) );
-		tmp.x = dot( worldMat[0], inputPos );
-		tmp.y = dot( worldMat[1], inputPos );
-		tmp.z = dot( worldMat[2], inputPos );
+		tmp4.x = dot( worldMat[0], inputPos );
+		tmp4.y = dot( worldMat[1], inputPos );
+		tmp4.z = dot( worldMat[2], inputPos );
 		worldPos.xyz += (tmp * inVs_blendWeights[@n]).xyz;
 		@property( hlms_normal || hlms_qtangent )
-			tmp.x = dot( worldMat[0].xyz, inputNormal );
-			tmp.y = dot( worldMat[1].xyz, inputNormal );
-			tmp.z = dot( worldMat[2].xyz, inputNormal );
-			worldNorm += tmp.xyz * inVs_blendWeights[@n];
+			half3 tmp3;
+			tmp3.x = dot( half3( worldMat[0].xyz ), inputNormal );
+			tmp3.y = dot( half3( worldMat[1].xyz ), inputNormal );
+			tmp3.z = dot( half3( worldMat[2].xyz ), inputNormal );
+			worldNorm += tmp3.xyz * half( inVs_blendWeights[@n] );
 		@end
 		@property( normal_map )
-			tmp.x = dot( worldMat[0].xyz, inputTangent );
-			tmp.y = dot( worldMat[1].xyz, inputTangent );
-			tmp.z = dot( worldMat[2].xyz, inputTangent );
-			worldTang += tmp.xyz * inVs_blendWeights[@n];
+			tmp3.x = dot( half3( worldMat[0].xyz ), inputTangent );
+			tmp3.y = dot( half3( worldMat[1].xyz ), inputTangent );
+			tmp3.z = dot( half3( worldMat[2].xyz ), inputTangent );
+			worldTang += tmp3.xyz * half( inVs_blendWeights[@n] );
 		@end
 	@end
 
@@ -190,8 +191,8 @@
 	@insertpiece( custom_vs_preTransform )
 	//Lighting is in view space
 	@property( hlms_normal || hlms_qtangent )	outVs.pos		= @insertpiece( CalculatePsPos );@end
-	@property( hlms_normal || hlms_qtangent )	outVs.normal	= mul( @insertpiece(local_normal), toFloat3x3( worldViewMat ) );@end
-	@property( normal_map )						outVs.tangent	= mul( @insertpiece(local_tangent), toFloat3x3( worldViewMat ) );@end
+	@property( hlms_normal || hlms_qtangent )	outVs.normal	= mul( @insertpiece(local_normal), toHalf3x3( worldViewMat ) );@end
+	@property( normal_map )						outVs.tangent	= mul( @insertpiece(local_tangent), toHalf3x3( worldViewMat ) );@end
 	@property( !hlms_dual_paraboloid_mapping )
         @property( !hlms_use_uv_baking )
 			@property( !hlms_instanced_stereo )
@@ -233,14 +234,14 @@
 	// Define inputNormal and inputTangent using inVs_normal, inVs_tangent, inVs_qtangent
 	@property( hlms_qtangent )
 		//Decode qTangent to TBN with reflection
-		float3 inputNormal	= xAxis( normalize( inVs_qtangent ) );
+		half3 inputNormal	= xAxis( normalize( inVs_qtangent ) );
 		@property( normal_map )
-			float3 inputTangent	= yAxis( inVs_qtangent );
+			half3 inputTangent	= yAxis( inVs_qtangent );
 			outVs.biNormalReflection = sign( inVs_qtangent.w ); //We ensure in C++ qtangent.w is never 0
 		@end
 	@else
 		@property( hlms_normal && hlms_pose && hlms_pose_normals )
-			float3 inputNormal = inVs_normal; // We need inputNormal as lvalue for PoseTransform
+			half3 inputNormal = inVs_normal; // We need inputNormal as lvalue for PoseTransform
 		@else
 			#define inputNormal inVs_normal
 		@end
@@ -263,7 +264,7 @@
 		float4 worldPos = float4( mul(inVs_vertex, worldMat).xyz, 1.0f );
 		@property( ( hlms_normal || hlms_qtangent) && hlms_num_shadow_map_lights )
 			// We need worldNorm for normal offset bias
-			float3 worldNorm = mul( inputNormal, toFloat3x3( worldMat ) ).xyz;
+			float3 worldNorm = mul( inputNormal, toHalf3x3( worldMat ) ).xyz;
 		@end
 	@end
 
@@ -271,10 +272,10 @@
 
 	@property( !hlms_skeleton && hlms_pose && ( hlms_normal || hlms_qtangent) && hlms_num_shadow_map_lights )
 		// We need worldNorm for normal offset bias, special path when using poses
-		float3 worldNorm;
-		worldNorm.x = dot( worldMat[0].xyz, inputNormal );
-		worldNorm.y = dot( worldMat[1].xyz, inputNormal );
-		worldNorm.z = dot( worldMat[2].xyz, inputNormal );
+		half3 worldNorm;
+		worldNorm.x = dot( half3( worldMat[0].xyz ), inputNormal );
+		worldNorm.y = dot( half3( worldMat[1].xyz ), inputNormal );
+		worldNorm.z = dot( half3( worldMat[2].xyz ), inputNormal );
 	@end
 
 	@insertpiece( SkeletonTransform )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
@@ -52,23 +52,24 @@
 	worldPos.xyz *= inVs_blendWeights[0];
     @property( hlms_normal || hlms_qtangent )
 		half3 worldNorm;
-		worldNorm.x = dot( half3( worldMat[0].xyz ), inputNormal );
-		worldNorm.y = dot( half3( worldMat[1].xyz ), inputNormal );
-		worldNorm.z = dot( half3( worldMat[2].xyz ), inputNormal );
-		worldNorm *= half( inVs_blendWeights[0] );
+		worldNorm.x = dot( half3_c( worldMat[0].xyz ), inputNormal );
+		worldNorm.y = dot( half3_c( worldMat[1].xyz ), inputNormal );
+		worldNorm.z = dot( half3_c( worldMat[2].xyz ), inputNormal );
+		worldNorm *= half_c( inVs_blendWeights[0] );
 	@end
 	@property( normal_map )
 		half3 worldTang;
-		worldTang.x = dot( half3( worldMat[0].xyz ), inputTangent );
-		worldTang.y = dot( half3( worldMat[1].xyz ), inputTangent );
-		worldTang.z = dot( half3( worldMat[2].xyz ), inputTangent );
-		worldTang *= half( inVs_blendWeights[0] );
+		worldTang.x = dot( half3_c( worldMat[0].xyz ), inputTangent );
+		worldTang.y = dot( half3_c( worldMat[1].xyz ), inputTangent );
+		worldTang.z = dot( half3_c( worldMat[2].xyz ), inputTangent );
+		worldTang *= half_c( inVs_blendWeights[0] );
 	@end
 
 	@psub( NeedsMoreThan1BonePerVertex, hlms_bones_per_vertex, 1 )
 	@property( NeedsMoreThan1BonePerVertex )
 		float4 tmp4;
 		tmp4.w = 1.0;
+		half3 tmp3;
 	@end //!NeedsMoreThan1BonePerVertex
 	@foreach( hlms_bones_per_vertex, n, 1 )
 		_idx = (inVs_blendIndices[@n] << 1u) + inVs_blendIndices[@n]; //inVs_blendIndices[@n] * 3; a 32-bit int multiply is 4 cycles on GCN! (and mul24 is not exposed to GLSL...)
@@ -78,19 +79,18 @@
 		tmp4.x = dot( worldMat[0], inputPos );
 		tmp4.y = dot( worldMat[1], inputPos );
 		tmp4.z = dot( worldMat[2], inputPos );
-		worldPos.xyz += (tmp * inVs_blendWeights[@n]).xyz;
+		worldPos.xyz += (tmp4 * inVs_blendWeights[@n]).xyz;
 		@property( hlms_normal || hlms_qtangent )
-			half3 tmp3;
-			tmp3.x = dot( half3( worldMat[0].xyz ), inputNormal );
-			tmp3.y = dot( half3( worldMat[1].xyz ), inputNormal );
-			tmp3.z = dot( half3( worldMat[2].xyz ), inputNormal );
-			worldNorm += tmp3.xyz * half( inVs_blendWeights[@n] );
+			tmp3.x = dot( half3_c( worldMat[0].xyz ), inputNormal );
+			tmp3.y = dot( half3_c( worldMat[1].xyz ), inputNormal );
+			tmp3.z = dot( half3_c( worldMat[2].xyz ), inputNormal );
+			worldNorm += tmp3.xyz * half_c( inVs_blendWeights[@n] );
 		@end
 		@property( normal_map )
-			tmp3.x = dot( half3( worldMat[0].xyz ), inputTangent );
-			tmp3.y = dot( half3( worldMat[1].xyz ), inputTangent );
-			tmp3.z = dot( half3( worldMat[2].xyz ), inputTangent );
-			worldTang += tmp3.xyz * half( inVs_blendWeights[@n] );
+			tmp3.x = dot( half3_c( worldMat[0].xyz ), inputTangent );
+			tmp3.y = dot( half3_c( worldMat[1].xyz ), inputTangent );
+			tmp3.z = dot( half3_c( worldMat[2].xyz ), inputTangent );
+			worldTang += tmp3.xyz * half_c( inVs_blendWeights[@n] );
 		@end
 	@end
 
@@ -138,7 +138,7 @@
 			@foreach( hlms_pose, n )
 				inputPos += bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) * poseWeights[@n];
 				@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
-				inputNormal += bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@n];
+				inputNormal += half3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@n] );
 				@end
 			@end
 		@else
@@ -153,7 +153,7 @@
 			@foreach( hlms_pose, n )
 				inputPos += bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) * poseWeights[@n];
 				@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
-					inputNormal += bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@nu];
+					inputNormal += half3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@nu] );
 				@end
 			@end
 		@end
@@ -264,7 +264,7 @@
 		float4 worldPos = float4( mul(inVs_vertex, worldMat).xyz, 1.0f );
 		@property( ( hlms_normal || hlms_qtangent) && hlms_num_shadow_map_lights )
 			// We need worldNorm for normal offset bias
-			float3 worldNorm = mul( inputNormal, toHalf3x3( worldMat ) ).xyz;
+			half3 worldNorm = mul( inputNormal, toHalf3x3( worldMat ) ).xyz;
 		@end
 	@end
 
@@ -273,9 +273,9 @@
 	@property( !hlms_skeleton && hlms_pose && ( hlms_normal || hlms_qtangent) && hlms_num_shadow_map_lights )
 		// We need worldNorm for normal offset bias, special path when using poses
 		half3 worldNorm;
-		worldNorm.x = dot( half3( worldMat[0].xyz ), inputNormal );
-		worldNorm.y = dot( half3( worldMat[1].xyz ), inputNormal );
-		worldNorm.z = dot( half3( worldMat[2].xyz ), inputNormal );
+		worldNorm.x = dot( half3_c( worldMat[0].xyz ), inputNormal );
+		worldNorm.y = dot( half3_c( worldMat[1].xyz ), inputNormal );
+		worldNorm.z = dot( half3_c( worldMat[2].xyz ), inputNormal );
 	@end
 
 	@insertpiece( SkeletonTransform )

--- a/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/800.VertexShader_piece_vs.any
@@ -117,10 +117,10 @@
 	@psub( MoreThanOnePose, hlms_pose, 1 )
 	@property( !MoreThanOnePose )
 		float4 poseWeights = readOnlyFetch( worldMatBuf, int(poseDataStart + 1u) );
-		float4 posePos = bufferFetch( poseBuf, int( vertexID @property( hlms_pose_normals )<< 1u@end ) );
+		float4 posePos = float4( bufferFetch( poseBuf, int( vertexID @property( hlms_pose_normals )<< 1u@end ) ) );
 		inputPos += posePos * poseWeights.x;
 		@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
-			float4 poseNormal = bufferFetch( poseBuf, int( (vertexID << 1u) + 1u ) );
+			float4 poseNormal = float4( bufferFetch( poseBuf, int( (vertexID << 1u) + 1u ) ) );
 			inputNormal += poseNormal.xyz * poseWeights.x;
 		@end
 		@pset( NumPoseWeightVectors, 1 )
@@ -136,7 +136,7 @@
 		@property( !MoreThanOnePoseWeightVector )
 			float4 poseWeights = readOnlyFetch( worldMatBuf, int( poseDataStart + 1u ) );
 			@foreach( hlms_pose, n )
-				inputPos += bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) * poseWeights[@n];
+				inputPos += float4( bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) ) * poseWeights[@n];
 				@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
 				inputNormal += midf3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@n] );
 				@end
@@ -151,7 +151,7 @@
 				poseWeights[@n * 4 + 3] = weights@n[3];
 			@end
 			@foreach( hlms_pose, n )
-				inputPos += bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) * poseWeights[@n];
+				inputPos += float4( bufferFetch( poseBuf, int( (vertexID + numVertices * @nu) @property( hlms_pose_normals )<< 1u@end ) ) ) * poseWeights[@n];
 				@property( hlms_pose_normals && (hlms_normal || hlms_qtangent) )
 					inputNormal += midf3_c( bufferFetch( poseBuf, int( ((vertexID + numVertices * @nu) << 1u) + 1u ) ).xyz * poseWeights[@nu] );
 				@end

--- a/Samples/Media/Hlms/Pbs/Any/Refractions_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Refractions_piece_ps.any
@@ -25,7 +25,7 @@
 	// refractNormal must be in view space, and we ignore .z component
 	midf2 refractNormal2d = OGRE_refract( pixelData.viewDir, pixelData.normal,
 										  refractF0, pixelData.NdotV ).xy;
-	float2 refractUv = screenPosUv.xy + refractNormal2d.xy *
+	float2 refractUv = screenPosUv.xy + float2( refractNormal2d.xy ) *
 					   float2( material.refractionStrength,
 							   material.refractionStrength * passBuf.aspectRatio ) /
 					   ( (-inPs.pos.z + 1.0) * (-inPs.pos.z + 1.0) );

--- a/Samples/Media/Hlms/Pbs/Any/Refractions_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Refractions_piece_ps.any
@@ -3,12 +3,12 @@
 
 @property( hlms_screen_space_refractions )
 @piece( DeclRefractionsFuncs )
-	float3 OGRE_refract( float3 viewDir, float3 normal, float refractionIndex, float NdotV )
+	half3 OGRE_refract( half3 viewDir, half3 normal, half refractionIndex, half NdotV )
 	{
-		float3 retVal;
-		float k = 1.0 - refractionIndex * refractionIndex * (1.0 - NdotV  * NdotV);
-		if( k < 0.0 )
-			retVal = float3( 0, 0, 0 );
+		half3 retVal;
+		half k = _h( 1.0 ) - refractionIndex * refractionIndex * (_h( 1.0 ) - NdotV  * NdotV);
+		if( k < _h( 0.0 ) )
+			retVal = half3_c( 0, 0, 0 );
 		else
 			retVal = -refractionIndex * viewDir - (sqrt( k ) - refractionIndex * NdotV) * normal;
 		return retVal;
@@ -17,27 +17,27 @@
 
 @piece( applyRefractions )
 	@property( !fresnel_scalar )
-		float refractF0 = pixelData.F0;
+		half refractF0 = pixelData.F0;
 	@else
-		float refractF0 = max( pixelData.F0.x, pixelData.F0.y, pixelData.F0.z );
+		half refractF0 = max( pixelData.F0.x, pixelData.F0.y, pixelData.F0.z );
 	@end
 
 	// refractNormal must be in view space, and we ignore .z component
-	float2 refractNormal2d = OGRE_refract( pixelData.viewDir, pixelData.normal,
-										   refractF0, pixelData.NdotV ).xy;
+	half2 refractNormal2d = OGRE_refract( pixelData.viewDir, pixelData.normal,
+										  refractF0, pixelData.NdotV ).xy;
 	float2 refractUv = screenPosUv.xy + refractNormal2d.xy *
 					   float2( material.refractionStrength,
 							   material.refractionStrength * passBuf.aspectRatio ) /
 					   ( (-inPs.pos.z + 1.0) * (-inPs.pos.z + 1.0) );
-	float3 refractionCol = OGRE_SampleLevel( refractionMap, refractionMapSampler, refractUv, 0 ).xyz;
-	float refractionDepth = OGRE_SampleLevel( depthTextureNoMsaa, refractionMapSampler, refractUv, 0 ).x;
+	half3 refractionCol = OGRE_SampleLevelF16( refractionMap, refractionMapSampler, refractUv, 0 ).xyz;
+	half refractionDepth = OGRE_SampleLevelF16( depthTextureNoMsaa, refractionMapSampler, refractUv, 0 ).x;
 
 	// We may need to fallback to regular transparency if we're sampling to close to the edges
 	// or the object being refracted is in front of us.
-	float3 fallbackRefractionCol = OGRE_Load2D( refractionMap, iFragCoord.xy, 0 ).xyz;
+	half3 fallbackRefractionCol = OGRE_Load2DF16( refractionMap, iFragCoord.xy, 0 ).xyz;
 
 	refractUv = saturate( abs( screenPosUv.xy * 2.0 - 1.0 ) * 10.0 - 9.0 );
-	float fallbackRefrW = max( refractUv.x, refractUv.y );
+	half fallbackRefrW = half_c( max( refractUv.x, refractUv.y ) );
 	fallbackRefrW = fallbackRefrW * fallbackRefrW;
 
 	@property( hlms_no_reverse_depth )
@@ -47,17 +47,17 @@
 	@end
 		{
 			// We're trying to refract an object that is in front of us. We can't do that.
-			fallbackRefrW = 1.0;
+			fallbackRefrW = _h( 1.0 );
 		}
 
 	refractionCol = lerp( refractionCol, fallbackRefractionCol, fallbackRefrW );
 
 	@property( use_texture_alpha )
-		float refractionAlpha = material.F0.w * pixelData.diffuse.w;
+		half refractionAlpha = half_c( material.F0.w ) * pixelData.diffuse.w;
 	@else
-		float refractionAlpha = material.F0.w;
+		half refractionAlpha = half_c( material.F0.w );
 	@end
 
-	finalColour += refractionCol.xyz * (1.0 - refractionAlpha);
+	finalColour += refractionCol.xyz * (_h( 1.0 ) - refractionAlpha);
 @end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/Refractions_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Refractions_piece_ps.any
@@ -3,12 +3,12 @@
 
 @property( hlms_screen_space_refractions )
 @piece( DeclRefractionsFuncs )
-	half3 OGRE_refract( half3 viewDir, half3 normal, half refractionIndex, half NdotV )
+	midf3 OGRE_refract( midf3 viewDir, midf3 normal, midf refractionIndex, midf NdotV )
 	{
-		half3 retVal;
-		half k = _h( 1.0 ) - refractionIndex * refractionIndex * (_h( 1.0 ) - NdotV  * NdotV);
+		midf3 retVal;
+		midf k = _h( 1.0 ) - refractionIndex * refractionIndex * (_h( 1.0 ) - NdotV  * NdotV);
 		if( k < _h( 0.0 ) )
-			retVal = half3_c( 0, 0, 0 );
+			retVal = midf3_c( 0, 0, 0 );
 		else
 			retVal = -refractionIndex * viewDir - (sqrt( k ) - refractionIndex * NdotV) * normal;
 		return retVal;
@@ -17,27 +17,27 @@
 
 @piece( applyRefractions )
 	@property( !fresnel_scalar )
-		half refractF0 = pixelData.F0;
+		midf refractF0 = pixelData.F0;
 	@else
-		half refractF0 = max( pixelData.F0.x, pixelData.F0.y, pixelData.F0.z );
+		midf refractF0 = max( pixelData.F0.x, pixelData.F0.y, pixelData.F0.z );
 	@end
 
 	// refractNormal must be in view space, and we ignore .z component
-	half2 refractNormal2d = OGRE_refract( pixelData.viewDir, pixelData.normal,
+	midf2 refractNormal2d = OGRE_refract( pixelData.viewDir, pixelData.normal,
 										  refractF0, pixelData.NdotV ).xy;
 	float2 refractUv = screenPosUv.xy + refractNormal2d.xy *
 					   float2( material.refractionStrength,
 							   material.refractionStrength * passBuf.aspectRatio ) /
 					   ( (-inPs.pos.z + 1.0) * (-inPs.pos.z + 1.0) );
-	half3 refractionCol = OGRE_SampleLevelF16( refractionMap, refractionMapSampler, refractUv, 0 ).xyz;
-	half refractionDepth = OGRE_SampleLevelF16( depthTextureNoMsaa, refractionMapSampler, refractUv, 0 ).x;
+	midf3 refractionCol = OGRE_SampleLevelF16( refractionMap, refractionMapSampler, refractUv, 0 ).xyz;
+	midf refractionDepth = OGRE_SampleLevelF16( depthTextureNoMsaa, refractionMapSampler, refractUv, 0 ).x;
 
 	// We may need to fallback to regular transparency if we're sampling to close to the edges
 	// or the object being refracted is in front of us.
-	half3 fallbackRefractionCol = OGRE_Load2DF16( refractionMap, iFragCoord.xy, 0 ).xyz;
+	midf3 fallbackRefractionCol = OGRE_Load2DF16( refractionMap, iFragCoord.xy, 0 ).xyz;
 
 	refractUv = saturate( abs( screenPosUv.xy * 2.0 - 1.0 ) * 10.0 - 9.0 );
-	half fallbackRefrW = half_c( max( refractUv.x, refractUv.y ) );
+	midf fallbackRefrW = midf_c( max( refractUv.x, refractUv.y ) );
 	fallbackRefrW = fallbackRefrW * fallbackRefrW;
 
 	@property( hlms_no_reverse_depth )
@@ -53,9 +53,9 @@
 	refractionCol = lerp( refractionCol, fallbackRefractionCol, fallbackRefrW );
 
 	@property( use_texture_alpha )
-		half refractionAlpha = half_c( material.F0.w ) * pixelData.diffuse.w;
+		midf refractionAlpha = midf_c( material.F0.w ) * pixelData.diffuse.w;
 	@else
-		half refractionAlpha = half_c( material.F0.w );
+		midf refractionAlpha = midf_c( material.F0.w );
 	@end
 
 	finalColour += refractionCol.xyz * (_h( 1.0 ) - refractionAlpha);

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_all.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_all.any
@@ -5,7 +5,7 @@
 	@piece( DeclNormalOffsetBiasFunc )
 		@foreach( 2, m )
 			// Perform normal offset bias. See https://github.com/OGRECave/ogre-next/issues/100
-			INLINE float3 getNormalOffsetBias( float3 worldNormal, float3 viewSpaceNormal,
+			INLINE float3 getNormalOffsetBias( midf3 worldNormal, midf3 viewSpaceNormal,
 											   float3 lightDir, float shadowMapTexSize,
 											   float depthRange, float normalOffsetBias
 			@property( @m == 0 )
@@ -14,13 +14,13 @@
 											   , float2 minUV, float2 maxUV )
 			@end
 			{
-				float tmpNdotL = saturate( dot( lightDir.xyz, viewSpaceNormal.xyz ) );
+				float tmpNdotL = saturate( dot( lightDir.xyz, float3( viewSpaceNormal.xyz ) ) );
 
 				@property( @m == 1 )
 					shadowMapTexSize /= maxUV.x - minUV.x;
 				@end
 
-				return ( ( 1.0f - tmpNdotL ) * normalOffsetBias * worldNormal.xyz * shadowMapTexSize );
+				return ( ( 1.0f - tmpNdotL ) * normalOffsetBias * float3( worldNormal.xyz ) * shadowMapTexSize );
 			}
 		@end
 	@end

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -40,22 +40,22 @@
 @end
 
 @property( syntax == glsl || syntax == glsles )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? 1.0 : texture( tex, vec3( uv, depth ) ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : half( texture( tex, vec3( uv, depth ) ) ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) textureLod( tex, uv, 0 ).x
 @end
 
 @property( syntax == glslvk )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? 1.0 : texture( sampler2DShadow( tex, sampler ), vec3( uv, depth ) ) )
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : half( texture( sampler2DShadow( tex, sampler ), vec3( uv, depth ) ) ) )
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) textureLod( sampler2D( tex, sampler ), uv, 0 ).x
 @end
 
 @property( syntax == hlsl )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? 1.0 : tex.SampleCmpLevelZero( sampler, uv.xy, depth ).x)
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : half( tex.SampleCmpLevelZero( sampler, uv.xy, depth ).x ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) tex.SampleLevel( sampler, uv, 0 ).x
 @end
 
 @property( syntax == metal )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? 1.0 : tex.sample_compare( sampler, float2( uv.xy ), depth ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : tex.sample_compare( sampler, float2( uv.xy ), depth ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) tex.sample( sampler, float2( uv.xy ), level(0) ).x
 @end
 @end
@@ -255,18 +255,18 @@
 	@end
 @foreach( 4, m )
 	@property( @m == 0 )
-		INLINE float getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE half getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 								float4 psPosLN, float4 invShadowMapSize )
 	@end @property( @m == 1 )
-		INLINE float getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE half getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 								float4 psPosLN, float4 invShadowMapSize, float2 minUV, float2 maxUV )
 	@end @property( @m == 2 )
-		INLINE float getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE half getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 									 float3 geomNormal, float normalOffsetBias,
 									 float3 posVS, float3 lightPos,float4 invShadowMapSize, float2 invDepthRange
 									 PASSBUF_ARG_DECL )
 	@end @property( @m == 3 )
-		INLINE float getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE half getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 									 float3 geomNormal, float normalOffsetBias,
 									 float3 posVS, float3 lightPos, float4 invShadowMapSize, float2 invDepthRange,
 									 float2 minUV, float2 maxUV, float2 lengthUV
@@ -313,7 +313,7 @@
 	@end
 
 	@property( !exponential_shadow_maps )
-		float retVal = 0.;
+		half retVal = _h( 0. );
 
 		@property( pcf >= 3 )
 			float2 offsets[@value(pcf_iterations)] =
@@ -408,30 +408,30 @@
 		@end
 
 		@property( pcf == 3 )
-			retVal *= 0.25;
+			retVal *= _h( 0.25 );
 		@end @property( pcf == 4 )
-			retVal *= 0.11111111111111;
+			retVal *= _h( 0.11111111111111 );
 		@end @property( pcf == 5)
-			retVal *= 0.0625;
+			retVal *= _h( 0.0625 );
 		@end @property( pcf == 6 )
-			retVal *= 0.04;
+			retVal *= _h( 0.04 );
 		@end
 	@end	///! exponential_shadow_maps
 	@property( exponential_shadow_maps )
 		float expDepth = OGRE_SAMPLE_SHADOW_ESM( shadowMap, shadowSampler, uv );
 		float retVal = exp( @value( exponential_shadow_maps ).0 * (expDepth - fDepth) );
-		retVal = min( retVal, 1.0 );
+		retVal = min( retVal, _h( 1.0 ) );
 	@end    ///! exponential_shadow_maps
 
 	@property( (@m == 0 || @m == 2) && syntax == metal )
 		//Metal does not support clamp to border colour
 		retVal = (uv.x <= 0.0h || uv.x >= 1.0h ||
-				  uv.y <= 0.0h || uv.y >= 1.0h) ? 1.0 : retVal;
+				  uv.y <= 0.0h || uv.y >= 1.0h) ? _h( 1.0 ) : retVal;
 	@end
 
 	@property( @m == 1 || @m == 3 )
 		retVal = (uv.x <= minUV.x || uv.x >= maxUV.x ||
-				  uv.y <= minUV.y || uv.y >= maxUV.y) ? 1.0 : retVal;
+				  uv.y <= minUV.y || uv.y >= maxUV.y) ? _h( 1.0 ) : retVal;
 	@end
 
 		return retVal;
@@ -448,9 +448,9 @@
 	@property( debug_pssm_splits )
 		float3 debugPssmSplit = float3( 0, 0, 0 );
 	@end
-	float fShadow = 1.0;
+	half fShadow = _h( 1.0 );
 	@property( hlms_pssm_blend )
-		float fShadowBlend = 1.0;
+		half fShadowBlend = _h( 1.0 );
 	@end
 	@property( receive_shadows )
 		if( inPs.depth <= passBuf.pssmSplitPoints@value(CurrentShadowMap) )
@@ -466,9 +466,11 @@
 											  inPs_posL1,
 											  passBuf.shadowRcv[@value(CurrentShadowMap)].invShadowMapSize
 											  hlms_shadowmap@value(CurrentShadowMap)_uv_param );
-					fShadow = lerp( fShadow, fShadowBlend,
-									(inPs.depth - passBuf.pssmBlendPoints@value(CurrentShadowMapBlend)) /
-									(passBuf.pssmSplitPoints@value(CurrentShadowMapBlend) - passBuf.pssmBlendPoints@counter(CurrentShadowMapBlend)) );
+					fShadow = lerp(
+						fShadow, fShadowBlend,
+						half( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
+							  ( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
+								passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
 				}
 			@end
 			@property( debug_pssm_splits )
@@ -489,16 +491,19 @@
 											  inPs_posL@value(CurrentShadowMap),
 											  passBuf.shadowRcv[@value(CurrentShadowMap)].invShadowMapSize
 											  hlms_shadowmap@value(CurrentShadowMap)_uv_param );
-					fShadow = lerp( fShadow, fShadowBlend,
-									(inPs.depth - passBuf.pssmBlendPoints@value(CurrentShadowMapBlend)) /
-									(passBuf.pssmSplitPoints@value(CurrentShadowMapBlend) - passBuf.pssmBlendPoints@counter(CurrentShadowMapBlend)) );
+					fShadow = lerp(
+						fShadow, fShadowBlend,
+						half( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
+							  ( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
+								passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
 				}
 			@end @property( hlms_pssm_fade && @n == hlms_pssm_splits_minus_one )
 				if( inPs.depth > passBuf.pssmFadePoint )
 				{
-					fShadow = lerp( fShadow, 1.0,
-									(inPs.depth - passBuf.pssmFadePoint) /
-									(passBuf.pssmSplitPoints@value(hlms_pssm_splits_minus_one) - passBuf.pssmFadePoint) );
+					fShadow = lerp( fShadow, _h( 1.0 ),
+									half( ( inPs.depth - passBuf.pssmFadePoint ) /
+										  ( passBuf.pssmSplitPoints@value( hlms_pssm_splits_minus_one ) -
+											passBuf.pssmFadePoint ) ) );
 				}
 			@end
 			@property( debug_pssm_splits )
@@ -514,12 +519,12 @@
 	@end
 @end @property( !hlms_pssm_splits && hlms_num_shadow_map_lights && hlms_lights_directional )
 	@property( receive_shadows )
-		float fShadow = getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
-								   inPs_posL0,
-								   passBuf.shadowRcv[@value(CurrentShadowMap)].invShadowMapSize
-								   hlms_shadowmap@counter(CurrentShadowMap)_uv_param );
+		half fShadow = getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
+								  inPs_posL0,
+								  passBuf.shadowRcv[@value(CurrentShadowMap)].invShadowMapSize
+								  hlms_shadowmap@counter(CurrentShadowMap)_uv_param );
 	@else
-		float fShadow = 1.0;
+		half fShadow = _h( 1.0 );
 	@end
 @end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -235,7 +235,7 @@
 
 	@foreach( 2, m )
 		// Perform normal offset bias. See https://github.com/OGRECave/ogre-next/issues/100
-		INLINE float3 getNormalOffsetBiasPoint( float3 geomNormal, float3 lightDir,
+		INLINE float3 getNormalOffsetBiasPoint( midf3 geomNormal, float3 lightDir,
 												float normalOffsetBias, float shadowMapTexSize,
 												float depthRange
 		@property( @m == 0 )
@@ -244,13 +244,13 @@
 												, float2 minUV, float2 maxUV )
 		@end
 		{
-			float tmpNdotL = saturate( dot( lightDir.xyz, geomNormal.xyz ) );
+			float tmpNdotL = saturate( dot( lightDir.xyz, float3( geomNormal.xyz ) ) );
 
 			@property( @m == 1 )
 				shadowMapTexSize /= maxUV.x - minUV.x;
 			@end
 
-			return ( ( 1.0f - tmpNdotL ) * normalOffsetBias * geomNormal.xyz * shadowMapTexSize );
+			return ( ( 1.0f - tmpNdotL ) * normalOffsetBias * float3( geomNormal.xyz ) * shadowMapTexSize );
 		}
 	@end
 @foreach( 4, m )
@@ -262,12 +262,12 @@
 								float4 psPosLN, float4 invShadowMapSize, float2 minUV, float2 maxUV )
 	@end @property( @m == 2 )
 		INLINE midf getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
-									 float3 geomNormal, float normalOffsetBias,
+									 midf3 geomNormal, float normalOffsetBias,
 									 float3 posVS, float3 lightPos,float4 invShadowMapSize, float2 invDepthRange
 									 PASSBUF_ARG_DECL )
 	@end @property( @m == 3 )
 		INLINE midf getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
-									 float3 geomNormal, float normalOffsetBias,
+									 midf3 geomNormal, float normalOffsetBias,
 									 float3 posVS, float3 lightPos, float4 invShadowMapSize, float2 invDepthRange,
 									 float2 minUV, float2 maxUV, float2 lengthUV
 									 PASSBUF_ARG_DECL )

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -419,8 +419,8 @@
 	@end	///! exponential_shadow_maps
 	@property( exponential_shadow_maps )
 		float expDepth = OGRE_SAMPLE_SHADOW_ESM( shadowMap, shadowSampler, uv );
-		float retVal = exp( @value( exponential_shadow_maps ).0 * (expDepth - fDepth) );
-		retVal = min( retVal, _h( 1.0 ) );
+		float unclampedVal = exp( @value( exponential_shadow_maps ).0 * (expDepth - fDepth) );
+		half retVal = half_c( min( unclampedVal, 1.0 ) );
 	@end    ///! exponential_shadow_maps
 
 	@property( (@m == 0 || @m == 2) && syntax == metal )

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -40,17 +40,17 @@
 @end
 
 @property( syntax == glsl || syntax == glsles )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : half_c( texture( tex, vec3( uv, depth ) ) ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : midf_c( texture( tex, vec3( uv, depth ) ) ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) textureLod( tex, uv, 0 ).x
 @end
 
 @property( syntax == glslvk )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : half_c( texture( sampler2DShadow( tex, sampler ), vec3( uv, depth ) ) ) )
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : midf_c( texture( sampler2DShadow( tex, sampler ), vec3( uv, depth ) ) ) )
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) textureLod( sampler2D( tex, sampler ), uv, 0 ).x
 @end
 
 @property( syntax == hlsl )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : half_c( tex.SampleCmpLevelZero( sampler, uv.xy, depth ).x ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : midf_c( tex.SampleCmpLevelZero( sampler, uv.xy, depth ).x ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) tex.SampleLevel( sampler, uv, 0 ).x
 @end
 
@@ -255,18 +255,18 @@
 	@end
 @foreach( 4, m )
 	@property( @m == 0 )
-		INLINE half getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE midf getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 								float4 psPosLN, float4 invShadowMapSize )
 	@end @property( @m == 1 )
-		INLINE half getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE midf getShadow( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 								float4 psPosLN, float4 invShadowMapSize, float2 minUV, float2 maxUV )
 	@end @property( @m == 2 )
-		INLINE half getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE midf getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 									 float3 geomNormal, float normalOffsetBias,
 									 float3 posVS, float3 lightPos,float4 invShadowMapSize, float2 invDepthRange
 									 PASSBUF_ARG_DECL )
 	@end @property( @m == 3 )
-		INLINE half getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
+		INLINE midf getShadowPoint( @insertpiece( TEXTURE2DSHADOW ) shadowMap, @insertpiece( SamplerShadow )
 									 float3 geomNormal, float normalOffsetBias,
 									 float3 posVS, float3 lightPos, float4 invShadowMapSize, float2 invDepthRange,
 									 float2 minUV, float2 maxUV, float2 lengthUV
@@ -313,7 +313,7 @@
 	@end
 
 	@property( !exponential_shadow_maps )
-		half retVal = _h( 0. );
+		midf retVal = _h( 0. );
 
 		@property( pcf >= 3 )
 			float2 offsets[@value(pcf_iterations)] =
@@ -420,7 +420,7 @@
 	@property( exponential_shadow_maps )
 		float expDepth = OGRE_SAMPLE_SHADOW_ESM( shadowMap, shadowSampler, uv );
 		float unclampedVal = exp( @value( exponential_shadow_maps ).0 * (expDepth - fDepth) );
-		half retVal = half_c( min( unclampedVal, 1.0 ) );
+		midf retVal = midf_c( min( unclampedVal, 1.0 ) );
 	@end    ///! exponential_shadow_maps
 
 	@property( (@m == 0 || @m == 2) && syntax == metal )
@@ -448,9 +448,9 @@
 	@property( debug_pssm_splits )
 		float3 debugPssmSplit = float3( 0, 0, 0 );
 	@end
-	half fShadow = _h( 1.0 );
+	midf fShadow = _h( 1.0 );
 	@property( hlms_pssm_blend )
-		half fShadowBlend = _h( 1.0 );
+		midf fShadowBlend = _h( 1.0 );
 	@end
 	@property( receive_shadows )
 		if( inPs.depth <= passBuf.pssmSplitPoints@value(CurrentShadowMap) )
@@ -468,7 +468,7 @@
 											  hlms_shadowmap@value(CurrentShadowMap)_uv_param );
 					fShadow = lerp(
 						fShadow, fShadowBlend,
-						half_c( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
+						midf_c( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
 								( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
 								  passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
 				}
@@ -493,7 +493,7 @@
 											  hlms_shadowmap@value(CurrentShadowMap)_uv_param );
 					fShadow = lerp(
 						fShadow, fShadowBlend,
-						half_c( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
+						midf_c( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
 								( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
 								  passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
 				}
@@ -501,7 +501,7 @@
 				if( inPs.depth > passBuf.pssmFadePoint )
 				{
 					fShadow = lerp( fShadow, _h( 1.0 ),
-									half_c( ( inPs.depth - passBuf.pssmFadePoint ) /
+									midf_c( ( inPs.depth - passBuf.pssmFadePoint ) /
 											( passBuf.pssmSplitPoints@value( hlms_pssm_splits_minus_one ) -
 											  passBuf.pssmFadePoint ) ) );
 				}
@@ -519,12 +519,12 @@
 	@end
 @end @property( !hlms_pssm_splits && hlms_num_shadow_map_lights && hlms_lights_directional )
 	@property( receive_shadows )
-		half fShadow = getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
+		midf fShadow = getShadow( hlms_shadowmap@value(CurrentShadowMap), @insertpiece( UseSamplerShadow )
 								  inPs_posL0,
 								  passBuf.shadowRcv[@value(CurrentShadowMap)].invShadowMapSize
 								  hlms_shadowmap@counter(CurrentShadowMap)_uv_param );
 	@else
-		half fShadow = _h( 1.0 );
+		midf fShadow = _h( 1.0 );
 	@end
 @end
 @end

--- a/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/ShadowMapping_piece_ps.any
@@ -40,22 +40,22 @@
 @end
 
 @property( syntax == glsl || syntax == glsles )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : half( texture( tex, vec3( uv, depth ) ) ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : half_c( texture( tex, vec3( uv, depth ) ) ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) textureLod( tex, uv, 0 ).x
 @end
 
 @property( syntax == glslvk )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : half( texture( sampler2DShadow( tex, sampler ), vec3( uv, depth ) ) ) )
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : half_c( texture( sampler2DShadow( tex, sampler ), vec3( uv, depth ) ) ) )
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) textureLod( sampler2D( tex, sampler ), uv, 0 ).x
 @end
 
 @property( syntax == hlsl )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : half( tex.SampleCmpLevelZero( sampler, uv.xy, depth ).x ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : half_c( tex.SampleCmpLevelZero( sampler, uv.xy, depth ).x ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) tex.SampleLevel( sampler, uv, 0 ).x
 @end
 
 @property( syntax == metal )
-	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? half( 1.0 ) : tex.sample_compare( sampler, float2( uv.xy ), depth ))
+	#define OGRE_SAMPLE_SHADOW( tex, sampler, uv, depth ) (OGRE_DEPTH_CMP_GE( depth, OGRE_DEPTH_DEFAULT_CLEAR ) ? _h( 1.0 ) : tex.sample_compare( sampler, float2( uv.xy ), depth ))
 	#define OGRE_SAMPLE_SHADOW_ESM( tex, sampler, uv ) tex.sample( sampler, float2( uv.xy ), level(0) ).x
 @end
 @end
@@ -468,9 +468,9 @@
 											  hlms_shadowmap@value(CurrentShadowMap)_uv_param );
 					fShadow = lerp(
 						fShadow, fShadowBlend,
-						half( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
-							  ( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
-								passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
+						half_c( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
+								( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
+								  passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
 				}
 			@end
 			@property( debug_pssm_splits )
@@ -493,17 +493,17 @@
 											  hlms_shadowmap@value(CurrentShadowMap)_uv_param );
 					fShadow = lerp(
 						fShadow, fShadowBlend,
-						half( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
-							  ( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
-								passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
+						half_c( ( inPs.depth - passBuf.pssmBlendPoints@value( CurrentShadowMapBlend ) ) /
+								( passBuf.pssmSplitPoints@value( CurrentShadowMapBlend ) -
+								  passBuf.pssmBlendPoints@counter( CurrentShadowMapBlend ) ) ) );
 				}
 			@end @property( hlms_pssm_fade && @n == hlms_pssm_splits_minus_one )
 				if( inPs.depth > passBuf.pssmFadePoint )
 				{
 					fShadow = lerp( fShadow, _h( 1.0 ),
-									half( ( inPs.depth - passBuf.pssmFadePoint ) /
-										  ( passBuf.pssmSplitPoints@value( hlms_pssm_splits_minus_one ) -
-											passBuf.pssmFadePoint ) ) );
+									half_c( ( inPs.depth - passBuf.pssmFadePoint ) /
+											( passBuf.pssmSplitPoints@value( hlms_pssm_splits_minus_one ) -
+											  passBuf.pssmFadePoint ) ) );
 				}
 			@end
 			@property( debug_pssm_splits )

--- a/Samples/Media/Hlms/Pbs/GLSL/PixelShader_ps.glsl
+++ b/Samples/Media/Hlms/Pbs/GLSL/PixelShader_ps.glsl
@@ -50,7 +50,7 @@ layout(std140) uniform;
 		@end
 	@end
 	vulkan_layout( ogre_t@value(refractionMap) )	uniform texture2D	refractionMap;
-	vulkan( layout( ogre_s@value(refractionMap) )	uniform sampler		refractionMapSampler );
+	vulkan( layout( ogre_s@value(refractionMap) )	uniform sampler			refractionMapSampler );
 @end
 
 @insertpiece( DeclPlanarReflTextures )
@@ -83,7 +83,7 @@ vulkan_layout( location = 0 ) in block
 @end
 @property( irradiance_volumes )
 	vulkan_layout( ogre_t@value(irradianceVolume) )	uniform texture3D	irradianceVolume;
-	vulkan( layout( ogre_s@value(irradianceVolume) )uniform sampler		irradianceVolumeSampler );
+	vulkan( layout( ogre_s@value(irradianceVolume) )uniform sampler			irradianceVolumeSampler );
 @end
 
 @foreach( num_textures, n )

--- a/Samples/Media/Hlms/Pbs/GLSL/PixelShader_ps.glsl
+++ b/Samples/Media/Hlms/Pbs/GLSL/PixelShader_ps.glsl
@@ -10,15 +10,15 @@ layout(std140) uniform;
 @property( !hlms_render_depth_only )
 	@property( !hlms_shadowcaster )
 		@property( !hlms_prepass )
-			layout(location = @counter(rtv_target), index = 0) out vec4 outColour;
+			layout(location = @counter(rtv_target), index = 0) out midf4 outColour;
 		@end
 		@property( hlms_gen_normals_gbuffer )
 			#define outPs_normals outNormals
-			layout(location = @counter(rtv_target)) out vec4 outNormals;
+			layout(location = @counter(rtv_target)) out midf4 outNormals;
 		@end
 		@property( hlms_prepass )
 			#define outPs_shadowRoughness outShadowRoughness
-			layout(location = @counter(rtv_target)) out vec2 outShadowRoughness;
+			layout(location = @counter(rtv_target)) out midf2 outShadowRoughness;
 		@end
 	@else
 		layout(location = @counter(rtv_target), index = 0) out float outColour;

--- a/Samples/Media/Hlms/Pbs/GLSL/VertexShader_vs.glsl
+++ b/Samples/Media/Hlms/Pbs/GLSL/VertexShader_vs.glsl
@@ -17,7 +17,7 @@ layout(std140) uniform;
 vulkan_layout( OGRE_POSITION ) in vec4 vertex;
 
 @property( hlms_normal )vulkan_layout( OGRE_NORMAL ) in float3 normal;@end
-@property( hlms_qtangent )vulkan_layout( OGRE_NORMAL ) in half4 qtangent;@end
+@property( hlms_qtangent )vulkan_layout( OGRE_NORMAL ) in midf4 qtangent;@end
 
 @property( normal_map && !hlms_qtangent )
 	@property( hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in float4 tangent;@end

--- a/Samples/Media/Hlms/Pbs/GLSL/VertexShader_vs.glsl
+++ b/Samples/Media/Hlms/Pbs/GLSL/VertexShader_vs.glsl
@@ -16,13 +16,13 @@ layout(std140) uniform;
 
 vulkan_layout( OGRE_POSITION ) in vec4 vertex;
 
-@property( hlms_normal )vulkan_layout( OGRE_NORMAL ) in half3 normal;@end
+@property( hlms_normal )vulkan_layout( OGRE_NORMAL ) in float3 normal;@end
 @property( hlms_qtangent )vulkan_layout( OGRE_NORMAL ) in half4 qtangent;@end
 
 @property( normal_map && !hlms_qtangent )
-	@property( hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in half4 tangent;@end
-	@property( !hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in half3 tangent;@end
-	@property( hlms_binormal )vulkan_layout( OGRE_BIRNORMAL ) in half3 binormal;@end
+	@property( hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in float4 tangent;@end
+	@property( !hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in float3 tangent;@end
+	@property( hlms_binormal )vulkan_layout( OGRE_BIRNORMAL ) in float3 binormal;@end
 @end
 
 @property( hlms_skeleton )

--- a/Samples/Media/Hlms/Pbs/GLSL/VertexShader_vs.glsl
+++ b/Samples/Media/Hlms/Pbs/GLSL/VertexShader_vs.glsl
@@ -16,13 +16,13 @@ layout(std140) uniform;
 
 vulkan_layout( OGRE_POSITION ) in vec4 vertex;
 
-@property( hlms_normal )vulkan_layout( OGRE_NORMAL ) in vec3 normal;@end
-@property( hlms_qtangent )vulkan_layout( OGRE_NORMAL ) in vec4 qtangent;@end
+@property( hlms_normal )vulkan_layout( OGRE_NORMAL ) in half3 normal;@end
+@property( hlms_qtangent )vulkan_layout( OGRE_NORMAL ) in half4 qtangent;@end
 
 @property( normal_map && !hlms_qtangent )
-	@property( hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in vec4 tangent;@end
-	@property( !hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in vec3 tangent;@end
-	@property( hlms_binormal )vulkan_layout( OGRE_BIRNORMAL ) in vec3 binormal;@end
+	@property( hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in half4 tangent;@end
+	@property( !hlms_tangent4 )vulkan_layout( OGRE_TANGENT ) in half3 tangent;@end
+	@property( hlms_binormal )vulkan_layout( OGRE_BIRNORMAL ) in half3 binormal;@end
 @end
 
 @property( hlms_skeleton )

--- a/Samples/Media/Hlms/Pbs/HLSL/Textures_piece_ps.hlsl
+++ b/Samples/Media/Hlms/Pbs/HLSL/Textures_piece_ps.hlsl
@@ -2,10 +2,10 @@
 @property( !hlms_render_depth_only && !hlms_shadowcaster )
 	@piece( ExtraOutputTypes )
 		@property( hlms_gen_normals_gbuffer )
-			float4 normals			: SV_Target@counter(rtv_target);
+			midf4 normals			: SV_Target@counter(rtv_target);
 		@end
 		@property( hlms_prepass )
-			float2 shadowRoughness	: SV_Target@counter(rtv_target);
+			midf2 shadowRoughness	: SV_Target@counter(rtv_target);
 		@end
 	@end
 @end

--- a/Samples/Media/Hlms/Pbs/Metal/Forward3D_piece_ps.metal
+++ b/Samples/Media/Hlms/Pbs/Metal/Forward3D_piece_ps.metal
@@ -3,13 +3,13 @@
 @property( hlms_enable_decals )
 	@piece( DeclDecalsSamplers )
 		, sampler decalsSampler	[[sampler(@value(decalsSampler))]]
-		@property( hlms_decals_diffuse ), texture2d_array<float> decalsDiffuseTex	[[texture(@value(decalsDiffuseTex))]]@end
-		@property( hlms_decals_normals ), texture2d_array<float> decalsNormalsTex	[[texture(@value(decalsNormalsTex))]]@end
+		@property( hlms_decals_diffuse ), texture2d_array<midf> decalsDiffuseTex	[[texture(@value(decalsDiffuseTex))]]@end
+		@property( hlms_decals_normals ), texture2d_array<midf> decalsNormalsTex	[[texture(@value(decalsNormalsTex))]]@end
 		@property( hlms_decals_diffuse == hlms_decals_emissive )
 			#define decalsEmissiveTex decalsDiffuseTex
 		@end
 		@property( hlms_decals_emissive && hlms_decals_diffuse != hlms_decals_emissive )
-			, texture2d_array<float> decalsEmissiveTex	[[texture(@value(decalsEmissiveTex))]]
+			, texture2d_array<midf> decalsEmissiveTex	[[texture(@value(decalsEmissiveTex))]]
 		@end
 	@end
 @end

--- a/Samples/Media/Hlms/Pbs/Metal/PixelShader_ps.metal
+++ b/Samples/Media/Hlms/Pbs/Metal/PixelShader_ps.metal
@@ -77,11 +77,11 @@ fragment @insertpiece( output_type ) main_metal
 
 	@property( hlms_use_prepass )
 		@property( !hlms_use_prepass_msaa )
-		, texture2d<float, access::read> gBuf_normals			[[texture(@value(gBuf_normals))]]
-		, texture2d<float, access::read> gBuf_shadowRoughness	[[texture(@value(gBuf_shadowRoughness))]]
+		, texture2d<midf, access::read> gBuf_normals			[[texture(@value(gBuf_normals))]]
+		, texture2d<midf, access::read> gBuf_shadowRoughness	[[texture(@value(gBuf_shadowRoughness))]]
 		@end @property( hlms_use_prepass_msaa )
-		, texture2d_ms<float, access::read> gBuf_normals		[[texture(@value(gBuf_normals))]]
-		, texture2d_ms<float, access::read> gBuf_shadowRoughness[[texture(@value(gBuf_shadowRoughness))]]
+		, texture2d_ms<midf, access::read> gBuf_normals		[[texture(@value(gBuf_normals))]]
+		, texture2d_ms<midf, access::read> gBuf_shadowRoughness[[texture(@value(gBuf_shadowRoughness))]]
 		@end
 
 		@property( hlms_use_ssr )
@@ -98,7 +98,7 @@ fragment @insertpiece( output_type ) main_metal
 				, texture2d<float> depthTextureNoMsaa			[[texture(@value(depthTextureNoMsaa))]]
 			@end
 		@end
-		, texture2d<float>	refractionMap			[[texture(@value(refractionMap))]]
+		, texture2d<midf>	refractionMap			[[texture(@value(refractionMap))]]
 		, sampler			refractionMapSampler	[[sampler(@value(refractionMap))]]
 	@end
 
@@ -107,22 +107,22 @@ fragment @insertpiece( output_type ) main_metal
 	@insertpiece( DeclLightProfilesTexture )
 
 	@property( irradiance_volumes )
-		, texture3d<float>	irradianceVolume		[[texture(@value(irradianceVolume))]]
+		, texture3d<midf>	irradianceVolume		[[texture(@value(irradianceVolume))]]
 		, sampler			irradianceVolumeSampler	[[sampler(@value(irradianceVolume))]]
 	@end
 
 	@foreach( num_textures, n )
-		, texture2d_array<float> textureMaps@n [[texture(@value(textureMaps@n))]]@end
+		, texture2d_array<midf> textureMaps@n [[texture(@value(textureMaps@n))]]@end
 	@property( use_envprobe_map )
 		@property( !hlms_enable_cubemaps_auto )
-			, texturecube<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
+			, texturecube<midf>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 		@end
 		@property( hlms_enable_cubemaps_auto )
 			@property( !hlms_cubemaps_use_dpm )
-				, texturecube_array<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
+				, texturecube_array<midf>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 			@end
 			@property( hlms_cubemaps_use_dpm )
-				, texture2d_array<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
+				, texture2d_array<midf>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 			@end
 		@end
 		@property( envMapRegSampler < samplerStateStart )
@@ -172,7 +172,7 @@ fragment @insertpiece( output_type ) main_metal
 	// END UNIFORM DECLARATION
 
 	@foreach( num_textures, n )
-		, texture2d_array<float> textureMaps@n [[texture(@value(textureMaps@n))]]@end
+		, texture2d_array<midf> textureMaps@n [[texture(@value(textureMaps@n))]]@end
 	@foreach( num_samplers, n )
 		, sampler samplerState@value(samplerStateStart) [[sampler(@counter(samplerStateStart))]]@end
 )

--- a/Samples/Media/Hlms/Pbs/Metal/Textures_piece_ps.metal
+++ b/Samples/Media/Hlms/Pbs/Metal/Textures_piece_ps.metal
@@ -2,10 +2,10 @@
 @property( !hlms_render_depth_only && !hlms_shadowcaster )
 	@piece( ExtraOutputTypes )
 		@property( hlms_gen_normals_gbuffer )
-			float4 normals			[[ color(@counter(rtv_target)) ]];
+			midf4 normals			[[ color(@counter(rtv_target)) ]];
 		@end
 		@property( hlms_prepass )
-			float2 shadowRoughness	[[ color(@counter(rtv_target)) ]];
+			midf2 shadowRoughness	[[ color(@counter(rtv_target)) ]];
 		@end
 	@end
 @end

--- a/Samples/Media/Hlms/Pbs/Metal/VertexShader_vs.metal
+++ b/Samples/Media/Hlms/Pbs/Metal/VertexShader_vs.metal
@@ -9,7 +9,7 @@ struct VS_INPUT
 {
 	float4 position [[attribute(VES_POSITION)]];
 @property( hlms_normal )	float3 normal [[attribute(VES_NORMAL)]];@end
-@property( hlms_qtangent )	float4 qtangent [[attribute(VES_NORMAL)]];@end
+@property( hlms_qtangent )	midf4 qtangent [[attribute(VES_NORMAL)]];@end
 
 @property( normal_map && !hlms_qtangent )
 	@property( hlms_tangent4 )float4 tangent	[[attribute(VES_TANGENT)]];@end

--- a/Samples/Media/Hlms/Pbs/Metal/VertexShader_vs.metal
+++ b/Samples/Media/Hlms/Pbs/Metal/VertexShader_vs.metal
@@ -62,8 +62,8 @@ vertex PS_INPUT main_metal
 		@end
 	@end
 	@property( hlms_vertex_id )
-		, uint vertexId [[vertex_id]]
-		, uint baseVertex [[base_vertex]]
+		, uint inVs_vertexId [[vertex_id]]
+		, uint baseVertexID [[base_vertex]]
 	@end
 	@insertpiece( custom_vs_uniformDeclaration )
 	// END UNIFORM DECLARATION

--- a/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
@@ -264,14 +264,14 @@
 
 			int gBufSubsample = int( findLSB( sampleMask ) );
 
-			pixelData.normal = normalize( OGRE_Load2DMS( gBuf_normals, iFragCoord, gBufSubsample ).xyz * 2.0 - 1.0 );
-			float2 shadowRoughness = OGRE_Load2DMS( gBuf_shadowRoughness, iFragCoord, gBufSubsample ).xy;
+			pixelData.normal = normalize( OGRE_Load2DMSF16( gBuf_normals, iFragCoord, gBufSubsample ).xyz * _h( 2.0 ) - _h( 1.0 ) );
+			midf2 shadowRoughness = OGRE_Load2DMSF16( gBuf_shadowRoughness, iFragCoord, gBufSubsample ).xy;
 		@else
-			pixelData.normal = normalize( OGRE_Load2D( gBuf_normals, iFragCoord, 0 ).xyz * 2.0 - 1.0 );
-			float2 shadowRoughness = OGRE_Load2D( gBuf_shadowRoughness, iFragCoord, 0 ).xy;
+			pixelData.normal = normalize( OGRE_Load2DF16( gBuf_normals, iFragCoord, 0 ).xyz * _h( 2.0 ) - _h( 1.0 ) );
+			midf2 shadowRoughness = OGRE_Load2DF16( gBuf_shadowRoughness, iFragCoord, 0 ).xy;
 		@end
 
-		float fShadow = shadowRoughness.x;
+		midf fShadow = shadowRoughness.x;
 
 		@property( roughness_map )
 			pixelData.roughness = shadowRoughness.y * 0.98 + 0.02;
@@ -376,27 +376,27 @@
 
 			@property( hlms_alphablend )
 				@property( use_texture_alpha )
-					outPs_colour0.w	= material.F0.w * pixelData.diffuse.w;
+					outPs_colour0.w	= _h( material.F0.w ) * pixelData.diffuse.w;
 				@else
-					outPs_colour0.w	= material.F0.w;
+					outPs_colour0.w	= _h( material.F0.w );
 				@end
 			@else
-				outPs_colour0.w		= 1.0;
+				outPs_colour0.w		= _h( 1.0 );
 			@end
 
 			@property( debug_pssm_splits )
-				outPs_colour0.xyz = mix( outPs_colour0.xyz, debugPssmSplit.xyz, 0.2f );
+				outPs_colour0.xyz = mix( outPs_colour0.xyz, debugPssmSplit.xyz, _h( 0.2f ) );
 			@end
 
-            @property( hlms_gen_normals_gbuffer )
-                outPs_normals = float4( pixelData.normal * 0.5 + 0.5, 1.0 );
+			@property( hlms_gen_normals_gbuffer )
+				outPs_normals = midf4_c( pixelData.normal * _h( 0.5 ) + _h( 0.5 ), 1.0 );
             @end
 		@else
-			outPs_normals			= float4( pixelData.normal * 0.5 + 0.5, 1.0 );
+			outPs_normals = midf4_c( pixelData.normal * _h( 0.5 ) + _h( 0.5 ), 1.0 );
 			@property( hlms_pssm_splits )
-				outPs_shadowRoughness	= float2( fShadow, (pixelData.roughness - 0.02) * 1.02040816 );
+				outPs_shadowRoughness	= midf2_c( fShadow, (pixelData.roughness - 0.02) * 1.02040816 );
 			@end @property( !hlms_pssm_splits )
-				outPs_shadowRoughness	= float2( 1.0, (pixelData.roughness - 0.02) * 1.02040816 );
+				outPs_shadowRoughness	= midf2_c( 1.0, (pixelData.roughness - 0.02) * 1.02040816 );
 			@end
 		@end
 	@end

--- a/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
@@ -22,15 +22,15 @@
 		@insertpiece( DeclareBRDF_AreaLightApprox )
 	@end
 
-	#define SampleMetalness0( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
-	#define SampleMetalness1( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
-	#define SampleMetalness2( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
-	#define SampleMetalness3( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
+	#define SampleMetalness0( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
+	#define SampleMetalness1( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
+	#define SampleMetalness2( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
+	#define SampleMetalness3( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
 
-	#define SampleRoughness0( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
-	#define SampleRoughness1( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
-	#define SampleRoughness2( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
-	#define SampleRoughness3( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2D( tex, sampler, uv, arrayIdx )
+	#define SampleRoughness0( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
+	#define SampleRoughness1( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
+	#define SampleRoughness2( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
+	#define SampleRoughness3( tex, sampler, uv, arrayIdx ) OGRE_SampleArray2DF16( tex, sampler, uv, arrayIdx )
 
 	#define OGRE_UNPACK_X_2x16( packedInt ) ((packedInt) & 0x0000FFFFu)
 	#define OGRE_UNPACK_Y_2x16( packedInt ) ((packedInt) >> 16u)
@@ -103,23 +103,23 @@
 										   texIndex_diffuseIdx );
 	@else
 		/// If there are no diffuse maps, we must initialize it to some value.
-		pixelData.diffuse.xyzw = float4( 1, 1, 1, 1 );
+		pixelData.diffuse.xyzw = half4_c( 1, 1, 1, 1 );
 	@end
 
 	@foreach( detail_maps_diffuse, n )
-		@property( !detail_map@n )float3 detailCol@n = float3( 0.0f, 0.0f, 0.0f );@end
+		@property( !detail_map@n )half3 detailCol@n = half3_c( 0.0f, 0.0f, 0.0f );@end
 	@end
 
 
 	@property( !detail_maps_diffuse && !detail_maps_normal )
-		float4 detailWeights = float4( 0.25f, 0.25f, 0.25f, 0.25f );
+		half4 detailWeights = half4_c( 0.25f, 0.25f, 0.25f, 0.25f );
 	@else
 		pixelData.diffuse.xyz *= (detailCol0.xyz * detailWeights.x + detailCol1.xyz * detailWeights.y) +
 								 (detailCol2.xyz * detailWeights.z + detailCol3.xyz * detailWeights.w);
 	@end
 
 	/// Apply the material's diffuse over the textures
-	pixelData.diffuse.xyz *= material.kD.xyz;
+	pixelData.diffuse.xyz *= half3_c( material.kD.xyz );
 @end
 
 @undefpiece( SampleSpecularMap )
@@ -127,23 +127,23 @@
 	/// SPECUlAR MAP
 	@foreach( 4, n )
 		@property( metalness_map@n )
-			float metalness@n = SampleMetalness@n( textureMaps@value( metalness_map@n_idx ),
-												   samplerState@value(metalness_map@n_sampler),
-												   inPs.uv0.xy * material.detailOffsetScale[@n].zw +
-												   material.detailOffsetScale[@n].xy,
-												   texIndex_detailMetalnessIdx@n ).x;
+			half metalness@n = SampleMetalness@n( textureMaps@value( metalness_map@n_idx ),
+												  samplerState@value(metalness_map@n_sampler),
+												  inPs.uv0.xy * material.detailOffsetScale[@n].zw +
+												  material.detailOffsetScale[@n].xy,
+												  texIndex_detailMetalnessIdx@n ).x;
 		@else
-			float metalness@n = 0;
+			half metalness@n = _h( 0 );
 		@end
 	@end
 
-	pixelData.specular.xyz = float3( 1.0f, 1.0f, 1.0f );
-	float metalness =	(metalness0 * detailWeights.x * material.metalness.x +
-						 metalness1 * detailWeights.y * material.metalness.y) +
-						(metalness2 * detailWeights.z * material.metalness.z +
-						 metalness3 * detailWeights.w * material.metalness.w);
+	pixelData.specular.xyz = half3_c( 1.0f, 1.0f, 1.0f );
+	half metalness =	(metalness0 * detailWeights.x * half_c( material.metalness.x ) +
+						 metalness1 * detailWeights.y * half_c( material.metalness.y )) +
+						(metalness2 * detailWeights.z * half_c( material.metalness.z ) +
+						 metalness3 * detailWeights.w * half_c( material.metalness.w ));
 
-	pixelData.F0 = lerp( float3( 0.03f, 0.03f, 0.03f ), pixelData.diffuse.xyz * 3.14159f, metalness );
+	pixelData.F0 = lerp( half3_c( 0.03f, 0.03f, 0.03f ), pixelData.diffuse.xyz * _h( 3.14159f ), metalness );
 	pixelData.diffuse.xyz = pixelData.diffuse.xyz - pixelData.diffuse.xyz * metalness;
 @end
 
@@ -152,41 +152,41 @@
 	/// ROUGHNESS MAP
 	@foreach( 4, n )
 		@property( roughness_map@n )
-			float roughness@n = SampleRoughness@n( textureMaps@value( roughness_map@n_idx ),
-												   samplerState@value(roughness_map@n_sampler),
-												   inPs.uv0.xy * material.detailOffsetScale[@n].zw +
-												   material.detailOffsetScale[@n].xy,
-												   texIndex_detailRoughnessIdx@n ).x;
+			half roughness@n = SampleRoughness@n( textureMaps@value( roughness_map@n_idx ),
+												  samplerState@value(roughness_map@n_sampler),
+												  inPs.uv0.xy * material.detailOffsetScale[@n].zw +
+												  material.detailOffsetScale[@n].xy,
+												  texIndex_detailRoughnessIdx@n ).x;
 		@else
-			float roughness@n = 0;
+			half roughness@n = _h( 0 );
 		@end
 	@end
 
-	pixelData.perceptualRoughness =	(roughness0 * detailWeights.x * material.roughness.x +
-									 roughness1 * detailWeights.y * material.roughness.y) +
-									(roughness2 * detailWeights.z * material.roughness.z +
-									 roughness3 * detailWeights.w * material.roughness.w);
+	pixelData.perceptualRoughness =	(roughness0 * detailWeights.x * half_c( material.roughness.x ) +
+									 roughness1 * detailWeights.y * half_c( material.roughness.y )) +
+									(roughness2 * detailWeights.z * half_c( material.roughness.z ) +
+									 roughness3 * detailWeights.w * half_c( material.roughness.w ));
 	@property( perceptual_roughness )
-		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, 0.001f );
+		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, _h( 0.001f ) );
 	@else
-		pixelData.roughness = max( pixelData.perceptualRoughness, 0.001f );
+		pixelData.roughness = max( pixelData.perceptualRoughness, _h( 0.001f ) );
 	@end
 @end
 
 @undefpiece( LoadNormalData )
 @piece( LoadNormalData )
 	// Geometric normal
-	pixelData.geomNormal = OGRE_Sample( terrainNormals, samplerStateTerra, inPs.uv0.xy ).xyz * 2.0 - 1.0;
+	pixelData.geomNormal = OGRE_SampleF16( terrainNormals, samplerStateTerra, inPs.uv0.xy ).xyz * _h( 2.0 ) - _h( 1.0 );
 	@property( z_up )
-		  pixelData.geomNormal.yz = float2( -pixelData.geomNormal.z, pixelData.geomNormal.y );
+		  pixelData.geomNormal.yz = half2_c( -pixelData.geomNormal.z, pixelData.geomNormal.y );
 	@end
-	pixelData.geomNormal = mul( pixelData.geomNormal, toFloat3x3( passBuf.view ) );
+	pixelData.geomNormal = mul( pixelData.geomNormal, toHalf3x3( passBuf.view ) );
 	@property( normal_map )
 		//Get the TBN matrix
-		float3 viewSpaceUnitX	= mul( float3( 1, 0, 0 ) , toFloat3x3( passBuf.view ) );
-		float3 vTangent			= normalize( cross( pixelData.geomNormal, viewSpaceUnitX ) );
-		float3 vBinormal		= cross( vTangent, pixelData.geomNormal );
-		float3x3 TBN			= buildFloat3x3( vBinormal, vTangent, pixelData.geomNormal );
+		half3 viewSpaceUnitX	= mul( half3_c( 1, 0, 0 ), toHalf3x3( passBuf.view ) );
+		half3 vTangent			= normalize( cross( pixelData.geomNormal, viewSpaceUnitX ) );
+		half3 vBinormal			= cross( vTangent, pixelData.geomNormal );
+		half3x3 TBN				= buildHalf3x3( vBinormal, vTangent, pixelData.geomNormal );
 	@end
 @end
 
@@ -284,9 +284,9 @@
 		@insertpiece( custom_ps_preLights )
 
 		@property( !custom_disable_directional_lights )
-			float fTerrainShadow = OGRE_Sample( terrainShadows, samplerStateTerra, inPs.uv0.xy ).x;
+			half fTerrainShadow = OGRE_SampleF16( terrainShadows, samplerStateTerra, inPs.uv0.xy ).x;
 			@property( !(hlms_pssm_splits || (!hlms_pssm_splits && hlms_num_shadow_map_lights && hlms_lights_directional)) )
-				float fShadow = 1.0f;
+				half fShadow = _h( 1.0f );
 			@end
 			fShadow *= fTerrainShadow;
 
@@ -340,20 +340,24 @@
 					if( vctSpecular.w == 0 )
 					{
 				@end
-						pixelData.envColourS += lerp( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-						pixelData.envColourD += lerp( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+						pixelData.envColourS += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
+													  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
+						pixelData.envColourD += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
+													  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
 					@property( vct_num_probes )
 					}
 				@end
 				@else
-					pixelData.envColourS = lerp( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-					pixelData.envColourD = lerp( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+					pixelData.envColourS = lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
+												 half3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
+					pixelData.envColourD = lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
+												 half3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
 				@end
 			@end
 			@property( ambient_fixed && vct_num_probes )
 				//Only use ambient lighting if object is outside any VCT probe
-				finalColour += vctSpecular.w == 0 ? float3( 0, 0, 0 ) :
-													(passBuf.ambientUpperHemi.xyz * pixelData.diffuse.xyz);
+				finalColour += vctSpecular.w == 0 ? half3_c( 0, 0, 0 ) :
+													(half3_c( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz);
 			@end
 
 		@property( needs_env_brdf )

--- a/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
@@ -103,23 +103,23 @@
 										   texIndex_diffuseIdx );
 	@else
 		/// If there are no diffuse maps, we must initialize it to some value.
-		pixelData.diffuse.xyzw = half4_c( 1, 1, 1, 1 );
+		pixelData.diffuse.xyzw = midf4_c( 1, 1, 1, 1 );
 	@end
 
 	@foreach( detail_maps_diffuse, n )
-		@property( !detail_map@n )half3 detailCol@n = half3_c( 0.0f, 0.0f, 0.0f );@end
+		@property( !detail_map@n )midf3 detailCol@n = midf3_c( 0.0f, 0.0f, 0.0f );@end
 	@end
 
 
 	@property( !detail_maps_diffuse && !detail_maps_normal )
-		half4 detailWeights = half4_c( 0.25f, 0.25f, 0.25f, 0.25f );
+		midf4 detailWeights = midf4_c( 0.25f, 0.25f, 0.25f, 0.25f );
 	@else
 		pixelData.diffuse.xyz *= (detailCol0.xyz * detailWeights.x + detailCol1.xyz * detailWeights.y) +
 								 (detailCol2.xyz * detailWeights.z + detailCol3.xyz * detailWeights.w);
 	@end
 
 	/// Apply the material's diffuse over the textures
-	pixelData.diffuse.xyz *= half3_c( material.kD.xyz );
+	pixelData.diffuse.xyz *= midf3_c( material.kD.xyz );
 @end
 
 @undefpiece( SampleSpecularMap )
@@ -127,23 +127,23 @@
 	/// SPECUlAR MAP
 	@foreach( 4, n )
 		@property( metalness_map@n )
-			half metalness@n = SampleMetalness@n( textureMaps@value( metalness_map@n_idx ),
+			midf metalness@n = SampleMetalness@n( textureMaps@value( metalness_map@n_idx ),
 												  samplerState@value(metalness_map@n_sampler),
 												  inPs.uv0.xy * material.detailOffsetScale[@n].zw +
 												  material.detailOffsetScale[@n].xy,
 												  texIndex_detailMetalnessIdx@n ).x;
 		@else
-			half metalness@n = _h( 0 );
+			midf metalness@n = _h( 0 );
 		@end
 	@end
 
-	pixelData.specular.xyz = half3_c( 1.0f, 1.0f, 1.0f );
-	half metalness =	(metalness0 * detailWeights.x * half_c( material.metalness.x ) +
-						 metalness1 * detailWeights.y * half_c( material.metalness.y )) +
-						(metalness2 * detailWeights.z * half_c( material.metalness.z ) +
-						 metalness3 * detailWeights.w * half_c( material.metalness.w ));
+	pixelData.specular.xyz = midf3_c( 1.0f, 1.0f, 1.0f );
+	midf metalness =	(metalness0 * detailWeights.x * midf_c( material.metalness.x ) +
+						 metalness1 * detailWeights.y * midf_c( material.metalness.y )) +
+						(metalness2 * detailWeights.z * midf_c( material.metalness.z ) +
+						 metalness3 * detailWeights.w * midf_c( material.metalness.w ));
 
-	pixelData.F0 = lerp( half3_c( 0.03f, 0.03f, 0.03f ), pixelData.diffuse.xyz * _h( 3.14159f ), metalness );
+	pixelData.F0 = lerp( midf3_c( 0.03f, 0.03f, 0.03f ), pixelData.diffuse.xyz * _h( 3.14159f ), metalness );
 	pixelData.diffuse.xyz = pixelData.diffuse.xyz - pixelData.diffuse.xyz * metalness;
 @end
 
@@ -152,20 +152,20 @@
 	/// ROUGHNESS MAP
 	@foreach( 4, n )
 		@property( roughness_map@n )
-			half roughness@n = SampleRoughness@n( textureMaps@value( roughness_map@n_idx ),
+			midf roughness@n = SampleRoughness@n( textureMaps@value( roughness_map@n_idx ),
 												  samplerState@value(roughness_map@n_sampler),
 												  inPs.uv0.xy * material.detailOffsetScale[@n].zw +
 												  material.detailOffsetScale[@n].xy,
 												  texIndex_detailRoughnessIdx@n ).x;
 		@else
-			half roughness@n = _h( 0 );
+			midf roughness@n = _h( 0 );
 		@end
 	@end
 
-	pixelData.perceptualRoughness =	(roughness0 * detailWeights.x * half_c( material.roughness.x ) +
-									 roughness1 * detailWeights.y * half_c( material.roughness.y )) +
-									(roughness2 * detailWeights.z * half_c( material.roughness.z ) +
-									 roughness3 * detailWeights.w * half_c( material.roughness.w ));
+	pixelData.perceptualRoughness =	(roughness0 * detailWeights.x * midf_c( material.roughness.x ) +
+									 roughness1 * detailWeights.y * midf_c( material.roughness.y )) +
+									(roughness2 * detailWeights.z * midf_c( material.roughness.z ) +
+									 roughness3 * detailWeights.w * midf_c( material.roughness.w ));
 	@property( perceptual_roughness )
 		pixelData.roughness = max( pixelData.perceptualRoughness * pixelData.perceptualRoughness, _h( 0.001f ) );
 	@else
@@ -178,15 +178,15 @@
 	// Geometric normal
 	pixelData.geomNormal = OGRE_SampleF16( terrainNormals, samplerStateTerra, inPs.uv0.xy ).xyz * _h( 2.0 ) - _h( 1.0 );
 	@property( z_up )
-		  pixelData.geomNormal.yz = half2_c( -pixelData.geomNormal.z, pixelData.geomNormal.y );
+		  pixelData.geomNormal.yz = midf2_c( -pixelData.geomNormal.z, pixelData.geomNormal.y );
 	@end
-	pixelData.geomNormal = mul( pixelData.geomNormal, toHalf3x3( passBuf.view ) );
+	pixelData.geomNormal = mul( pixelData.geomNormal, toMidf3x3( passBuf.view ) );
 	@property( normal_map )
 		//Get the TBN matrix
-		half3 viewSpaceUnitX	= mul( half3_c( 1, 0, 0 ), toHalf3x3( passBuf.view ) );
-		half3 vTangent			= normalize( cross( pixelData.geomNormal, viewSpaceUnitX ) );
-		half3 vBinormal			= cross( vTangent, pixelData.geomNormal );
-		half3x3 TBN				= buildHalf3x3( vBinormal, vTangent, pixelData.geomNormal );
+		midf3 viewSpaceUnitX	= mul( midf3_c( 1, 0, 0 ), toMidf3x3( passBuf.view ) );
+		midf3 vTangent			= normalize( cross( pixelData.geomNormal, viewSpaceUnitX ) );
+		midf3 vBinormal			= cross( vTangent, pixelData.geomNormal );
+		midf3x3 TBN				= buildMidf3x3( vBinormal, vTangent, pixelData.geomNormal );
 	@end
 @end
 
@@ -284,9 +284,9 @@
 		@insertpiece( custom_ps_preLights )
 
 		@property( !custom_disable_directional_lights )
-			half fTerrainShadow = OGRE_SampleF16( terrainShadows, samplerStateTerra, inPs.uv0.xy ).x;
+			midf fTerrainShadow = OGRE_SampleF16( terrainShadows, samplerStateTerra, inPs.uv0.xy ).x;
 			@property( !(hlms_pssm_splits || (!hlms_pssm_splits && hlms_num_shadow_map_lights && hlms_lights_directional)) )
-				half fShadow = _h( 1.0f );
+				midf fShadow = _h( 1.0f );
 			@end
 			fShadow *= fTerrainShadow;
 
@@ -340,24 +340,24 @@
 					if( vctSpecular.w == 0 )
 					{
 				@end
-						pixelData.envColourS += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
-													  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
-						pixelData.envColourD += lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
-													  half3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
+						pixelData.envColourS += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+													  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
+						pixelData.envColourD += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+													  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
 					@property( vct_num_probes )
 					}
 				@end
 				@else
-					pixelData.envColourS = lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
-												 half3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
-					pixelData.envColourD = lerp( half3_c( passBuf.ambientLowerHemi.xyz ),
-												 half3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
+					pixelData.envColourS = lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+												 midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
+					pixelData.envColourD = lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+												 midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
 				@end
 			@end
 			@property( ambient_fixed && vct_num_probes )
 				//Only use ambient lighting if object is outside any VCT probe
-				finalColour += vctSpecular.w == 0 ? half3_c( 0, 0, 0 ) :
-													(half3_c( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz);
+				finalColour += vctSpecular.w == 0 ? midf3_c( 0, 0, 0 ) :
+													(midf3_c( passBuf.ambientUpperHemi.xyz ) * pixelData.diffuse.xyz);
 			@end
 
 		@property( needs_env_brdf )

--- a/Samples/Media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
+++ b/Samples/Media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
@@ -1,7 +1,7 @@
 @property( !hlms_shadowcaster && terra_enabled )
 
 @piece( custom_VStoPS )
-	half terrainShadow;
+	midf terrainShadow;
 @end
 
 /// Extra per-pass global data we need for applying our
@@ -33,7 +33,7 @@
 									   passBuf.terraOrigin.xz, 0 ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-	outVs.terrainShadow = mix( half_c( terraShadowData.x ), _h( 1.0 ), half_c( saturate( terraHeightWeight ) ) );
+	outVs.terrainShadow = mix( midf_c( terraShadowData.x ), _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
+++ b/Samples/Media/Hlms/Terra/GLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.glsl
@@ -1,7 +1,7 @@
 @property( !hlms_shadowcaster && terra_enabled )
 
 @piece( custom_VStoPS )
-    float terrainShadow;
+	half terrainShadow;
 @end
 
 /// Extra per-pass global data we need for applying our
@@ -33,7 +33,7 @@
 									   passBuf.terraOrigin.xz, 0 ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-    outVs.terrainShadow = mix( terraShadowData.x, 1.0, clamp( terraHeightWeight, 0.0, 1.0 ) );
+	outVs.terrainShadow = mix( half_c( terraShadowData.x ), _h( 1.0 ), half_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/GLSL/PixelShader_ps.glsl
+++ b/Samples/Media/Hlms/Terra/GLSL/PixelShader_ps.glsl
@@ -28,7 +28,7 @@ in block
 @property( !hlms_render_depth_only )
 	@property( !hlms_shadowcaster )
 		@property( !hlms_prepass )
-			layout(location = @counter(rtv_target), index = 0) out vec4 outColour;
+			layout(location = @counter(rtv_target), index = 0) out midf4 outColour;
 		@end
 		@property( hlms_gen_normals_gbuffer )
 			#define outPs_normals outNormals

--- a/Samples/Media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
+++ b/Samples/Media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
@@ -1,7 +1,7 @@
 @property( !hlms_shadowcaster && terra_enabled )
 
 @piece( custom_VStoPS )
-    float terrainShadow : TEXCOORD@counter(texcoord);
+	half terrainShadow : TEXCOORD@counter(texcoord);
 @end
 
 /// Extra per-pass global data we need for applying our
@@ -33,7 +33,7 @@
 								0 ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-    outVs.terrainShadow = lerp( terraShadowData.x, 1.0, saturate( terraHeightWeight ) );
+	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), half_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
+++ b/Samples/Media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
@@ -1,7 +1,7 @@
 @property( !hlms_shadowcaster && terra_enabled )
 
 @piece( custom_VStoPS )
-	half terrainShadow : TEXCOORD@counter(texcoord);
+	midf terrainShadow : TEXCOORD@counter(texcoord);
 @end
 
 /// Extra per-pass global data we need for applying our
@@ -33,7 +33,7 @@
 								0 ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), half_c( saturate( terraHeightWeight ) ) );
+	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
+++ b/Samples/Media/Hlms/Terra/HLSL/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.hlsl
@@ -33,7 +33,7 @@
 								0 ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
+	outVs.terrainShadow = lerp( midf_c( terraShadowData.x ), _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
+++ b/Samples/Media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
@@ -1,7 +1,7 @@
 @property( !hlms_shadowcaster && terra_enabled )
 
 @piece( custom_VStoPS )
-	half terrainShadow;
+	midf terrainShadow;
 @end
 
 /// Extra per-pass global data we need for applying our
@@ -33,7 +33,7 @@
 								level(0) ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), half_c( saturate( terraHeightWeight ) ) );
+	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
+++ b/Samples/Media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
@@ -33,7 +33,7 @@
 								level(0) ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
+	outVs.terrainShadow = lerp( midf_c( terraShadowData.x ), _h( 1.0 ), midf_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
+++ b/Samples/Media/Hlms/Terra/Metal/PbsTerraShadows/PbsTerraShadows_piece_vs_piece_ps.metal
@@ -1,7 +1,7 @@
 @property( !hlms_shadowcaster && terra_enabled )
 
 @piece( custom_VStoPS )
-	float terrainShadow;
+	half terrainShadow;
 @end
 
 /// Extra per-pass global data we need for applying our
@@ -33,7 +33,7 @@
 								level(0) ).xyz;
 	float terraHeightWeight = terraWorldPos.y * passBuf.invTerraBounds.y + passBuf.terraOrigin.y;
     terraHeightWeight = (terraHeightWeight - terraShadowData.y) * terraShadowData.z * 1023.0;
-    outVs.terrainShadow = lerp( terraShadowData.x, 1.0, saturate( terraHeightWeight ) );
+	outVs.terrainShadow = lerp( terraShadowData.x, _h( 1.0 ), half_c( saturate( terraHeightWeight ) ) );
 @end
 
 @property( hlms_lights_directional && hlms_num_shadow_map_lights )

--- a/Samples/Media/Hlms/Terra/Metal/PixelShader_ps.metal
+++ b/Samples/Media/Hlms/Terra/Metal/PixelShader_ps.metal
@@ -75,8 +75,8 @@ fragment @insertpiece( output_type ) main_metal
 	@insertpiece( custom_ps_uniformDeclaration )
 	// END UNIFORM DECLARATION
 
-	, texture2d<float> terrainNormals	[[texture(@value(terrainNormals))]]
-	, texture2d<float> terrainShadows	[[texture(@value(terrainShadows))]]
+	, texture2d<midf> terrainNormals	[[texture(@value(terrainNormals))]]
+	, texture2d<midf> terrainShadows	[[texture(@value(terrainShadows))]]
 	, sampler samplerStateTerra			[[sampler(@value(terrainNormals))]]
 
 	@property( hlms_forwardplus )
@@ -86,11 +86,11 @@ fragment @insertpiece( output_type ) main_metal
 
 	@property( hlms_use_prepass )
 		@property( !hlms_use_prepass_msaa )
-		, texture2d<float, access::read> gBuf_normals			[[texture(@value(gBuf_normals))]]
-		, texture2d<float, access::read> gBuf_shadowRoughness	[[texture(@value(gBuf_shadowRoughness))]]
+		, texture2d<midf, access::read> gBuf_normals			[[texture(@value(gBuf_normals))]]
+		, texture2d<midf, access::read> gBuf_shadowRoughness	[[texture(@value(gBuf_shadowRoughness))]]
 		@end @property( hlms_use_prepass_msaa )
-		, texture2d_ms<float, access::read> gBuf_normals		[[texture(@value(gBuf_normals))]]
-		, texture2d_ms<float, access::read> gBuf_shadowRoughness[[texture(@value(gBuf_shadowRoughness))]]
+		, texture2d_ms<midf, access::read> gBuf_normals		[[texture(@value(gBuf_normals))]]
+		, texture2d_ms<midf, access::read> gBuf_shadowRoughness[[texture(@value(gBuf_shadowRoughness))]]
 		@end
 
 		@property( hlms_use_ssr )
@@ -103,20 +103,20 @@ fragment @insertpiece( output_type ) main_metal
 
 
 	@property( irradiance_volumes )
-		, texture3d<float>	irradianceVolume		[[texture(@value(irradianceVolume))]]
+		, texture3d<midf>	irradianceVolume		[[texture(@value(irradianceVolume))]]
 		, sampler			irradianceVolumeSampler	[[sampler(@value(irradianceVolume))]]
 	@end
 
 	@foreach( num_textures, n )
-		, texture2d_array<float> textureMaps@n [[texture(@value(textureMaps@n))]]@end
+		, texture2d_array<midf> textureMaps@n [[texture(@value(textureMaps@n))]]@end
 	@property( use_envprobe_map )
 		@property( !hlms_enable_cubemaps_auto )
-			, texturecube<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
+			, texturecube<midf>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 		@else
 			@property( !hlms_cubemaps_use_dpm )
-				, texturecube_array<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
+				, texturecube_array<midf>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 			@else
-				, texture2d_array<float>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
+				, texture2d_array<midf>	texEnvProbeMap [[texture(@value(texEnvProbeMap))]]
 			@end
 		@end
 		@property( envMapRegSampler < samplerStateStart )

--- a/Samples/Media/Hlms/Unlit/Any/500.StructsUnlit_piece_all.any
+++ b/Samples/Media/Hlms/Unlit/Any/500.StructsUnlit_piece_all.any
@@ -99,7 +99,7 @@
 			@end
 		@end
 		@property( hlms_colour )
-			INTERPOLANT( float4 colour, @counter(texcoord) );
+			INTERPOLANT( midf4 colour, @counter(texcoord) );
 		@end
 		@foreach( out_uv_half_count, n )
 			INTERPOLANT( float@value( out_uv_half_count@n ) uv@n, @counter(texcoord) );@end

--- a/Samples/Media/Hlms/Unlit/Any/700.BlendModes_piece_ps.any
+++ b/Samples/Media/Hlms/Unlit/Any/700.BlendModes_piece_ps.any
@@ -4,26 +4,26 @@
 @piece( NormalNonPremul )
 	//Normal Non Premultiplied @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz, topImage@value(t).xyz, topImage@value(t).a );
-	diffuseCol.w = lerp( diffuseCol.w, 1.0, topImage@value(t).w );
+	diffuseCol.w = lerp( diffuseCol.w, _h( 1.0 ), topImage@value(t).w );
 @end
 
 @piece( NormalPremul )
 	//Normal Premultiplied @counter(t)
-	diffuseCol.xyz = (1.0 - topImage@value(t).a) * diffuseCol.xyz + topImage@value(t).xyz;
-	diffuseCol.w = lerp( diffuseCol.w, 1.0, topImage@value(t).w );
+	diffuseCol.xyz = (_h( 1.0 ) - topImage@value(t).a) * diffuseCol.xyz + topImage@value(t).xyz;
+	diffuseCol.w = lerp( diffuseCol.w, _h( 1.0 ), topImage@value(t).w );
 @end
 
 @piece( Add )
 	//Add @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   min( diffuseCol.xyz + topImage@value(t).xyz, float3(1.0,1.0,1.0) ),
+						   min( diffuseCol.xyz + topImage@value(t).xyz, midf3_c(1.0,1.0,1.0) ),
 						   topImage@value(t).a );
 @end
 
 @piece( Subtract )
 	//Subtract @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   max( diffuseCol.xyz - topImage@value(t).xyz, float3(0.0,0.0,0.0) ),
+						   max( diffuseCol.xyz - topImage@value(t).xyz, midf3_c(0.0,0.0,0.0) ),
 						   topImage@value(t).a );
 @end
 
@@ -37,21 +37,21 @@
 @piece( Multiply2x )
 	//Multiply2x @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   min( diffuseCol.xyz * topImage@value(t).xyz * 2.0, float3(1.0,1.0,1.0) ),
+						   min( diffuseCol.xyz * topImage@value(t).xyz * _h( 2.0 ), midf3_c(1.0,1.0,1.0) ),
 						   topImage@value(t).a );
 @end
 
 @piece( Screen )
 	//Screen @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   1.0 - (1.0 - diffuseCol.xyz) * (1.0 - topImage@value(t).xyz),
+						   _h( 1.0 ) - (_h( 1.0 ) - diffuseCol.xyz) * (_h( 1.0 ) - topImage@value(t).xyz),
 						   topImage@value(t).a );
 @end
 
 @piece( Overlay )
 	//Overlay @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   diffuseCol.xyz * ( diffuseCol.xyz + 2.0 * topImage@value(t).xyz * (1.0 - diffuseCol.xyz) ),
+						   diffuseCol.xyz * ( diffuseCol.xyz + _h( 2.0 ) * topImage@value(t).xyz * (_h( 1.0 ) - diffuseCol.xyz) ),
 						   topImage@value(t).a );
 @end
 
@@ -72,14 +72,14 @@
 @piece( GrainExtract )
 	//GrainExtract @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   (diffuseCol.xyz - topImage@value(t).xyz) + 0.5f,
+						   (diffuseCol.xyz - topImage@value(t).xyz) + _h( 0.5f ),
 						   topImage@value(t).a );
 @end
 
 @piece( GrainMerge )
 	//GrainMerge @counter(t)
 	diffuseCol.xyz = lerp( diffuseCol.xyz,
-						   (diffuseCol.xyz + topImage@value(t).xyz) - 0.5f,
+						   (diffuseCol.xyz + topImage@value(t).xyz) - _h( 0.5f ),
 						   topImage@value(t).a );
 @end
 

--- a/Samples/Media/Hlms/Unlit/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Unlit/Any/800.PixelShader_piece_ps.any
@@ -5,11 +5,11 @@
 	@foreach( diffuse_map, n )
 		#define DiffuseSampler@n samplerState@value(diffuse_map@n_sampler)
 		@property( diffuse_map@n_array )
-			#define SampleDiffuse@n( tex, sampler, uv, d ) OGRE_SampleArray2D( tex, sampler, uv, d )
+			#define SampleDiffuse@n( tex, sampler, uv, d ) OGRE_SampleArray2DF16( tex, sampler, uv, d )
 			#define DiffuseTexture@n textureMapsArray@value(diffuse_map@n_idx)
 			@piece( diffuseIdx@n ), diffuseIdx@n@end
 		@else
-			#define SampleDiffuse@n( tex, sampler, uv ) OGRE_Sample( tex, sampler, uv )
+			#define SampleDiffuse@n( tex, sampler, uv ) OGRE_SampleF16( tex, sampler, uv )
 			#define DiffuseTexture@n textureMaps@value(diffuse_map@n_idx)
 		@end
 
@@ -54,7 +54,7 @@
 @end
 
 @piece( DefaultBodyPS )
-	float4 diffuseCol = float4( 1.0f, 1.0f, 1.0f, 1.0f );
+	midf4 diffuseCol = midf4_c( 1.0f, 1.0f, 1.0f, 1.0f );
 
 	@property( diffuse_map || alpha_test || diffuse )
 		@insertpiece( LoadMaterial )
@@ -86,8 +86,8 @@
 	// Load each additional layer and blend it
 	@foreach( diffuse_map, n, 1 )
 		@property( diffuse_map@n )
-			float4 topImage@n = SampleDiffuse@n( DiffuseTexture@n, DiffuseSampler@n,
-												 DiffuseUV@n @insertpiece( diffuseIdx@n ) ).@insertpiece(diffuse_map@n_tex_swizzle);
+			midf4 topImage@n = SampleDiffuse@n( DiffuseTexture@n, DiffuseSampler@n,
+												DiffuseUV@n @insertpiece( diffuseIdx@n ) ).@insertpiece(diffuse_map@n_tex_swizzle);
 			@insertpiece( blend_mode_idx@n )
 		@end
 	@end
@@ -97,7 +97,7 @@
 		diffuseCol *= inPs.colour;
 	@else
 		@property( diffuse )
-			diffuseCol *= material.diffuse;
+			diffuseCol *= midf4_c( material.diffuse );
 		@end
 	@end
 

--- a/Samples/Media/Hlms/Unlit/Any/800.VertexShader_piece_vs.any
+++ b/Samples/Media/Hlms/Unlit/Any/800.VertexShader_piece_vs.any
@@ -80,7 +80,7 @@
 
 	@property( !hlms_shadowcaster || alpha_test )
 		@property( hlms_colour )
-			outVs.colour = inVs_colour;
+			outVs.colour = midf4_c( inVs_colour );
 			@property( diffuse )
 				@insertpiece( LoadMaterial )
 				@insertpiece( custom_vs_posMaterialLoad )

--- a/Samples/Media/Hlms/Unlit/GLSL/PixelShader_ps.glsl
+++ b/Samples/Media/Hlms/Unlit/GLSL/PixelShader_ps.glsl
@@ -9,9 +9,9 @@ in vec4 gl_FragCoord;
 @end
 
 @property( !hlms_shadowcaster )
-layout(location = FRAG_COLOR, index = 0) out vec4 outColour;
+layout(location = FRAG_COLOR, index = 0) out midf4 outColour;
 @end @property( hlms_shadowcaster )
-layout(location = FRAG_COLOR, index = 0) out float outColour;
+layout(location = FRAG_COLOR, index = 0) out midf outColour;
 @end
 
 // START UNIFORM DECLARATION

--- a/Samples/Media/Hlms/Unlit/Metal/PixelShader_ps.metal
+++ b/Samples/Media/Hlms/Unlit/Metal/PixelShader_ps.metal
@@ -30,9 +30,9 @@ fragment @insertpiece( output_type ) main_metal
 	@property( !hlms_shadowcaster || alpha_test )
 		@foreach( num_textures, n )
 			@property( is_texture@n_array )
-				, texture2d_array<float> textureMapsArray@n [[texture(@value(textureMapsArray@n))]]
+				, texture2d_array<midf> textureMapsArray@n [[texture(@value(textureMapsArray@n))]]
 			@else
-				, texture2d<float> textureMaps@n [[texture(@value(textureMaps@n))]]
+				, texture2d<midf> textureMaps@n [[texture(@value(textureMaps@n))]]
 			@end
 		@end
 	@end

--- a/Scripts/UnitTesting/RunUnitTests.py
+++ b/Scripts/UnitTesting/RunUnitTests.py
@@ -29,7 +29,6 @@ g_unitTests = \
 	['Sample_Postprocessing', 'Sample_Postprocessing.json'],
 	['Sample_Refractions', 'Sample_Refractions.json'],
 	['Sample_SceneFormat', 'Sample_SceneFormat.json'],
-	['Sample_SceneFormat', 'Sample_SceneFormat.json'],
 	['Sample_ScreenSpaceReflections', 'Sample_ScreenSpaceReflections.json'],
 	['Sample_ShadowMapDebugging', 'Sample_ShadowMapDebugging.json'],
 	['Sample_ShadowMapFromCode', 'Sample_ShadowMapFromCode.json'],
@@ -102,9 +101,13 @@ def runUnitTest( exeName, jsonName ):
 	if g_system == 'darwin':
 		shutil.copyfile( './ogreMetal.cfg', os.path.join( exeFullpath + '.app/Contents/Resources', 'ogre.cfg' ) )
 		exeFullpath += '.app/Contents/MacOS/' + exeName
+	elif g_system == 'linux' and g_api == 'd3d11':
+		exeFullpath += '.exe'
 
 	args = [exeFullpath, '--ut_playback=' + jsonFullpath, '--ut_output=' + outputFolder]
 
+	if g_system == 'linux' and g_api == 'd3d11':
+		args = ['wine'] + args[:]
 	#if g_system == 'darwin':
 	#	args = ['open', '-W', '-n', '-a' ] + [args[0]] + ['--args'] + args[1:]
 
@@ -124,6 +127,11 @@ if g_system != 'darwin':
 		shutil.copyfile( './ogreGL.cfg', os.path.join( g_exeFolder, 'ogre.cfg' ) )
 	elif g_api == 'vk':
 		shutil.copyfile( './ogreVk.cfg', os.path.join( g_exeFolder, 'ogre.cfg' ) )
+		# Remove samples that don't work w/ Vulkan
+		g_unitTests[:] = [unitTest for unitTest in g_unitTests \
+			if unitTest[0] != 'Sample_ScreenSpaceReflections' and \
+				unitTest[0] != 'Sample_TutorialUav01_Setup' and \
+				unitTest[0] != 'Sample_TutorialUav02_Setup']
 	else:
 		shutil.copyfile( './ogreD3D11.cfg', os.path.join( g_exeFolder, 'ogre.cfg' ) )
 else:


### PR DESCRIPTION
This PR adds `Hlms::setPrecisionMode` with the following options:

 - `PrecisionFull32`
     - `midf` datatype maps to float (i.e. 32-bit)
     - This setting is always supported
 - `PrecisionMidf16`
     - `midf` datatype maps to float16_t (i.e. forced 16-bit)
     - It forces the driver to produce 16-bit code, even if unoptimal
     - Great for testing quality downgrades caused by 16-bit support
     - This depends on `RSC_SHADER_FLOAT16`
     - If unsupported, we fallback to `PrecisionRelaxed`
     - If unsupported, we then fallback to `PrecisionFull32`
 - `PrecisionRelaxed`
     - `midf` datatype maps to mediump float / min16float
     - The driver is allowed to work in either 16-bit or 32-bit code
     - This depends on `RSC_SHADER_RELAXED_FLOAT`
     - If unsupported, we fallback to `PrecisionMidf16`
     - If unsupported, we then fallback to `PrecisionFull32`

We use the keyword "midf" because "half" is already taken on Metal.

The default is `PrecisionFull32` which always works and ensures no quality problems.

`PrecisionMidf16` & `PrecisionRelaxed` may need more testing but may help with either performance or battery usage in mobile.

`PrecisionRelaxed` is supported by D3D11 however it's force-disabled because of fxc bugs.

Only Vulkan and Metal can currently take advantage of these settings and is likely to stay that way.

Support is very new: I've encountered various bugs (in drivers, in [spirv-reflect](https://github.com/KhronosGroup/SPIRV-Reflect/issues/134), in [fxc](https://twitter.com/matiasgoldberg/status/1485758709473189888), in [RenderDoc](https://github.com/baldurk/renderdoc/issues/2466)) so users are advised to test this option thoroughly before deploying it.

Metal is likely the API with best half 16-bit support at the moment.