### PR TITLE
Fix doc format errors in unordered lists

### DIFF
--- a/Components/Hlms/Pbs/include/OgreHlmsPbs.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbs.h
@@ -331,9 +331,9 @@ namespace Ogre
 
             Performance: Whether this setting results in higher or lower performance depends on:
 
-                1. Vertex count of the scene (high vertex count benefit from bInPixelShader = true)
-                2. Screen resolution (large resolutions benefit from bInPixelShader = false)
-                3. Number of shadow mapping lights (large numbers benefit from bInPixelShader = true)
+            1. Vertex count of the scene (high vertex count benefit from bInPixelShader = true)
+            2. Screen resolution (large resolutions benefit from bInPixelShader = false)
+            3. Number of shadow mapping lights (large numbers benefit from bInPixelShader = true)
 
             You will have to profile which setting gives you better performance, although
             generally speaking for low number of lights (e.g. < 5)

--- a/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
@@ -259,104 +259,104 @@ namespace Ogre
     public:
         /** Valid parameters in params:
         @param params
-            * fresnel <value [g, b]>
-                The IOR. @see setIndexOfRefraction
+            + fresnel <value [g, b]>
+                The IOR. See setIndexOfRefraction()
                 When specifying three values, the fresnel is separate for each
                 colour component
 
-            * fresnel_coeff <value [g, b]>
+            + fresnel_coeff <value [g, b]>
                 Directly sets the fresnel values, instead of using IORs
                 "F0" in most books about PBS
 
-            * roughness <value>
+            + roughness \<value>
                 Specifies the roughness value. Should be in range (0; inf)
                 Note: Values extremely close to zero could cause NaNs and
                 INFs in the pixel shader, also depends on the GPU's precision.
 
-            * background_diffuse <r g b a>
+            + background_diffuse <r g b a>
                 Specifies diffuse colour to use as a background when diffuse texture are not present.
                 Does not replace 'diffuse <r g b>'
                 Default: background_diffuse 1 1 1 1
 
-            * diffuse <r g b>
+            + diffuse <r g b>
                 Specifies the RGB diffuse colour. "kD" in most books about PBS
                 Default: diffuse 1 1 1 1
                 Note: Internally the diffuse colour is divided by PI.
 
-            * diffuse_map <texture name>
+            + diffuse_map <texture name>
                 Name of the diffuse texture for the base image (optional)
 
-            * diffuse_map_grayscale <true, false>
+            + diffuse_map_grayscale <true, false>
                 When set to true diffuse map would be sampled with .rrra swizzle
                 Default: false
 
-            * specular <r g b>
+            + specular <r g b>
                 Specifies the RGB specular colour. "kS" in most books about PBS
                 Default: specular 1 1 1 1
 
-            * specular_map <texture name>
+            + specular_map <texture name>
                 Name of the specular texture for the base image (optional).
 
-            * roughness_map <texture name>
+            + roughness_map <texture name>
                 Name of the roughness texture for the base image (optional)
                 Note: Only the Red channel will be used, and the texture will be converted to
                 an efficient monochrome representation.
 
-            * normal_map <texture name>
+            + normal_map <texture name>
                 Name of the normal texture for the base image (optional) for normal mapping
 
-            * detail_weight_map <texture name>
+            + detail_weight_map <texture name>
                 Texture that when present, will be used as mask/weight for the 4 detail maps.
                 The R channel is used for detail map #0; the G for detail map #1, B for #2,
                 and Alpha for #3.
                 This affects both the diffuse and normal-mapped detail maps.
 
-            * detail_map0 <texture name>
+            + detail_map0 <texture name>
               Similar: detail_map1, detail_map2, detail_map3
                 Name of the detail map to be used on top of the diffuse colour.
                 There can be gaps (i.e. set detail maps 0 and 2 but not 1)
 
-            * detail_blend_mode0 <blend_mode>
+            + detail_blend_mode0 <blend_mode>
               Similar: detail_blend_mode1, detail_blend_mode2, detail_blend_mode3
                 Blend mode to use for each detail map. Valid values are:
                     "NormalNonPremul", "NormalPremul", "Add", "Subtract", "Multiply",
                     "Multiply2x", "Screen", "Overlay", "Lighten", "Darken",
                     "GrainExtract", "GrainMerge", "Difference"
 
-            * detail_offset_scale0 <offset_u> <offset_v> <scale_u> <scale_v>
+            + detail_offset_scale0 <offset_u> <offset_v> <scale_u> <scale_v>
               Similar: detail_offset_scale1, detail_offset_scale2, detail_offset_scale3
                 Sets the UV offset and scale of the detail maps.
 
-            * detail_normal_map0 <texture name>
+            + detail_normal_map0 <texture name>
               Similar: detail_normal_map1, detail_normal_map2, detail_normal_map3
                 Name of the detail map's normal map to be used.
                 It's not affected by blend mode. May be used even if
                 there is no detail_map
 
-            * detail_normal_offset_scale0 <offset_u> <offset_v> <scale_u> <scale_v>
+            + detail_normal_offset_scale0 <offset_u> <offset_v> <scale_u> <scale_v>
               Similar: detail_normal_offset_scale1, detail_normal_offset_scale2,
                        detail_normal_offset_scale3
                 Sets the UV offset and scale of the detail normal maps.
 
-            * reflection_map <texture name>
+            + reflection_map <texture name>
                 Name of the reflection map. Must be a cubemap. Doesn't use an UV set because
                 the tex. coords are automatically calculated.
 
-            * uv_diffuse_map <uv>
+            + uv_diffuse_map <uv>
               Similar: uv_specular_map, uv_normal_map, uv_detail_mapN, uv_detail_normal_mapN,
                        uv_detail_weight_map
               where N is a number between 0 and 3.
                 UV set to use for the particular texture map.
                 The UV value must be in range [0; 8)
 
-            * transparency <value>
+            + transparency \<value>
               Specifies the transparency amount. Value in range [0; 1]
               where 0 = full transparency and 1 = fully opaque.
 
-            * transparency_mode <transparent, none, fade>
+            + transparency_mode <transparent, none, fade>
               Specifies the transparency mode. @see TransparencyModes
 
-            * alpha_from_textures <true, false>
+            + alpha_from_textures <true, false>
               When set to false transparency calculations ignore the alpha channel in
               the textures
         */
