### PR TITLE
Fix typos in RenderSystems/

### DIFF
--- a/Components/Overlay/src/OgreFont.cpp
+++ b/Components/Overlay/src/OgreFont.cpp
@@ -97,7 +97,7 @@ namespace Ogre
     //---------------------------------------------------------------------
     Font::~Font()
     {
-        // have to call this here reather than in Resource destructor
+        // have to call this here rather than in Resource destructor
         // since calling virtual methods in base destructors causes crash
         unload();
     }

--- a/OgreMain/include/OgreNode.h
+++ b/OgreMain/include/OgreNode.h
@@ -525,7 +525,7 @@ namespace Ogre
         virtual_l2 void rotate( const Vector3 &axis, const Radian &angle,
                                 TransformSpace relativeTo = TS_LOCAL );
 
-        /** Rotate the node around an aritrary axis using a Quarternion.
+        /** Rotate the node around an arbitrary axis using a Quarternion.
          */
         virtual_l2 void rotate( const Quaternion &q, TransformSpace relativeTo = TS_LOCAL );
 

--- a/OgreMain/include/OgreOldNode.h
+++ b/OgreMain/include/OgreOldNode.h
@@ -489,7 +489,7 @@ namespace Ogre
             virtual void rotate( const Vector3 &axis, const Radian &angle,
                                  TransformSpace relativeTo = TS_LOCAL );
 
-            /** Rotate the OldNode around an aritrary axis using a Quarternion.
+            /** Rotate the OldNode around an arbitrary axis using a Quarternion.
              */
             virtual void rotate( const Quaternion &q, TransformSpace relativeTo = TS_LOCAL );
 

--- a/OgreMain/src/OgreMaterial.cpp
+++ b/OgreMain/src/OgreMaterial.cpp
@@ -72,7 +72,7 @@ namespace Ogre
     Material::~Material()
     {
         removeAllTechniques();
-        // have to call this here reather than in Resource destructor
+        // have to call this here rather than in Resource destructor
         // since calling virtual methods in base destructors causes crash
         unload();
     }

--- a/OgreMain/src/OgreMesh.cpp
+++ b/OgreMain/src/OgreMesh.cpp
@@ -98,7 +98,7 @@ namespace Ogre
         //-----------------------------------------------------------------------
         Mesh::~Mesh()
         {
-            // have to call this here reather than in Resource destructor
+            // have to call this here rather than in Resource destructor
             // since calling virtual methods in base destructors causes crash
             unload();
         }

--- a/OgreMain/src/OgreMesh2.cpp
+++ b/OgreMain/src/OgreMesh2.cpp
@@ -73,7 +73,7 @@ namespace Ogre
     //-----------------------------------------------------------------------
     Mesh::~Mesh()
     {
-        // have to call this here reather than in Resource destructor
+        // have to call this here rather than in Resource destructor
         // since calling virtual methods in base destructors causes crash
         unload();
     }

--- a/OgreMain/src/OgreSkeleton.cpp
+++ b/OgreMain/src/OgreSkeleton.cpp
@@ -70,7 +70,7 @@ namespace Ogre
         //---------------------------------------------------------------------
         Skeleton::~Skeleton()
         {
-            // have to call this here reather than in Resource destructor
+            // have to call this here rather than in Resource destructor
             // since calling virtual methods in base destructors causes crash
             unload();
         }

--- a/RenderSystems/Direct3D11/include/OgreD3D11HardwareOcclusionQuery.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11HardwareOcclusionQuery.h
@@ -39,7 +39,7 @@ namespace Ogre
     // If you use multiple rendering passes you can test only the first pass and all other passes don't
     // have to be rendered if the first pass results has too few pixels visible.
 
