### PR TITLE
When a SceneManager is destroyed, prevent node array defragmenting

### DIFF
--- a/OgreMain/include/Math/Array/OgreArrayMemoryManager.h
+++ b/OgreMain/include/Math/Array/OgreArrayMemoryManager.h
@@ -229,6 +229,9 @@ namespace Ogre
         /// ArrayMemoryManager::destroySlot already does this when the number
         /// of fragmented slots reaches mCleanupThreshold
         void defragment();
+        
+        ///  Prevent defragmentation from ever happening.
+        void neverDefragment();
 
         /// Defragments memory, then reallocates a smaller pool that tightly fits
         /// the current number of objects. Useful when you know you won't be creating

--- a/OgreMain/include/Math/Array/OgreNodeMemoryManager.h
+++ b/OgreMain/include/Math/Array/OgreNodeMemoryManager.h
@@ -190,6 +190,9 @@ namespace Ogre
 
         /// @copydoc ArrayMemoryManager::defragment
         void defragment();
+        
+        /// @copydoc ArrayMemoryManager::neverDefragment
+        void neverDefragment();
 
         /// @copydoc ArrayMemoryManager::shrinkToFit
         void shrinkToFit();

--- a/OgreMain/src/Math/Array/OgreArrayMemoryManager.cpp
+++ b/OgreMain/src/Math/Array/OgreArrayMemoryManager.cpp
@@ -250,6 +250,11 @@ namespace Ogre
         }
     }
     //-----------------------------------------------------------------------------------
+    void ArrayMemoryManager::neverDefragment()
+    {
+        mCleanupThreshold = std::numeric_limits<size_t>::max();
+    }
+    //-----------------------------------------------------------------------------------
     void ArrayMemoryManager::defragment()
     {
         // Sort, last values first. This may improve performance in some

--- a/OgreMain/src/Math/Array/OgreNodeMemoryManager.cpp
+++ b/OgreMain/src/Math/Array/OgreNodeMemoryManager.cpp
@@ -182,6 +182,18 @@ namespace Ogre
         }
     }
     //-----------------------------------------------------------------------------------
+    void NodeMemoryManager::neverDefragment()
+    {
+        ArrayMemoryManagerVec::iterator itor = mMemoryManagers.begin();
+        ArrayMemoryManagerVec::iterator endt = mMemoryManagers.end();
+
+        while( itor != endt )
+        {
+            itor->neverDefragment();
+            ++itor;
+        }
+    }
+    //-----------------------------------------------------------------------------------
     void NodeMemoryManager::shrinkToFit()
     {
         ArrayMemoryManagerVec::iterator itor = mMemoryManagers.begin();

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -246,6 +246,10 @@ namespace Ogre
         mRadialDensityMask = 0;
 
         fireSceneManagerDestroyed();
+        for( size_t i = 0; i < NUM_SCENE_MEMORY_MANAGER_TYPES; ++i )
+        {
+            mNodeMemoryManager[i].neverDefragment();
+        }
         clearScene( true, false );
         destroyAllCameras();
 


### PR DESCRIPTION
This prevents a delay when a SceneManager is destroyed, caused by array memory managers defragmenting.