### PR TITLE
Make Frustum::getProjectionParamsAB work with orthographic projection

### DIFF
--- a/OgreMain/include/OgreFrustum.h
+++ b/OgreMain/include/OgreFrustum.h
@@ -214,8 +214,14 @@ namespace Ogre
         virtual const Radian &getFOVy() const;
 
         /// Returns the terms projectionA and projectionB in .x and .y respectively, which can
-        /// be used to reconstruct linear depth from a Z buffer with the following formula:
+        /// be used to reconstruct linear depth from a Z buffer.  If the projection type is PT_PERSPECTIVE,
+		/// use the following formula:
+		/// 
         ///     linearDepth = projectionParams.y / (fDepth - projectionParams.x);
+		///     
+		/// But if the projection type is PT_ORTHOGRAPHIC, use the formula:
+		/// 
+		///     linearDepth = (fDepth - projectionParams.x) / projectionParams.y;
         Vector2 getProjectionParamsAB() const;
 
         /** Sets the position of the near clipping plane.

--- a/OgreMain/include/OgreFrustum.h
+++ b/OgreMain/include/OgreFrustum.h
@@ -215,13 +215,13 @@ namespace Ogre
 
         /// Returns the terms projectionA and projectionB in .x and .y respectively, which can
         /// be used to reconstruct linear depth from a Z buffer.  If the projection type is PT_PERSPECTIVE,
-		/// use the following formula:
-		/// 
+        /// use the following formula:
+        /// 
         ///     linearDepth = projectionParams.y / (fDepth - projectionParams.x);
-		///     
-		/// But if the projection type is PT_ORTHOGRAPHIC, use the formula:
-		/// 
-		///     linearDepth = (fDepth - projectionParams.x) / projectionParams.y;
+        ///     
+        /// But if the projection type is PT_ORTHOGRAPHIC, use the formula:
+        /// 
+        ///     linearDepth = (fDepth - projectionParams.x) / projectionParams.y;
         Vector2 getProjectionParamsAB() const;
 
         /** Sets the position of the near clipping plane.

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -113,15 +113,31 @@ namespace Ogre
         Vector2 retVal;
 
         const RenderSystem *renderSystem = Root::getSingleton().getRenderSystem();
-        if( !renderSystem->isReverseDepth() )
+        if(getProjectionType() == PT_PERSPECTIVE)
         {
-            retVal.x = farPlane / ( farPlane - nearPlane );                   // projectionA
-            retVal.y = ( -farPlane * nearPlane ) / ( farPlane - nearPlane );  // projectionB
+            if( !renderSystem->isReverseDepth() )
+            {
+                retVal.x = farPlane / ( farPlane - nearPlane );                   // projectionA
+                retVal.y = ( -farPlane * nearPlane ) / ( farPlane - nearPlane );  // projectionB
+            }
+            else
+            {
+                retVal.x = -nearPlane / ( farPlane - nearPlane );                // projectionA
+                retVal.y = ( farPlane * nearPlane ) / ( farPlane - nearPlane );  // projectionB
+            }
         }
         else
         {
-            retVal.x = -nearPlane / ( farPlane - nearPlane );                // projectionA
-            retVal.y = ( farPlane * nearPlane ) / ( farPlane - nearPlane );  // projectionB
+            if( !renderSystem->isReverseDepth() )
+            {
+                retVal.x = -nearPlane / ( farPlane - nearPlane );                // projectionA
+                retVal.y = 1.0 / ( farPlane - nearPlane );                       // projectionB
+            }
+            else
+            {
+                retVal.x = farPlane / ( farPlane - nearPlane );                   // projectionA
+                retVal.y = -1.0 / ( farPlane - nearPlane );                       // projectionB
+            }
         }
 
         return retVal;


### PR DESCRIPTION
Frustum::getProjectionParamsAB was assuming a perspective projection.  This change makes it work with orthographic projection too, and documents it accordingly.