### PR TITLE
fixed BT_DEFAULT_SHARED mapping and D3D11 RS

### DIFF
--- a/OgreMain/src/Vao/OgreBufferPacked.cpp
+++ b/OgreMain/src/Vao/OgreBufferPacked.cpp
@@ -149,10 +149,10 @@ namespace Ogre
     void *RESTRICT_ALIAS_RETURN BufferPacked::map( size_t elementStart, size_t elementCount,
                                                    bool bAdvanceFrame )
     {
-        if( mBufferType < BT_DYNAMIC_DEFAULT )
+        if( mBufferType < BT_DEFAULT_SHARED )
         {
             OGRE_EXCEPT( Exception::ERR_INVALID_STATE,
-                         "Only dynamic buffers can be mapped! Use upload instead.",
+                         "Only dynamic or shared buffers can be mapped! Use upload instead.",
                          "BufferPacked::map" );
         }
 
@@ -172,6 +172,7 @@ namespace Ogre
         }
 
 #if OGRE_DEBUG_MODE
+        if( mBufferType != BT_DEFAULT_SHARED )
         {
             uint32 currentFrame = mVaoManager->getFrameCount();
             if( mLastFrameMappedAndAdvanced == currentFrame )

--- a/RenderSystems/Direct3D11/src/Vao/OgreD3D11VaoManager.cpp
+++ b/RenderSystems/Direct3D11/src/Vao/OgreD3D11VaoManager.cpp
@@ -57,19 +57,22 @@ THE SOFTWARE.
 
 namespace Ogre
 {
-    static const char *c_vboTypes[3][3] = { {
+    static const char *c_vboTypes[3][4] = { {
                                                 "VERTEX_IMMUTABLE",
                                                 "VERTEX_DEFAULT",
+                                                "VERTEX_DEFAULT_SHARED",
                                                 "VERTEX_DYNAMIC",
                                             },
                                             {
                                                 "INDEX_IMMUTABLE",
                                                 "INDEX_DEFAULT",
+                                                "INDEX_DEFAULT_SHARED",
                                                 "INDEX_DYNAMIC",
                                             },
                                             {
                                                 "SHADER_IMMUTABLE",
                                                 "SHADER_DEFAULT",
+                                                "SHADER_DEFAULT_SHARED",
                                                 "SHADER_DYNAMIC",
                                             } };
 
@@ -89,6 +92,10 @@ namespace Ogre
         mDefaultPoolSize[VERTEX_BUFFER][BT_DEFAULT] = 32 * 1024 * 1024;
         mDefaultPoolSize[INDEX_BUFFER][BT_DEFAULT] = 16 * 1024 * 1024;
         mDefaultPoolSize[SHADER_BUFFER][BT_DEFAULT] = 16 * 1024 * 1024;
+
+        mDefaultPoolSize[VERTEX_BUFFER][BT_DEFAULT_SHARED] = 32 * 1024 * 1024;
+        mDefaultPoolSize[INDEX_BUFFER][BT_DEFAULT_SHARED] = 16 * 1024 * 1024;
+        mDefaultPoolSize[SHADER_BUFFER][BT_DEFAULT_SHARED] = 16 * 1024 * 1024;
 
         mDefaultPoolSize[VERTEX_BUFFER][BT_DYNAMIC_DEFAULT] = 16 * 1024 * 1024;
         mDefaultPoolSize[INDEX_BUFFER][BT_DYNAMIC_DEFAULT] = 16 * 1024 * 1024;


### PR DESCRIPTION
discovered some issues with new buffer type BT_DEFAULT_SHARED:
1. BufferPacked::map() should take in account new buffer type.
2. Unfortunately D3D11 RS was affected, so I made quick fix.