-    // Be sure to render all occluder first and whats out so the RenderQue don't switch places on
+    // Be sure to render all occluder first and what's out so the RenderQue don't switch places on
     // the occluding objects and the tested objects because it thinks it's more effective..
 
     /**

--- a/RenderSystems/Direct3D11/include/OgreD3D11Prerequisites.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11Prerequisites.h
@@ -141,7 +141,7 @@ namespace Ogre
     typedef SharedPtr<D3D11HLSLProgram> D3D11HLSLProgramPtr;
 
     //-------------------------------------------
-    // Windows setttings
+    // Windows settings
     //-------------------------------------------
 #if( OGRE_PLATFORM == OGRE_PLATFORM_WIN32 || OGRE_PLATFORM == OGRE_PLATFORM_WINRT ) && \
     !defined( OGRE_STATIC_LIB )

--- a/RenderSystems/Direct3D11/include/OgreD3D11TextureGpuManager.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11TextureGpuManager.h
@@ -75,7 +75,7 @@ namespace Ogre
 
         /** Creates a special D3D11TextureGpuWindow pointer, to be used by Ogre::Window.
             The pointer can be freed by a regular OGRE_DELETE. We do not track this pointer.
-            If caller doesnt' delete it, it will leak.
+            If caller doesn't delete it, it will leak.
         */
         TextureGpu *createTextureGpuWindow( bool fromFlipModeSwapchain, Window *window );
         TextureGpu *createWindowDepthBuffer();

--- a/RenderSystems/Direct3D11/src/OgreD3D11AsyncTextureTicket.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11AsyncTextureTicket.cpp
@@ -339,7 +339,7 @@ namespace Ogre
 
                     LogManager::getSingleton().logMessage(
                         "WARNING: Calling AsyncTextureTicket::queryIsTransferDone too "
-                        "often with innacurate tracking in the same frame this transfer "
+                        "often with inaccurate tracking in the same frame this transfer "
                         "was issued. Switching to accurate tracking. If this is an accident, "
                         "wait until you've rendered a few frames before checking if it's done. "
                         "If this is on purpose, consider calling AsyncTextureTicket::download()"

--- a/RenderSystems/Direct3D11/src/OgreD3D11GpuProgramManager.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11GpuProgramManager.cpp
@@ -43,7 +43,7 @@ namespace Ogre
 
         void throwException()
         {
-            String message = "D3D11 dosn't support assembly shaders. Shader name:" + mName + "\n";
+            String message = "D3D11 doesn't support assembly shaders. Shader name:" + mName + "\n";
             OGRE_EXCEPT( Exception::ERR_RENDERINGAPI_ERROR, message,
                          "D3D11UnsupportedGpuProgram::loadFromSource" );
         }

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderPassDescriptor.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderPassDescriptor.cpp
@@ -94,7 +94,7 @@ namespace Ogre
             {
                 OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
                              "Cannot mix RenderWindow colour texture with depth or stencil buffer "
-                             "that aren't for RenderWindows, or viceversa",
+                             "that aren't for RenderWindows, or vice-versa",
                              "D3D11RenderPassDescriptor::checkRenderWindowStatus" );
             }
 

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -477,7 +477,7 @@ namespace Ogre
         // to GL (which is measured in milliseconds per shader, instead of seconds).
         // There's two possible reasons to disable this hack:
         //  1. Easier debugging. Shader structs like "Material m[256];" get declared
-        //     as "Material m[2];" which cause debuggers to show only 2 entires,
+        //     as "Material m[2];" which cause debuggers to show only 2 entries,
         //     instead of all of them. Some debuggers (like RenderDoc) allow changing
         //     the amount of elements displayed and workaround it; nonetheless
         //     disabling it makes your life easier.

--- a/RenderSystems/Direct3D11/src/Vao/OgreD3D11UavBufferPacked.cpp
+++ b/RenderSystems/Direct3D11/src/Vao/OgreD3D11UavBufferPacked.cpp
@@ -75,7 +75,7 @@ namespace Ogre
         TexBufferPacked *retVal = OGRE_NEW D3D11TexBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, pixelFormat, true, mDevice );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;