@@ -669,33 +669,33 @@ namespace Ogre
             the manual mode of operation.
         @par
             Manual Advantages:
-                * It's independent of camera position.
-                * The reflections are always visible and working on the object.
-                * Works best for static objects
-                * Also works well on dynamic objects that you can guarantee are going
+                + It's independent of camera position.
+                + The reflections are always visible and working on the object.
+                + Works best for static objects
+                + Also works well on dynamic objects that you can guarantee are going
                   to be constrained to the probe's area.
             Manual Disadvantages:
-                * Needs to be manually applied on the material by the user.
-                * Can produce harsh lighting/reflection seams when two objects affected
+                + Needs to be manually applied on the material by the user.
+                + Can produce harsh lighting/reflection seams when two objects affected
                   by different probes are close together.
-                * Sucks for dynamic objects.
+                + Sucks for dynamic objects.
 
             To use manual probes just call:
                 datablock->setCubemapProbe( probe );
         @par
             Auto Advantages:
-                * Smoothly blends between probes, making smooth transitions
-                * Avoids seams.
-                * No need to change anything on the material or the object,
+                + Smoothly blends between probes, making smooth transitions
+                + Avoids seams.
+                + No need to change anything on the material or the object,
                   you don't need to do anything.
-                * Works best for dynamic objects (eg. characters)
-                * Also works well on static objects if the camera is inside rooms/corridors, thus
+                + Works best for dynamic objects (eg. characters)
+                + Also works well on static objects if the camera is inside rooms/corridors, thus
                   blocking the view from distant rooms that aren't receiving reflections.
             Auto Disadvantages:
-                * Objects that are further away won't have reflections as
+                + Objects that are further away won't have reflections as
                   only one probe can be active.
-                * It depends on the camera's position.
-                * Doesn't work well if the user can see many distant objects at once, as they
+                + It depends on the camera's position.
+                + Doesn't work well if the user can see many distant objects at once, as they
                   won't have reflections until you get close.
 
             To use Auto you don't need to do anything. Just enable PCC:

