### PR TITLE
fix alignment warnings from Visual Studio for certain classes

### DIFF
--- a/OgreMain/include/OgreAutoParamDataSource.h
+++ b/OgreMain/include/OgreAutoParamDataSource.h
@@ -55,32 +55,9 @@ namespace Ogre
         matrices when they are requested more than once when the underlying information has
         not altered.
     */
-    class _OgreExport AutoParamDataSource : public OgreAllocatedObj
+    class _OgreExport AutoParamDataSource : public AllocatedObject<AlignAllocPolicy<>>
     {
-    public:
-        void* operator new(size_t size) {
-            void *ptr = nullptr;
-            #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
-            ptr = _aligned_malloc( size, OGRE_SIMD_ALIGNMENT );
-            #else
-            // size must be an integral multiple of alignment
-            size = ( ( size + OGRE_SIMD_ALIGNMENT - 1 ) / OGRE_SIMD_ALIGNMENT ) * OGRE_SIMD_ALIGNMENT;
-            result = aligned_alloc( OGRE_SIMD_ALIGNMENT, size );
-            #endif
-            if (ptr == nullptr)
-            {
-                throw std::bad_alloc();
-            }
-            return ptr;
-        }
-        void operator delete(void* ptr) {
-            #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
-            _aligned_free( ptr );
-            #else
-            free( ptr );
-            #endif
-        }
-      protected:
+       protected:
         const Light &getLight( size_t index ) const;
         OGRE_SIMD_ALIGNED_DECL( mutable Matrix4, mWorldMatrix[256] );
         mutable size_t mWorldMatrixCount;

--- a/OgreMain/include/OgreAutoParamDataSource.h
+++ b/OgreMain/include/OgreAutoParamDataSource.h
@@ -57,7 +57,7 @@ namespace Ogre
     */
     class _OgreExport AutoParamDataSource : public AllocatedObject<AlignAllocPolicy<>>
     {
-       protected:
+	protected:
         const Light &getLight( size_t index ) const;
         OGRE_SIMD_ALIGNED_DECL( mutable Matrix4, mWorldMatrix[256] );
         mutable size_t mWorldMatrixCount;

--- a/OgreMain/include/OgreAutoParamDataSource.h
+++ b/OgreMain/include/OgreAutoParamDataSource.h
@@ -57,7 +57,30 @@ namespace Ogre
     */
     class _OgreExport AutoParamDataSource : public OgreAllocatedObj
     {
-    protected:
+    public:
+        void* operator new(size_t size) {
+            void *ptr = nullptr;
+            #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+            ptr = _aligned_malloc( size, OGRE_SIMD_ALIGNMENT );
+            #else
+            // size must be an integral multiple of alignment
+            size = ( ( size + OGRE_SIMD_ALIGNMENT - 1 ) / OGRE_SIMD_ALIGNMENT ) * OGRE_SIMD_ALIGNMENT;
+            result = aligned_alloc( OGRE_SIMD_ALIGNMENT, size );
+            #endif
+            if (ptr == nullptr)
+            {
+                throw std::bad_alloc();
+            }
+            return ptr;
+        }
+        void operator delete(void* ptr) {
+            #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+            _aligned_free( ptr );
+            #else
+            free( ptr );
+            #endif
+        }
+      protected:
         const Light &getLight( size_t index ) const;
         OGRE_SIMD_ALIGNED_DECL( mutable Matrix4, mWorldMatrix[256] );
         mutable size_t mWorldMatrixCount;

--- a/OgreMain/include/OgreAutoParamDataSource.h
+++ b/OgreMain/include/OgreAutoParamDataSource.h
@@ -57,7 +57,7 @@ namespace Ogre
     */
     class _OgreExport AutoParamDataSource : public AllocatedObject<AlignAllocPolicy<>>
     {
-	protected:
+    protected:
         const Light &getLight( size_t index ) const;
         OGRE_SIMD_ALIGNED_DECL( mutable Matrix4, mWorldMatrix[256] );
         mutable size_t mWorldMatrixCount;

--- a/OgreMain/include/OgreHlms.h
+++ b/OgreMain/include/OgreHlms.h
@@ -80,7 +80,7 @@ namespace Ogre
             that PSOs require additional information, such as HlmsMacroblock. HlmsBlendblock.
             For more information of all that is required, see HlmsPso
     */
-    class _OgreExport Hlms : public OgreAllocatedObj
+    class _OgreExport Hlms : public AllocatedObject<AlignAllocPolicy<>>
     {
     public:
         friend class HlmsDiskCache;

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -231,7 +231,7 @@ namespace Ogre
         dependent on the Camera, which will always call back the SceneManager
         which created it to render the scene.
      */
-    class _OgreExport SceneManager : public OgreAllocatedObj, public IdObject
+    class _OgreExport SceneManager : public AllocatedObject<AlignAllocPolicy<>>, public IdObject
     {
     public:
         /// Default query mask for entities @see SceneQuery


### PR DESCRIPTION
When compiling Ogre in Visual Studio 2022 on Windows, I got warnings like:

```
OgreMain\include\OgreSceneManager.h(718,1): warning C4316: 'Ogre::AutoParamDataSource': object allocated on the heap may not be aligned 16 (compiling source file D:\MoreCode\Ogre\ogre-next-fork\OgreMain\src\OgreDefaultSceneQueries.cpp)

OgreMain\src\OgreRoot.cpp(276,53): warning C4316: 'Ogre::HlmsLowLevel': object allocated on the heap may not be aligned 16

OgreMain\src\OgreSceneManagerEnumerator.cpp(310,78): warning C4316: 'Ogre::DefaultSceneManager': object allocated on the heap may not be aligned 16
```

These changes make the warnings go away.