@@ -91,7 +91,7 @@ namespace Ogre
         ReadOnlyBufferPacked *retVal = OGRE_NEW D3D11ReadOnlyBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, PFG_NULL, true, mDevice );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;

--- a/RenderSystems/Direct3D11/src/Vao/OgreD3D11VaoManager.cpp
+++ b/RenderSystems/Direct3D11/src/Vao/OgreD3D11VaoManager.cpp
@@ -186,7 +186,7 @@ namespace Ogre
                 assert( mVbos[i][j].empty() );
 
         // 4096u is a sensible default because most Hlms implementations need 16 bytes per
-        // instance in a const buffer. HlmsBufferManager::mapNextConstBuffer purposedly clamps
+        // instance in a const buffer. HlmsBufferManager::mapNextConstBuffer purposely clamps
         // its const buffers to 64kb, so that 64kb / 16 = 4096 and thus it can never exceed
         // 4096 instances.
         // However due to instanced stereo, we need twice that
@@ -808,7 +808,7 @@ namespace Ogre
                 "PERFORMANCE WARNING D3D11: Calling createAsyncTicket when there are "
                 "pending immutable buffers to be created. This will force Ogre to "
                 "create them immediately; which diminish our ability to batch meshes "
-                "toghether & could affect performance during rendering.\n"
+                "together & could affect performance during rendering.\n"
                 "You should call createAsyncTicket after all immutable meshes have "
                 "been loaded to ensure they get batched together. If you're already "
                 "doing this, you can ignore this warning.\n"

--- a/RenderSystems/GL3Plus/include/GLSL/OgreGLSLPreprocessor.h
+++ b/RenderSystems/GL3Plus/include/GLSL/OgreGLSLPreprocessor.h
@@ -51,7 +51,7 @@ namespace Ogre
      *     required. This is crucial if, say, GLSL compiler reports you an error
      *     with a line number.
      * <li>#define: Parametrized and non-parametrized macros. Invoking a macro with
-     *     less arguments than it takes assignes empty values to missing arguments.
+     *     less arguments than it takes assigns empty values to missing arguments.
      * <li>#undef: Forget defined macros
      * <li>#ifdef/#ifndef/#else/#endif: Conditional suppression of parts of code.
      * <li>#if: Supports numeric expression of any complexity, also supports the

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusHardwareOcclusionQuery.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusHardwareOcclusionQuery.h
@@ -49,7 +49,7 @@ namespace Ogre
     // If you use multiple rendering passes you can test only the first pass and all other passes don't
     // have to be rendered if the first pass result has too few pixels visible.
 
-    // Be sure to render all occluder first and whats out so the RenderQue don't switch places on
+    // Be sure to render all occluder first and what's out so the RenderQue don't switch places on
     // the occluding objects and the tested objects because it thinks it's more effective..
 
     /**

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusTextureGpuManager.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusTextureGpuManager.h
@@ -73,12 +73,12 @@ namespace Ogre
 
         /** Creates a special GL3PlusTextureGpuWindow pointer, to be used by Ogre::Window.
             The pointer can be freed by a regular OGRE_DELETE. We do not track this pointer.
-            If caller doesnt' delete it, it will leak.
+            If caller doesn't delete it, it will leak.
         */
         TextureGpu *createTextureGpuWindow( GL3PlusContext *context, Window *window );
 
         /// See EglPBufferWindow. We do not track this pointer.
