### PR TITLE
Correct docs of Light::setRectSize

### DIFF
--- a/OgreMain/include/OgreLight.h
+++ b/OgreMain/include/OgreLight.h
@@ -360,8 +360,9 @@ namespace Ogre
         */
         Real getSpotlightNearClipDistance() const { return mSpotNearClip; }
 
-        /** For custom 2D shape and area lights, sets the dimensions of the rectangle, in half size
-        @param halfSize
+        /** For custom 2D shape and area lights, sets the dimensions of the rectangle
+        @param rectSize
+            Dimensions of light area.
         */
         void setRectSize( Vector2 rectSize );
 


### PR DESCRIPTION
By experimental results, Light::setRectSize sets the full size, not the half size, of an area light.