### PR TITLE
Cmake changes to fix build issues

### DIFF
--- a/Samples/2.0/ApiUsage/PlanarReflections/CMakeLists.txt
+++ b/Samples/2.0/ApiUsage/PlanarReflections/CMakeLists.txt
@@ -23,6 +23,6 @@ add_recursive( ./ SOURCE_FILES )
 
 ogre_add_executable(Sample_PlanarReflections WIN32 MACOSX_BUNDLE ${SOURCE_FILES} ${SAMPLE_COMMON_RESOURCES})
 
-target_link_libraries(Sample_PlanarReflections ${OGRE_LIBRARIES} ${OGRE_SAMPLES_LIBRARIES} OgrePlanarReflections )
+target_link_libraries(Sample_PlanarReflections ${OGRE_LIBRARIES} ${OGRE_SAMPLES_LIBRARIES} ${OGRE_NEXT}PlanarReflections )
 ogre_config_sample_lib(Sample_PlanarReflections)
 ogre_config_sample_pkg(Sample_PlanarReflections)

--- a/Samples/2.0/Tutorials/Tutorial_Terrain/CMakeLists.txt
+++ b/Samples/2.0/Tutorials/Tutorial_Terrain/CMakeLists.txt
@@ -29,7 +29,7 @@ ogre_add_executable(Sample_Tutorial_Terrain WIN32 MACOSX_BUNDLE ${SOURCE_FILES} 
 
 target_link_libraries(Sample_Tutorial_Terrain ${OGRE_LIBRARIES} ${OGRE_SAMPLES_LIBRARIES} ${OGRE_NEXT}HlmsPbs)
 if( OGRE_BUILD_COMPONENT_PLANAR_REFLECTIONS )
-    target_link_libraries( Sample_Tutorial_Terrain OgrePlanarReflections )
+    target_link_libraries( Sample_Tutorial_Terrain ${OGRE_NEXT}PlanarReflections )
 endif()
 ogre_config_sample_lib(Sample_Tutorial_Terrain)
 ogre_config_sample_pkg(Sample_Tutorial_Terrain)


### PR DESCRIPTION
I tried to build Ogre 2.4 from master and ran into some issues with the CMAKE option "OGRE_USE_NEW_PROJECT_NAME" set to true.

The planar reflections api and terrain tutorial samples try to link against OgrePlanarReflections.lib instead of OgreNextPlanarReflections.lib when the Cmake option "OGRE_USE_NEW_PROJECT_NAME" is true and fail linking.

Related to #259