-        /// If caller doesnt' delete it, it will leak.
+        /// If caller doesn't delete it, it will leak.
         TextureGpu *createTextureGpuHeadlessWindow( GL3PlusContext *context, Window *window );
 
         GLuint getBlankTextureGlName( TextureTypes::TextureTypes textureType ) const;

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLMonolithicProgram.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLMonolithicProgram.cpp
@@ -326,7 +326,7 @@ namespace Ogre
             {
                 // IMPORTANT: If you get a dangling pointer at currentUniform->mConstantDef
                 // (e.g. detected via ASAN) then see GLSLShader::MonolithicCacheStatus
-                // If you loaded -> unloaded -> modifed code -> loaded again
+                // If you loaded -> unloaded -> modified code -> loaded again
                 // then you need to set MCS_INVALIDATE (which is a workaround)
                 //
                 // The Monolithic cache is not from perfect and ideally should be moved

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusAsyncTextureTicket.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusAsyncTextureTicket.cpp
@@ -408,7 +408,7 @@ namespace Ogre
 
                     LogManager::getSingleton().logMessage(
                         "WARNING: Calling AsyncTextureTicket::queryIsTransferDone too "
-                        "often with innacurate tracking in the same frame this transfer "
+                        "often with inaccurate tracking in the same frame this transfer "
                         "was issued. Switching to accurate tracking. If this is an accident, "
                         "wait until you've rendered a few frames before checking if it's done. "
                         "If this is on purpose, consider calling AsyncTextureTicket::download()"

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderPassDescriptor.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderPassDescriptor.cpp
@@ -93,7 +93,7 @@ namespace Ogre
             {
                 OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
                              "Cannot mix RenderWindow colour texture with depth or stencil buffer "
-                             "that aren't for RenderWindows, or viceversa",
+                             "that aren't for RenderWindows, or vice-versa",
                              "GL3PlusRenderPassDescriptor::checkRenderWindowStatus" );
             }
 

--- a/RenderSystems/GL3Plus/src/Vao/OgreGL3PlusUavBufferPacked.cpp
+++ b/RenderSystems/GL3Plus/src/Vao/OgreGL3PlusUavBufferPacked.cpp
@@ -56,7 +56,7 @@ namespace Ogre
         TexBufferPacked *retVal = OGRE_NEW GL3PlusTexBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, pixelFormat );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;
@@ -72,7 +72,7 @@ namespace Ogre
         ReadOnlyBufferPacked *retVal = OGRE_NEW GL3PlusReadOnlyUavBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, PFG_NULL );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;

--- a/RenderSystems/GL3Plus/src/Vao/OgreGL3PlusVaoManager.cpp
+++ b/RenderSystems/GL3Plus/src/Vao/OgreGL3PlusVaoManager.cpp
@@ -173,7 +173,7 @@ namespace Ogre
         mSupportsBaseInstance = _supportsBaseInstance;
 
         // 4096u is a sensible default because most Hlms implementations need 16 bytes per
-        // instance in a const buffer. HlmsBufferManager::mapNextConstBuffer purposedly clamps
+        // instance in a const buffer. HlmsBufferManager::mapNextConstBuffer purposely clamps
         // its const buffers to 64kb, so that 64kb / 16 = 4096 and thus it can never exceed
         // 4096 instances.
         // However due to instanced stereo, we need twice that

--- a/RenderSystems/GL3Plus/src/windowing/gtk/OgreGTKGLSupport.cpp
+++ b/RenderSystems/GL3Plus/src/windowing/gtk/OgreGTKGLSupport.cpp
@@ -195,7 +195,7 @@ void GTKGLSupport::end_context()
 
 void GTKGLSupport::initialiseExtensions()
 {
-    // XXX anythign to actually do here?
+    // XXX anything to actually do here?
 }
 
 bool GTKGLSupport::checkMinGLVersion( const String &v ) const