--- a/Components/Hlms/Pbs/include/Vct/OgreVctLighting.h
+++ b/Components/Hlms/Pbs/include/Vct/OgreVctLighting.h
@@ -318,8 +318,8 @@ namespace Ogre
             Normally regular mipmaps of 3D textures increase memory consumption by 1/7
             Anisotropic mipmaps of 3D textures increase memory consumption by 6/7
 
-             * Isotropic 256x256x256 RGBA8_UNORM = 256x256x256x4 * (1+1/7) = 64 MB * 1.143 =  73.14MB
-             * Anisotrop 256x256x256 RGBA8_UNORM = 256x256x256x4 * (1+6/7) = 64 MB * 1.857 = 118.85MB
+             + Isotropic 256x256x256 RGBA8_UNORM = 256x256x256x4 * (1+1/7) = 64 MB * 1.143 =  73.14MB
+             + Anisotrop 256x256x256 RGBA8_UNORM = 256x256x256x4 * (1+6/7) = 64 MB * 1.857 = 118.85MB
 
         @remarks
             After changing this setting, VctLighting::update

--- a/Components/Hlms/Unlit/include/OgreHlmsUnlitDatablock.h
+++ b/Components/Hlms/Unlit/include/OgreHlmsUnlitDatablock.h
@@ -87,13 +87,13 @@ namespace Ogre
     public:
         /** Valid parameters in params:
         @param params
-            * diffuse [r g b [a]]
+            + diffuse [r g b [a]]
                 If absent, the values of mR, mG, mB & mA will be ignored by the pixel shader.
                 When present, the rgba values can be specified.
                 Default: Absent
                 Default (when present): diffuse 1 1 1 1
 
-            * diffuse_map [texture name] [#uv]
+            + diffuse_map [texture name] [#uv]
                 Name of the diffuse texture for the base image (optional, otherwise a dummy is set)
                 The #uv parameter is optional, and specifies the texcoord set that will
                 be used. Valid range is [0; 8)
@@ -101,7 +101,7 @@ namespace Ogre
 
                 Note: The UV set is evaluated when creating the Renderable cache.
 
-            * diffuse_map1 [texture name] [blendmode] [#uv]
+            + diffuse_map1 [texture name] [blendmode] [#uv]
                 Name of the diffuse texture that will be layered on top of the base image.
                 The #uv parameter is optional. Valid range is [0; 8)
                 The blendmode parameter is optional. Valid values are:
@@ -114,19 +114,19 @@ namespace Ogre
                 Default uv:             0
                 Example: diffuse_map1 myTexture.png Add 3
 
-             * diffuse_map2 through diffuse_map16
+			+ diffuse_map2 through diffuse_map16
                 Same as diffuse_map1 but for subsequent layers to be applied on top of the previous
                 images. You can't leave gaps (i.e. specify diffuse_map0 & diffuse_map2 but not
                 diffuse_map1).
                 Note that not all mobile HW supports 16 textures at the same time, thus we will
                 just cut/ignore the extra textures that won't fit (we log a warning though).
 
-             * animate <#tex_unit> [<#tex_unit> <#tex_unit> ... <#tex_unit>]
+			+ animate <#tex_unit> [<#tex_unit> <#tex_unit> ... <#tex_unit>]
                 Enables texture animation through a 4x4 matrix for the specified textures.
                 Default: All texture animation/manipulation disabled.
                 Example: animate 0 1 2 3 4 14 15
 
-             * alpha_test [compare_func] [threshold]
+			+ alpha_test [compare_func] [threshold]
                 When present, mAlphaTestThreshold is used.
                 compare_func is optional. Valid values are:
                     less, less_equal, equal, greater, greater_equal, not_equal

--- a/Components/SceneFormat/include/OgreSceneFormatImporter.h
+++ b/Components/SceneFormat/include/OgreSceneFormatImporter.h
@@ -201,9 +201,9 @@ namespace Ogre
             Combination of SceneFlags::SceneFlags, to know what to export and what to exclude.
             Defaults to importing everything.
             Note that some combinations can cause issues:
-                * Excluding scene nodes
-                * Excluding meshes without excluding Items and Entities.
-                * etc
+                + Excluding scene nodes
+                + Excluding meshes without excluding Items and Entities.
+                + etc
 
             By default LightsVpl is not set so that InstantRadiosity is regenerated.
             By setting LightsVpl and unsetting SceneFlags::BuildInstantRadiosity, you can speed up

--- a/OgreMain/include/Compositor/OgreCompositorManager2.h
+++ b/OgreMain/include/Compositor/OgreCompositorManager2.h
@@ -68,15 +68,16 @@ namespace Ogre
         The CompositorManager2 works by defining definitions which tell how the instance will
         behave.
         The top down view is the following:
-            * Workspace
-                * Node
-                    * Target
-                        * PASS_SCENE
-                        * PASS_QUAD
-                        * PASS_CLEAR
-                        * PASS_STENCIL
-                        * PASS_RESOLVE
-                * Shadow Node
+            + Workspace
+                + Node
+                    + Target
+                        + PASS_SCENE
+                        + PASS_QUAD
+                        + PASS_CLEAR
+                        + PASS_STENCIL
+                        + PASS_RESOLVE
+                + Shadow Node
+                
         A Node definition must be created first. Inside the Node Def. different passes can be defined
         including which targets they should render to.
         Once the definitions are set, a workspace instance must be created using addWorkspace
@@ -90,12 +91,12 @@ namespace Ogre
     @par
         A node has inputs (textures), local textures, and outputs. It can also directly global textures
         that are defined in a workspace definition. There a few basic rules:
-            * Global Textures use the "global_" prefix. For example "global_myRT" is a global texture.
+            + Global Textures use the "global_" prefix. For example "global_myRT" is a global texture.
               Trying to create a Local texture with that name will throw.
-            * Global Textures can't be used as node input nor output.
-            * Textures that came as Input can be used as Output.
-            * A node may have no Input nor Output.
-            * Shadow Nodes can't have input, but can have output to be used with other nodes.
+            + Global Textures can't be used as node input nor output.
+            + Textures that came as Input can be used as Output.
+            + A node may have no Input nor Output.
+            + Shadow Nodes can't have input, but can have output to be used with other nodes.
     @par
         Shadow Nodes are particular case of Nodes which are used for rendering shadow maps, and can
         only be references from a PASS_SCENE object; and will be executed when that pass is.

--- a/OgreMain/include/Compositor/OgreTextureDefinition.h
+++ b/OgreMain/include/Compositor/OgreTextureDefinition.h
@@ -268,9 +268,9 @@ namespace Ogre
 
         /** WARNING: Be very careful with this function.
             Removes a texture.
-            * If the texture is from an input channel (TEXTURE_INPUT),
+            + If the texture is from an input channel (TEXTURE_INPUT),
               the input channel is removed.
-            * If the texture is a local definition (TEXTURE_LOCAL) the texture definition
+            + If the texture is a local definition (TEXTURE_LOCAL) the texture definition
               is removed and all the references to mLocalTextureDefs[i+1] ...
               mLocalTextureDefs[i+n] are updated.
               However, the output channels will now contain an invalid index and will
@@ -278,7 +278,7 @@ namespace Ogre
               the order). It is your responsability to call
               CompositorNodeDef::mapOutputChannel again with a valid texture name to
               the channel it was occupying.
-            * If the texture is a global texture (TEXTURE_GLOBAL), the global texture
+            + If the texture is a global texture (TEXTURE_GLOBAL), the global texture
               can no longer be accessed until
               addTextureSourceName( name, 0, TEXTURE_GLOBAL ) is called again.
         @param name
@@ -566,8 +566,9 @@ namespace Ogre
 
         /** If the texture comes from an input channel, we don't have yet enough information,
             as we're missing:
-                * Whether the texture is colour or depth
-                * The default depth settings (prefersDepthTexture, depth format, etc)
+                + Whether the texture is colour or depth
+                + The default depth settings (prefersDepthTexture, depth format, etc)
+                
             Use this function to force the given texture to be analyzed at runtime when
             creating the pass.
         @remarks

--- a/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
+++ b/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
@@ -73,15 +73,16 @@ namespace Ogre
     class CompositorTargetDef;
 
     /** Interface to abstract all types of pass definitions (see CompositorPassType):
-            * PASS_SCENE (see CompositorPassSceneDef)
-            * PASS_QUAD (see CompositorPassQuadDef)
-            * PASS_CLEAR (see CompositorPassClearDef)
-            * PASS_STENCIL (see CompositorPassStencilDef)
-            * PASS_DEPTHCOPY (see CompositorPassDepthCopy)
-            * PASS_UAV (see CompositorPassUavDef)
-            * PASS_COMPUTE (see CompositorPassComputeDef)
-            * PASS_SHADOWS (see CompositorPassShadowsDef)
-            * PASS_MIPMAP (see CompositorPassMipmapDef)
+            + PASS_SCENE (see CompositorPassSceneDef)
+            + PASS_QUAD (see CompositorPassQuadDef)
+            + PASS_CLEAR (see CompositorPassClearDef)
+            + PASS_STENCIL (see CompositorPassStencilDef)
+            + PASS_DEPTHCOPY (see CompositorPassDepthCopy)
+            + PASS_UAV (see CompositorPassUavDef)
+            + PASS_COMPUTE (see CompositorPassComputeDef)
+            + PASS_SHADOWS (see CompositorPassShadowsDef)
+            + PASS_MIPMAP (see CompositorPassMipmapDef)
+            
         This class doesn't do much on its own. See the derived types for more information
         A definition is shared by all pass instantiations (i.e. Five CompositorPassScene can
         share the same CompositorPassSceneDef) and are assumed to remain const throughout

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayAabb.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayAabb.h
@@ -55,10 +55,10 @@ namespace Ogre
             this version stores the box in the form "center + halfSize"
             instead of the form "minimum, maximum" that is present in
             AxisAlignedBox:
-                * Merging is slightly more expensive
-                * intersects() is much cheaper
-                * Naturally deals with infinite boxes (no need for branches)
-                * Transform is cheaper (a common operation)
+                + Merging is slightly more expensive
+                + intersects() is much cheaper
+                + Naturally deals with infinite boxes (no need for branches)
+                + Transform is cheaper (a common operation)
         @par
             Extracting one aabb needs 84 bytes, while all 4 aabbs
             need 96 bytes, both cases are always two cache lines.

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayAabb.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayAabb.h
@@ -55,10 +55,10 @@ namespace Ogre
             this version stores the box in the form "center + halfSize"
             instead of the form "minimum, maximum" that is present in
             AxisAlignedBox:
-                * Merging is slightly more expensive
-                * intersects() is much cheaper
-                * Naturally deals with infinite boxes (no need for branches)
-                * Transform is cheaper (a common operation)
+                + Merging is slightly more expensive
+                + intersects() is much cheaper
+                + Naturally deals with infinite boxes (no need for branches)
+                + Transform is cheaper (a common operation)
         @par
             Extracting one aabb needs 84 bytes, while all 4 aabbs
             need 96 bytes, both cases are always two cache lines.

--- a/OgreMain/include/Math/Simple/C/OgreAabb.h
+++ b/OgreMain/include/Math/Simple/C/OgreAabb.h
@@ -50,10 +50,10 @@ namespace Ogre
             this version stores the box in the form "center + halfSize"
             instead of the form "minimum, maximum" that is present in
             AxisAlignedBox:
-                * Merging is slightly more expensive
-                * intersects() is much cheaper
-                * Naturally deals with infinite boxes (no need for branches)
-                * Transform is cheaper (a common operation)
+                + Merging is slightly more expensive
+                + intersects() is much cheaper
+                + Naturally deals with infinite boxes (no need for branches)
+                + Transform is cheaper (a common operation)
         @par
         This class represents a simple box which is aligned with the
         axes. Internally it only stores 2 points as the center of
@@ -62,12 +62,12 @@ namespace Ogre
         collision and visibility determination.
         @par
         Main differences with AxisAlignedBox:
-            * Aabb doesn't support null boxes as AxisAlignedBox did. Although
+            + Aabb doesn't support null boxes as AxisAlignedBox did. Although
               if the center iszero and half size is set to negative infinity,
               it may mimic the behavior. Another possibility is to just use NaNs,
               because they would cause false on all tests. However this would
               be horrible slow.
-            * BOX_INFINITE represents a truly infinite box and behaves exactly
+            + BOX_INFINITE represents a truly infinite box and behaves exactly
               the same as an infinite AxisAlignedBox. However, setting the latter
               to infinite still holds information in min & max variables, while
               aabb destroys all information present.

--- a/OgreMain/include/OgreDepthBuffer.h
+++ b/OgreMain/include/OgreDepthBuffer.h
@@ -63,14 +63,14 @@ namespace Ogre
 
         Behavior is consistent across all render systems, if, and only if, the same RSC flags are set
         RSC flags that affect this class are:
-            * RSC_RTT_SEPARATE_DEPTHBUFFER:
+            + RSC_RTT_SEPARATE_DEPTHBUFFER:
                 The RTT can create a custom depth buffer different from the main depth buffer. This
        means, an RTT is able to not share it's depth buffer with the main window if it wants to.
-            * RSC_RTT_MAIN_DEPTHBUFFER_ATTACHABLE:
+            + RSC_RTT_MAIN_DEPTHBUFFER_ATTACHABLE:
                 When RSC_RTT_SEPARATE_DEPTHBUFFER is set, some APIs (ie. OpenGL w/ FBO) don't allow using
                 the main depth buffer for offscreen RTTs. When this flag is set, the depth buffer can be
                 shared between the main window and an RTT.
-            * RSC_RTT_DEPTHBUFFER_RESOLUTION_LESSEQUAL:
+            + RSC_RTT_DEPTHBUFFER_RESOLUTION_LESSEQUAL:
                 When this flag isn't set, the depth buffer can only be shared across RTTs who have the
        EXACT same resolution. When it's set, it can be shared with RTTs as long as they have a resolution
        less or equal than the depth buffer's.

--- a/OgreMain/include/OgreHlmsComputeJob.h
+++ b/OgreMain/include/OgreHlmsComputeJob.h
@@ -170,9 +170,9 @@ namespace Ogre
         /** Sets the number of threads per group. Note the actual value may be
             changed by the shader template using the @pset() function.
             These values are passed to the template as:
-                * threads_per_group_x
-                * threads_per_group_y
-                * threads_per_group_z
+                + threads_per_group_x
+                + threads_per_group_y
+                + threads_per_group_z
         @remarks
             May trigger a recompilation if the value changes, regardless of
             what setInformHlmsOfTextureData says.
@@ -191,9 +191,9 @@ namespace Ogre
         /** Sets the number of groups of threads to dispatch. Note the actual value may be
             changed by the shader template using the @pset() function.
             These values are passed to the template as:
-                * num_thread_groups_x
-                * num_thread_groups_y
-                * num_thread_groups_z
+                + num_thread_groups_x
+                + num_thread_groups_y
+                + num_thread_groups_z
         @remarks
             As an example, it's typical to do:
                 numThreadGroupsX = ceil( threadsPerGroupX / image.width );

--- a/OgreMain/include/OgreHlmsDatablock.h
+++ b/OgreMain/include/OgreHlmsDatablock.h
@@ -137,9 +137,9 @@ namespace Ogre
 
     /** A blend block contains settings that rarely change, and thus are common to many materials.
         The reasons this structure isn't joined with HlmsMacroblock is that:
-            * The D3D11 API makes this distinction (much higher API overhead if we
+            + The D3D11 API makes this distinction (much higher API overhead if we
               change i.e. depth settings) due to D3D11_RASTERIZER_DESC.
-            * This block contains information of whether the material is transparent.
+            + This block contains information of whether the material is transparent.
               Transparent materials are sorted differently than opaque ones.
         Up to 32 different blocks are allowed!
     */