--- a/RenderSystems/GLES2/include/GLES2/gl2ext.h
+++ b/RenderSystems/GLES2/include/GLES2/gl2ext.h
@@ -19,7 +19,7 @@ extern "C" {
 /* New types shared by several extensions */
 
 #ifndef __gl3_h_
-/* These are defineed with respect to <inttypes.h> in the
+/* These are defined with respect to <inttypes.h> in the
  * Apple extension spec, but they are also used by non-APPLE
  * extensions, and in the Khronos header we use the Khronos
  * portable types in khrplatform.h, which must be defined.

--- a/RenderSystems/GLES2/include/OgreGLES2FBORenderTexture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2FBORenderTexture.h
@@ -114,7 +114,7 @@ namespace Ogre {
         */
         GLuint getTemporaryFBO(size_t i);
         
-        /** Detects all supported fbo's and recreates the tempory fbo */
+        /** Detects all supported fbo's and recreates the temporary fbo */
         void _reload();
         
     private:

--- a/RenderSystems/GLES2/include/OgreGLES2HardwareOcclusionQuery.h
+++ b/RenderSystems/GLES2/include/OgreGLES2HardwareOcclusionQuery.h
@@ -39,7 +39,7 @@ namespace Ogre {
 // If you use multiple rendering passes you can test only the first pass and all other passes don't have to be rendered 
 // if the first pass result has too few pixels visible.
 
-// Be sure to render all occluder first and whats out so the RenderQue don't switch places on 
+// Be sure to render all occluder first and what's out so the RenderQue don't switch places on 
 // the occluding objects and the tested objects because it thinks it's more effective..
 
 class _OgreGLES2Export GLES2HardwareOcclusionQuery : public HardwareOcclusionQuery MANAGED_RESOURCE

--- a/RenderSystems/GLES2/include/OgreGLES2PixelFormat.h
+++ b/RenderSystems/GLES2/include/OgreGLES2PixelFormat.h
@@ -87,7 +87,7 @@ namespace Ogre {
             static PixelFormat getClosestOGREFormat(GLenum fmt, GLenum dataType);
 
             /** Returns the maximum number of Mipmaps that can be generated until we reach
-                the mininum format possible. This does not count the base level.
+                the minimum format possible. This does not count the base level.
                 @param width
                     The width of the area
                 @param height

--- a/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESPreprocessor.h
+++ b/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESPreprocessor.h
@@ -51,7 +51,7 @@ namespace Ogre {
      *     required. This is crucial if, say, GLSL compiler reports you an error
      *     with a line number.
      * <li>#define: Parametrized and non-parametrized macros. Invoking a macro with
-     *     less arguments than it takes assignes empty values to missing arguments.
+     *     less arguments than it takes assigns empty values to missing arguments.
      * <li>#undef: Forget defined macros
      * <li>#ifdef/#ifndef/#else/#endif: Conditional suppression of parts of code.
      * <li>#if: Supports numeric expression of any complexity, also supports the

--- a/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramPipeline.h
+++ b/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESProgramPipeline.h
@@ -37,7 +37,7 @@ namespace Ogre
         programs via the Open GL program pipeline.
 
         Separable programs consist of shader objects which have been
-        individually linked. This allows for invidual shaders in a
+        individually linked. This allows for individual shaders in a
         program pipeline to be swapped without recompiling the program
         object, as would be necessary with monolithic programs. This
         is especially useful in the common case of only entities which

--- a/RenderSystems/GLES2/src/OgreGLES2RenderToVertexBuffer.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2RenderToVertexBuffer.cpp
@@ -277,7 +277,7 @@ namespace v1 {
         //TODO : Implement more?
         default:
             OGRE_EXCEPT(Exception::ERR_RENDERINGAPI_ERROR, 
-                "Unsupported vertex element sematic in render to vertex buffer", 
+                "Unsupported vertex element semantic in render to vertex buffer", 
                 "OgreGLES2RenderToVertexBuffer::getSemanticVaryingName");
         }
     }

--- a/RenderSystems/Metal/include/OgreMetalTextureGpuManager.h
+++ b/RenderSystems/Metal/include/OgreMetalTextureGpuManager.h
@@ -72,7 +72,7 @@ namespace Ogre
 
         /** Creates a special MetalTextureGpuWindow pointer, to be used by Ogre::Window.
             The pointer can be freed by a regular OGRE_DELETE. We do not track this pointer.
-            If caller doesnt' delete it, it will leak.
+            If caller doesn't delete it, it will leak.
         */
         TextureGpu *createTextureGpuWindow( MetalWindow *window );
         TextureGpu *createWindowDepthBuffer();

--- a/RenderSystems/Metal/src/OgreMetalAsyncTextureTicket.mm
+++ b/RenderSystems/Metal/src/OgreMetalAsyncTextureTicket.mm
@@ -251,7 +251,7 @@ namespace Ogre
 
                     LogManager::getSingleton().logMessage(
                         "WARNING: Calling AsyncTextureTicket::queryIsTransferDone too "
-                        "often with innacurate tracking in the same frame this transfer "
+                        "often with inaccurate tracking in the same frame this transfer "
                         "was issued. Switching to accurate tracking. If this is an accident, "
                         "wait until you've rendered a few frames before checking if it's done. "
                         "If this is on purpose, consider calling AsyncTextureTicket::download()"

--- a/RenderSystems/Metal/src/OgreMetalProgram.mm
+++ b/RenderSystems/Metal/src/OgreMetalProgram.mm
@@ -86,7 +86,7 @@ namespace Ogre
         mLibrary = nil;
         mFunction = nil;
 
-        // Have to call this here reather than in Resource destructor
+        // Have to call this here rather than in Resource destructor
         // since calling virtual methods in base destructors causes crash
         if( isLoaded() )
         {
@@ -248,7 +248,7 @@ namespace Ogre
         if( !mFunction )
         {
             mCompiled = false;
-            LogManager::getSingleton().logMessage( "Error retriving entry point '" + mEntryPoint +
+            LogManager::getSingleton().logMessage( "Error retrieving entry point '" + mEntryPoint +
                                                    "' in shader " + mName );
         }
 

--- a/RenderSystems/Metal/src/OgreMetalRenderPassDescriptor.mm
+++ b/RenderSystems/Metal/src/OgreMetalRenderPassDescriptor.mm
@@ -96,7 +96,7 @@ namespace Ogre
             {
                 OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
                              "Cannot mix RenderWindow colour texture with depth or stencil buffer "
-                             "that aren't for RenderWindows, or viceversa",
+                             "that aren't for RenderWindows, or vice-versa",
                              "MetalRenderPassDescriptor::checkRenderWindowStatus" );
             }
         }

--- a/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
+++ b/RenderSystems/Metal/src/OgreMetalRenderSystem.mm
@@ -2557,12 +2557,12 @@ namespace Ogre
             break;
         case GPT_HULL_PROGRAM:
             mActiveTessellationHullGpuProgramParameters = params;
-            OGRE_EXCEPT( Exception::ERR_NOT_IMPLEMENTED, "Tesselation is different in Metal.",
+            OGRE_EXCEPT( Exception::ERR_NOT_IMPLEMENTED, "Tessellation is different in Metal.",
                          "MetalRenderSystem::bindGpuProgramParameters" );
             break;
         case GPT_DOMAIN_PROGRAM:
             mActiveTessellationDomainGpuProgramParameters = params;
-            OGRE_EXCEPT( Exception::ERR_NOT_IMPLEMENTED, "Tesselation is different in Metal.",
+            OGRE_EXCEPT( Exception::ERR_NOT_IMPLEMENTED, "Tessellation is different in Metal.",
                          "MetalRenderSystem::bindGpuProgramParameters" );
             break;
         case GPT_COMPUTE_PROGRAM:

--- a/RenderSystems/Metal/src/Vao/OgreMetalUavBufferPacked.mm
+++ b/RenderSystems/Metal/src/Vao/OgreMetalUavBufferPacked.mm
@@ -61,7 +61,7 @@ namespace Ogre
         TexBufferPacked *retVal = OGRE_NEW MetalTexBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, pixelFormat, mDevice );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;
@@ -76,7 +76,7 @@ namespace Ogre
         ReadOnlyBufferPacked *retVal = OGRE_NEW MetalReadOnlyBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, PFG_NULL, mDevice );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;

--- a/RenderSystems/Metal/src/Vao/OgreMetalVaoManager.mm
+++ b/RenderSystems/Metal/src/Vao/OgreMetalVaoManager.mm
@@ -291,7 +291,7 @@ namespace Ogre
         if( !unalignedCopyFunc )
         {
             OGRE_EXCEPT( Exception::ERR_RENDERINGAPI_ERROR,
-                         "Error retriving entry point from internal 'ogre_gpu_memcpy'",
+                         "Error retrieving entry point from internal 'ogre_gpu_memcpy'",
                          "MetalVaoManager::MetalVaoManager" );
         }
 

--- a/RenderSystems/NULL/src/Vao/OgreNULLUavBufferPacked.cpp
+++ b/RenderSystems/NULL/src/Vao/OgreNULLUavBufferPacked.cpp
@@ -54,7 +54,7 @@ namespace Ogre
         TexBufferPacked *retVal = OGRE_NEW NULLTexBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, pixelFormat );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;
@@ -69,7 +69,7 @@ namespace Ogre
         ReadOnlyBufferPacked *retVal = OGRE_NEW NULLReadOnlyBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VaoManager *)0, bufferInterface, PFG_NULL );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;

--- a/RenderSystems/Vulkan/include/OgreVulkanRootLayout.h
+++ b/RenderSystems/Vulkan/include/OgreVulkanRootLayout.h
@@ -72,7 +72,7 @@ namespace Ogre
 
         /// When mArrayRanges is not empty, there's more emulated slots than bindings slots
         /// So when we're filling descriptors via VkWriteDescriptorSet/vkUpdateDescriptorSets
-        /// we must substracts the amount of slots that belong to arrays
+        /// we must subtracts the amount of slots that belong to arrays
         ///
         /// In other words this variable tracks how many slots have been "taken away" by arrays
         ///

--- a/RenderSystems/Vulkan/include/SPIRV-Reflect/spirv_reflect.h
+++ b/RenderSystems/Vulkan/include/SPIRV-Reflect/spirv_reflect.h
@@ -109,7 +109,7 @@ typedef uint32_t SpvReflectTypeFlags;
 NOTE: HLSL row_major and column_major decorations are reversed
       in SPIR-V. Meaning that matrices declrations with row_major
       will get reflected as column_major and vice versa. The
-      row and column decorations get appied during the compilation.
+      row and column decorations get applied during the compilation.
       SPIRV-Reflect reads the data as is and does not make any
       attempt to correct it to match what's in the source.
 
@@ -428,7 +428,7 @@ typedef struct SpvReflectEntryPoint {
     uint32_t                        z;
   } local_size;
   uint32_t                          invocations; // valid for geometry
-  uint32_t                          output_vertices; // valid for geometry, tesselation
+  uint32_t                          output_vertices; // valid for geometry, tessellation
 } SpvReflectEntryPoint;
 
 /*! @struct SpvReflectShaderModule
@@ -869,7 +869,7 @@ SpvReflectResult spvReflectEnumerateEntryPointPushConstantBlocks(
                          If no match can be found, or if an unrelated error
                          occurs, the return value will be NULL. Detailed
                          error results are written to *pResult.
-@note                    If the module contains multiple desriptor bindings
+@note                    If the module contains multiple descriptor bindings
                          with the same set and binding numbers, there are
                          no guarantees about which binding will be returned.
 
@@ -901,7 +901,7 @@ const SpvReflectDescriptorBinding* spvReflectGetDescriptorBinding(
                          If no match can be found, or if an unrelated error
                          occurs, the return value will be NULL. Detailed
                          error results are written to *pResult.
-@note                    If the entry point contains multiple desriptor bindings
+@note                    If the entry point contains multiple descriptor bindings
                          with the same set and binding numbers, there are
                          no guarantees about which binding will be returned.
 

--- a/RenderSystems/Vulkan/include/Vao/OgreVulkanDynamicBuffer.h
+++ b/RenderSystems/Vulkan/include/Vao/OgreVulkanDynamicBuffer.h
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
 namespace Ogre
 {
-    /** Vulkan maps per pool, thus mapping the same pool twice is a common ocurrence.
+    /** Vulkan maps per pool, thus mapping the same pool twice is a common occurrence.
     @par
         This class takes care of mapping pools just once while allowing
         BufferInterface to map subregions of it as if they were separate

--- a/RenderSystems/Vulkan/include/Vao/OgreVulkanVaoManager.h
+++ b/RenderSystems/Vulkan/include/Vao/OgreVulkanVaoManager.h
@@ -188,7 +188,7 @@ namespace Ogre
         /// Note: mVbos[CPU_INACCESIBLE] may contain some Vbos from memory types which are not
         /// mBestVkMemoryTypeIndex.
         ///
-        /// This can happen if a texture request couldn't be fullfilled but other memory
+        /// This can happen if a texture request couldn't be fulfilled but other memory
         /// types were available. If that's the case, then
         /// Vbo::vkMemoryTypeIdx & mBestVkMemoryTypeIndex[CPU_INACCESIBLE] will be 0
         VboVec mVbos[MAX_VBO_FLAG];

--- a/RenderSystems/Vulkan/src/OgreVulkanAsyncTextureTicket.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanAsyncTextureTicket.cpp
@@ -260,7 +260,7 @@ namespace Ogre
 
                     LogManager::getSingleton().logMessage(
                         "WARNING: Calling AsyncTextureTicket::queryIsTransferDone too "
-                        "often with innacurate tracking in the same frame this transfer "
+                        "often with inaccurate tracking in the same frame this transfer "
                         "was issued. Switching to accurate tracking. If this is an accident, "
                         "wait until you've rendered a few frames before checking if it's done. "
                         "If this is on purpose, consider calling AsyncTextureTicket::download()"

--- a/RenderSystems/Vulkan/src/OgreVulkanProgram.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanProgram.cpp
@@ -146,7 +146,7 @@ namespace Ogre
     //---------------------------------------------------------------------------
     VulkanProgram::~VulkanProgram()
     {
-        // Have to call this here reather than in Resource destructor
+        // Have to call this here rather than in Resource destructor
         // since calling virtual methods in base destructors causes crash
         if( isLoaded() )
         {

--- a/RenderSystems/Vulkan/src/OgreVulkanRenderPassDescriptor.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanRenderPassDescriptor.cpp
@@ -85,7 +85,7 @@ namespace Ogre
             {
                 OGRE_EXCEPT( Exception::ERR_INVALIDPARAMS,
                              "Cannot mix RenderWindow colour texture with depth or stencil buffer "
-                             "that aren't for RenderWindows, or viceversa",
+                             "that aren't for RenderWindows, or vice-versa",
                              "VulkanRenderPassDescriptor::checkRenderWindowStatus" );
             }
         }

--- a/RenderSystems/Vulkan/src/Vao/OgreVulkanUavBufferPacked.cpp
+++ b/RenderSystems/Vulkan/src/Vao/OgreVulkanUavBufferPacked.cpp
@@ -58,7 +58,7 @@ namespace Ogre
         TexBufferPacked *retVal = OGRE_NEW VulkanTexBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VulkanRenderSystem *)0, mVaoManager, bufferInterface, pixelFormat );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;
@@ -74,7 +74,7 @@ namespace Ogre
         ReadOnlyBufferPacked *retVal = OGRE_NEW VulkanReadOnlyBufferPacked(
             mInternalBufferStart * mBytesPerElement, mNumElements, mBytesPerElement, 0, mBufferType,
             (void *)0, false, (VulkanRenderSystem *)0, mVaoManager, bufferInterface, PFG_NULL );
-        // We were overriden by the BufferPacked we just created. Restore this back!
+        // We were overridden by the BufferPacked we just created. Restore this back!
         bufferInterface->_notifyBuffer( this );
 
         return retVal;


### PR DESCRIPTION
Found via `codespell -q 3 -L lod,namd,pevent RenderSystems/`