@@ -257,10 +257,11 @@ namespace Ogre
     };
 
     /** An hlms datablock contains individual information about a specific material. It consists of:
-            * A const pointer to an @HlmsMacroblock we do not own and may be shared by other datablocks.
-            * A const pointer to an @HlmsBlendblock we do not own and may be shared by other datablocks.
-            * The original properties from which this datablock was constructed.
-            * This type may be derived to contain additional information.
+            + A const pointer to an HlmsMacroblock we do not own and may be shared by other datablocks.
+            + A const pointer to an HlmsBlendblock we do not own and may be shared by other datablocks.
+            + The original properties from which this datablock was constructed.
+            + This type may be derived to contain additional information.
+                 
         Derived types can cache information present in mOriginalProperties as strings, like diffuse
         colour values, etc.
 

--- a/OgreMain/include/OgreHlmsLowLevel.h
+++ b/OgreMain/include/OgreHlmsLowLevel.h
@@ -50,8 +50,8 @@ namespace Ogre
         The older material system is data-driven (thanks to AutoParamDataSource) compared
         to HLMS where the user needs to write its own implementation in C++ (or modify an
         exisiting one). Old material system is still useful for:
-            * Quick prototyping of shaders
-            * Postprocessing effects.
+            + Quick prototyping of shaders
+            + Postprocessing effects.
         Take in mind that the old system is __slow__ compared to Hlms. So don't use this
         proxy for hundreds or more entities.
     @remarks

--- a/OgreMain/include/OgreLwString.h
+++ b/OgreMain/include/OgreLwString.h
@@ -59,10 +59,10 @@ namespace Ogre
         https://home.comcast.net/~tom_forsyth/blog.wiki.html#[[A%20sprintf%20that%20isn%27t%20as%20ugly]]
 
         The goals are:
-            * No dynamic allocation.
-            * Easier to read and control than sprintf()
-            * Type-safe (in as much as C can ever be type-safe - bloody auto-converts).
-            * Overflow-safe (i.e. it will refuse to scribble, and will assert in debug mode).
+            + No dynamic allocation.
+            + Easier to read and control than sprintf()
+            + Type-safe (in as much as C can ever be type-safe - bloody auto-converts).
+            + Overflow-safe (i.e. it will refuse to scribble, and will assert in debug mode).
 
         LwString needs to be fed a pointer and a maximum length size. The pointer's
         preexisting contents will be preserved. For example:

--- a/OgreMain/include/OgreRawPtr.h
+++ b/OgreMain/include/OgreRawPtr.h
@@ -40,9 +40,10 @@ THE SOFTWARE.
 namespace Ogre
 {
     /** Similar to std::unique_ptr, but:
-            * Uses a custom allocator (OGRE_MALLOC_SIMD)
-            * Pointers must be really unique (RESTRICT_ALIAS modifier is used!)
-            * To access the pointer, use get(); instead of using this container directly
+            + Uses a custom allocator (OGRE_MALLOC_SIMD)
+            + Pointers must be really unique (RESTRICT_ALIAS modifier is used!)
+            + To access the pointer, use get(); instead of using this container directly
+            
         The purpose of this container is to enclose a raw pointer while avoiding breaking
         the rule of 3 when copying.
         When defining the macro "OGRE_RAW_PTR_PROFILE", this container will raise an exception

--- a/OgreMain/include/OgreRenderSystem.h
+++ b/OgreMain/include/OgreRenderSystem.h
@@ -584,11 +584,12 @@ namespace Ogre
         @param
         renderWindowDescriptions Array of structures containing the descriptions of each render window.
         The structure's members are the same as the parameters of _createRenderWindow:
-        * name
-        * width
-        * height
-        * fullScreen
-        * miscParams
+        + name
+        + width
+        + height
+        + fullScreen
+        + miscParams
+		.
         See _createRenderWindow for details about each member.
         @param
         createdWindows This array will hold the created render windows.

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -759,9 +759,9 @@ namespace Ogre
         /** Culls the scene in a high level fashion (i.e. Octree, Portal, etc.) by taking into account
           all registered cameras. Produces a list of culled Entities & SceneNodes that must follow a very
             strict set of rules:
-                * Entities are separated by RenderQueue
-                * Entities sharing the same skeleton need to be adjacent (TODO: Required? dark_sylinc)
-                * SceneNodes must be separated by hierarchy depth and must be contiguous within the same
+                + Entities are separated by RenderQueue
+                + Entities sharing the same skeleton need to be adjacent (TODO: Required? dark_sylinc)
+                + SceneNodes must be separated by hierarchy depth and must be contiguous within the same
                   depth level. (@see mNodeMemoryManagerCulledList)
           @remarks
             The default implementation just returns all nodes in the scene. @see updateAllTransforms

--- a/OgreMain/include/OgreStagingTexture.h
+++ b/OgreMain/include/OgreStagingTexture.h
@@ -72,10 +72,10 @@ namespace Ogre
         in TextureBox::data. If so, that means we have ran out of space.
     @par
         Notably derived classes are:
-            * StagingTextureBufferImpl
-                * GL3PlusStagingTexture
-                * MetalStagingTexture
-            * D3D11StagingTexture
+            + StagingTextureBufferImpl
+                + GL3PlusStagingTexture
+                + MetalStagingTexture
+            + D3D11StagingTexture
     */
     class _OgreExport StagingTexture : public OgreAllocatedObj
     {

--- a/OgreMain/include/OgreTextureGpu.h
+++ b/OgreMain/include/OgreTextureGpu.h
@@ -751,12 +751,12 @@ namespace Ogre
         /** It is threadsafe to call this function from main thread.
             If this returns false, then the following functions are not threadsafe:
             Setters must not be called, and getters may change from a worker thread:
-                * setResolution
-                * getWidth, getHeight, getDepth, getDepthOrSlices, getNumSlices
-                * set/getPixelFormat
-                * set/getNumMipmaps
-                * set/getTextureType
-                * getTexturePool
+                + setResolution
+                + getWidth, getHeight, getDepth, getDepthOrSlices, getNumSlices
+                + set/getPixelFormat
+                + set/getNumMipmaps
+                + set/getTextureType
+                + getTexturePool
             Note that this function may return true but the worker thread
             may still be uploading to this texture. Use isDataReady to
             see if the worker thread is fully done with this texture.

--- a/OgreMain/include/OgreTextureGpuManager.h
+++ b/OgreMain/include/OgreTextureGpuManager.h
@@ -127,13 +127,13 @@ namespace Ogre
 
         TextureGpuManager uses a worker thread to load textures in the background.
         There are several restrictions the implementation needs to account for:
-            * D3D11 does not support persistent mapping. This means we must call unmap
+            + D3D11 does not support persistent mapping. This means we must call unmap
               on a StagingTexture before we can copy it to the final texture.
-            * Calling map/unmap from multiple threads is nearly impossible in OpenGL.
+            + Calling map/unmap from multiple threads is nearly impossible in OpenGL.
               This means map/unmap calls must happen in the main thread.
-            * ResourceGroupManager is not thread-friendly (building with thread
+            + ResourceGroupManager is not thread-friendly (building with thread
               support fills ResourceGroupManager with huge fat mutexes)
-            * Most APIs allow using a simple buffer to store all sorts of staging
+            + Most APIs allow using a simple buffer to store all sorts of staging
               data (regardless of format and resolution), but D3D11 is very inflexible
               about this, requiring StagingTextures to have a 2D resolution (rather
               than being a 1D buffer with just bytes), and must match the same
@@ -686,10 +686,10 @@ namespace Ogre
         /// destroyed.
         size_t getConsumedMemoryByStagingTextures( const StagingTextureVec &stagingTextures ) const;
         /** Checks if we've exceeded our memory budget for available staging textures.
-                * If we haven't, it early outs and returns nullptr.
-                * If we have, we'll start stalling the GPU until we find a StagingTexture that
+                + If we haven't, it early outs and returns nullptr.
+                + If we have, we'll start stalling the GPU until we find a StagingTexture that
                   can fit the requirements, and return that pointer.
-                * If we couldn't find a fit, we start removing StagingTextures until we've
+                + If we couldn't find a fit, we start removing StagingTextures until we've
                   freed enough to stay below the budget; and return a nullptr.
         */
         StagingTexture *checkStagingTextureLimits( uint32 width, uint32 height, uint32 depth,

--- a/OgreMain/include/OgreTextureGpuManagerListener.h
+++ b/OgreMain/include/OgreTextureGpuManagerListener.h
@@ -52,10 +52,10 @@ namespace Ogre
         /** Ogre normally puts Textures into pools (a Type2DArray texture) for efficient rendering
             Note that only textures of the same resolution and format can be put together in
             the same pool. This creates two issues:
-                * Unless it is known in advance, we do not know how large the array should be.
+                + Unless it is known in advance, we do not know how large the array should be.
                   if we create a pool that can hold 64 entries but only 1 texture is actually
                   needed, then we waste a lot of GPU memory.
-                * Large textures, such as 4096x4096 RGBA8 occupy a lot of memory 64MB.
+                + Large textures, such as 4096x4096 RGBA8 occupy a lot of memory 64MB.
                   These pools should not contain a large number of entries. For example
                   creating a pool of 8 entries of these textures means we'd be asking the
                   OS for 512MB of *contiguous* memory. Due to memory fragmentation, such


### PR DESCRIPTION
Fix doc format errors caused by the fact that in a documentation block starting with /**, an asterisk is not recognized as starting an unordered list item.