### PR TITLE
fix doxygen warnings involving @copydoc

### DIFF
--- a/OgreMain/include/Android/OgreAPKFileSystemArchive.h
+++ b/OgreMain/include/Android/OgreAPKFileSystemArchive.h
@@ -59,7 +59,7 @@ namespace Ogre
         /// @copydoc Archive::create
         DataStreamPtr create( const String &filename );
 
-        /// @copydoc Archive::delete
+        /// @copydoc Archive::remove
         void remove( const String &filename );
 
         /// @copydoc Archive::list

--- a/OgreMain/include/Compositor/OgreCompositorNode.h
+++ b/OgreMain/include/Compositor/OgreCompositorNode.h
@@ -315,7 +315,7 @@ namespace Ogre
         /// @copydoc CompositorWorkspace::resetAllNumPassesLeft
         void resetAllNumPassesLeft();
 
-        /// @copydoc CompositorPassDef::getPassNumber
+        /// See CompositorNodeDef::getPassNumber
         size_t getPassNumber( CompositorPass *pass ) const;
 
         /// Returns our parent workspace

--- a/OgreMain/include/Compositor/OgreCompositorShadowNode.h
+++ b/OgreMain/include/Compositor/OgreCompositorShadowNode.h
@@ -335,7 +335,7 @@ namespace Ogre
         /// to call it for every shadow map (otherwise you will trigger a O(N^2) behavior).
         void setStaticShadowMapDirty( size_t shadowMapIdx, bool includeLinked = true );
 
-        /// @copydoc CompositorNode::finalTargetResized
+        /// @copydoc CompositorNode::finalTargetResized01
         void finalTargetResized01( const TextureGpu *finalTarget ) override;
     };
 

--- a/OgreMain/include/OgreDistanceLodStrategy.h
+++ b/OgreMain/include/OgreDistanceLodStrategy.h
@@ -141,7 +141,7 @@ namespace Ogre
         /** Default constructor. */
         DistanceLodSphereStrategy();
 
-        /// @copydoc DistanceLodStrategy::getSquaredDepth
+        /// @copydoc DistanceLodStrategyBase::getSquaredDepth
         Real getSquaredDepth( const MovableObject *movableObject,
                               const Ogre::Camera  *camera ) const override;
 
@@ -210,7 +210,7 @@ namespace Ogre
         /** Default constructor. */
         DistanceLodBoxStrategy();
 
-        /// @copydoc DistanceLodStrategy::getSquaredDepth
+        /// @copydoc DistanceLodStrategyBase::getSquaredDepth
         Real getSquaredDepth( const MovableObject *movableObject,
                               const Ogre::Camera  *camera ) const override;
 

--- a/OgreMain/include/OgreEntity.h
+++ b/OgreMain/include/OgreEntity.h
@@ -418,9 +418,9 @@ namespace Ogre
             */
             void setPolygonModeOverrideable( bool PolygonModeOverrideable );
 
-            /** @copydoc ShadowCaster::getEdgeList. */
+            /** @copydoc v1::ManualObject::getEdgeList */
             EdgeData *getEdgeList();
-            /** @copydoc ShadowCaster::hasEdgeList. */
+            /** @copydoc v1::ManualObject::hasEdgeList */
             bool hasEdgeList();
 
             /** Internal method for retrieving bone matrix information. */

--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -735,23 +735,15 @@ namespace Ogre
         void setNamedConstant( const String &name, const Vector2 &vec );
         /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const Matrix4& m) */
         void setNamedConstant( const String &name, const Matrix4 &m );
-        /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const Matrix4* m, size_t
-         * numEntries) */
+        /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const Matrix4* m,
+         size_t numEntries) */
         void setNamedConstant( const String &name, const Matrix4 *m, size_t numEntries );
-        /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const float *val, size_t
-         * count) */
         void setNamedConstant( const String &name, const float *val, size_t count );
-        /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const double *val, size_t
-         * count) */
         void setNamedConstant( const String &name, const double *val, size_t count );
         /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const ColourValue&
          * colour) */
         void setNamedConstant( const String &name, const ColourValue &colour );
-        /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const int *val, size_t
-         * count) */
         void setNamedConstant( const String &name, const int *val, size_t count );
-        /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const uint *val, size_t
-         * count) */
         void setNamedConstant( const String &name, const uint *val, size_t count );
         // /** @copydoc GpuProgramParameters::setNamedConstant(const String& name, const bool *val,
         // size_t count) */ void setNamedConstant(const String& name, const bool *val, size_t count);

--- a/OgreMain/include/OgreHardwareBufferManager.h
+++ b/OgreMain/include/OgreHardwareBufferManager.h
@@ -425,7 +425,7 @@ namespace Ogre
                 return mImpl->createIndexBuffer( itype, numIndexes, usage, useShadowBuffer );
             }
 
-            /** @copydoc HardwareBufferManagerInterface::createVertexDeclaration */
+            /** @copydoc HardwareBufferManagerBase::createVertexDeclaration */
             VertexDeclaration *createVertexDeclaration() override
             {
                 return mImpl->createVertexDeclaration();

--- a/OgreMain/include/OgreManualObject.h
+++ b/OgreMain/include/OgreManualObject.h
@@ -461,8 +461,7 @@ namespace Ogre
                 void getRenderOperation( RenderOperation &op, bool casterPass ) override;
                 /** @copydoc Renderable::getWorldTransforms. */
                 void getWorldTransforms( Matrix4 *xform ) const override;
-                /** @copydoc Renderable::getSquaredViewDepth. */
-                Real getSquaredViewDepth( const Ogre::Camera * ) const;
+                 Real getSquaredViewDepth( const Ogre::Camera * ) const;
                 /** @copydoc Renderable::getLights. */
                 const LightList &getLights() const override;
             };

--- a/OgreMain/include/OgreManualObject.h
+++ b/OgreMain/include/OgreManualObject.h
@@ -461,7 +461,7 @@ namespace Ogre
                 void getRenderOperation( RenderOperation &op, bool casterPass ) override;
                 /** @copydoc Renderable::getWorldTransforms. */
                 void getWorldTransforms( Matrix4 *xform ) const override;
-                 Real getSquaredViewDepth( const Ogre::Camera * ) const;
+                Real getSquaredViewDepth( const Ogre::Camera * ) const;
                 /** @copydoc Renderable::getLights. */
                 const LightList &getLights() const override;
             };

--- a/OgreMain/include/OgreMesh.h
+++ b/OgreMain/include/OgreMesh.h
@@ -724,7 +724,7 @@ namespace Ogre
             void mergeAdjacentTexcoords( unsigned short finalTexCoordSet,
                                          unsigned short texCoordSetToDestroy );
 
-            /// @copydoc Mesh::msOptimizeForShadowMapping
+            /// @copydoc Ogre::Mesh::msOptimizeForShadowMapping
             static bool msOptimizeForShadowMapping;
 
             void prepareForShadowMapping( bool forceSameBuffers );

--- a/OgreMain/include/OgreParticleSystem.h
+++ b/OgreMain/include/OgreParticleSystem.h
@@ -538,7 +538,7 @@ namespace Ogre
 
         /** @copydoc MovableObject::setRenderQueueGroup */
         void setRenderQueueGroup( uint8 queueID ) override;
-        /** @copydoc MovableObject::setRenderQueueGroupAndPriority */
+        /** @copydoc Renderable::setRenderQueueSubGroup */
         void setRenderQueueSubGroup( uint8 subGroup );
 
         /** Set whether or not particles are sorted according to the camera.

--- a/OgreMain/include/OgrePixelCountLodStrategy.h
+++ b/OgreMain/include/OgrePixelCountLodStrategy.h
@@ -85,7 +85,6 @@ namespace Ogre
         /** Default constructor. */
         AbsolutePixelCountLodStrategy();
 
-        /// @copydoc LodStrategy::getValueImpl
         Real getValueImpl( const MovableObject *movableObject, const Camera *camera ) const override;
 
         void lodUpdateImpl( const size_t numNodes, ObjectData t, const Camera *camera,
@@ -143,7 +142,6 @@ namespace Ogre
         /** Default constructor. */
         ScreenRatioPixelCountLodStrategy();
 
-        /// @copydoc LodStrategy::getValueImpl
         Real getValueImpl( const MovableObject *movableObject, const Camera *camera ) const override;
 
         void lodUpdateImpl( const size_t numNodes, ObjectData t, const Camera *camera,

--- a/OgreMain/include/OgreStagingTextureBufferImpl.h
+++ b/OgreMain/include/OgreStagingTextureBufferImpl.h
@@ -69,7 +69,7 @@ namespace Ogre
         bool   isSmallerThan( const StagingTexture *other ) const override;
         size_t _getSizeBytes() override;
 
-        /// @copydoc StagingTexture::notifyStartMapRegion
+        /// @copydoc StagingTexture::startMapRegion
         void startMapRegion() override;
 
         size_t _getInternalTotalSizeBytes() const { return mSize; }

--- a/OgreMain/include/OgreTagPoint.h
+++ b/OgreMain/include/OgreTagPoint.h
@@ -96,7 +96,7 @@ namespace Ogre
             /** Gets the transform of this node just for the skeleton (not entity) */
             const Matrix4 &_getFullLocalTransform() const;
 
-            /** @copydoc Node::needUpdate */
+            /** @copydoc OldNode::needUpdate */
             void needUpdate( bool forceParentUpdate = false ) override;
 
             /** Overridden from Node in order to include parent Entity transform. */

--- a/OgreMain/include/OgreTextureGpu.h
+++ b/OgreMain/include/OgreTextureGpu.h
@@ -460,7 +460,10 @@ namespace Ogre
         TextureTypes::TextureTypes getInternalTextureType() const;
 
         void _setSourceType( uint8 type );
-        /// @copydoc TextureGpu::mSourceType
+        /// This setting is for where the texture is created, e.g. its a compositor texture, a shadow
+        /// texture or standard texture loaded for a mesh etc...
+        ///
+        /// This value is merely for statistical tracking purposes
         uint8 getSourceType() const;
 
         /** Sets the pixel format.

--- a/OgreMain/include/OgreTextureUnitState.h
+++ b/OgreMain/include/OgreTextureUnitState.h
@@ -550,14 +550,10 @@ namespace Ogre
          */
         bool getIsAlpha() const;
 
-        /// @copydoc Texture::getGamma
         Real getGamma() const { return mGamma; }
-        /// @copydoc Texture::setGamma
         void setGamma( Real gamma ) { mGamma = gamma; }
 
-        /// @copydoc Texture::setHardwareGammaEnabled
         void setHardwareGammaEnabled( bool enabled );
-        /// @copydoc Texture::isHardwareGammaEnabled
         bool isHardwareGammaEnabled() const;
 
         /** Gets the index of the set of texture co-ords this layer uses.

--- a/PlugIns/EXRCodec/include/OgreEXRCodec.h
+++ b/PlugIns/EXRCodec/include/OgreEXRCodec.h
@@ -30,9 +30,10 @@ THE SOFTWARE.
 
 #include "OgreImageCodec.h"
 
-namespace Ogre {
+namespace Ogre
+{
 
-    /** 
+    /**
      * Codec specialized in loading OpenEXR high dynamic range images.
      */
     class EXRCodec : public ImageCodec
@@ -42,17 +43,18 @@ namespace Ogre {
         virtual ~EXRCodec();
 
         /// @copydoc Codec::encode
-        DataStreamPtr code(MemoryDataStreamPtr& input, CodecDataPtr& pData) const;
+        DataStreamPtr code( MemoryDataStreamPtr &input, CodecDataPtr &pData ) const;
         /// @copydoc Codec::encodeToFile
-        void codeToFile(MemoryDataStreamPtr& input, const String& outFileName, CodecDataPtr& pData) const;
+        void codeToFile( MemoryDataStreamPtr &input, const String &outFileName,
+                         CodecDataPtr &pData ) const;
         /// @copydoc Codec::decode
-        DecodeResult decode(DataStreamPtr& input) const;
+        DecodeResult decode( DataStreamPtr &input ) const;
         /// @copydoc Codec::magicNumberToFileExt
-        String magicNumberToFileExt(const char* magicNumberPtr, size_t maxbytes) const;
+        String magicNumberToFileExt( const char *magicNumberPtr, size_t maxbytes ) const;
 
         String getType() const;
     };
 
-} // namespace
+}  // namespace Ogre
 
 #endif

--- a/PlugIns/EXRCodec/include/OgreEXRCodec.h
+++ b/PlugIns/EXRCodec/include/OgreEXRCodec.h
@@ -41,9 +41,9 @@ namespace Ogre {
         EXRCodec();
         virtual ~EXRCodec();
 
-        /// @copydoc Codec::code
+        /// @copydoc Codec::encode
         DataStreamPtr code(MemoryDataStreamPtr& input, CodecDataPtr& pData) const;
-        /// @copydoc Codec::codeToFile
+        /// @copydoc Codec::encodeToFile
         void codeToFile(MemoryDataStreamPtr& input, const String& outFileName, CodecDataPtr& pData) const;
         /// @copydoc Codec::decode
         DecodeResult decode(DataStreamPtr& input) const;

--- a/RenderSystems/Direct3D11/include/OgreD3D11RenderSystem.h
+++ b/RenderSystems/Direct3D11/include/OgreD3D11RenderSystem.h
@@ -193,7 +193,6 @@ namespace Ogre
                                      const NameValuePairList *miscParams = 0 ) override;
         void    _notifyWindowDestroyed( Window *window );
 
-        /// @copydoc RenderSystem::fireDeviceEvent
         void fireDeviceEvent( D3D11Device *device, const String &name,
                               D3D11Window *sendingWindow = NULL );
 
@@ -343,10 +342,8 @@ namespace Ogre
 
         D3D_FEATURE_LEVEL _getFeatureLevel() const { return mFeatureLevel; }
 
-        /// @copydoc RenderSystem::setSubroutine
         void setSubroutine( GpuProgramType gptype, size_t slotIndex, const String &subroutineName );
 
-        /// @copydoc RenderSystem::setSubroutineName
         void setSubroutine( GpuProgramType gptype, const String &slotName,
                             const String &subroutineName );
 

--- a/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
+++ b/RenderSystems/GL3Plus/include/OgreGL3PlusRenderSystem.h
@@ -501,10 +501,8 @@ namespace Ogre
                                        uint16 mask ) override;
         void bindGpuProgramPassIterationParameters( GpuProgramType gptype ) override;
 
-        /// @copydoc RenderSystem::_setSceneBlending
         void _setSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor,
                                 SceneBlendOperation op );
-        /// @copydoc RenderSystem::_setSeparateSceneBlending
         void _setSeparateSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor,
                                         SceneBlendFactor sourceFactorAlpha,
                                         SceneBlendFactor destFactorAlpha, SceneBlendOperation op,

--- a/RenderSystems/GL3Plus/include/windowing/EGL/OgreEGLGLSupport.h
+++ b/RenderSystems/GL3Plus/include/windowing/EGL/OgreEGLGLSupport.h
@@ -51,30 +51,30 @@ namespace Ogre
         EGLGLSupport();
         ~EGLGLSupport();
 
-        /// @copydoc see GL3PlusSupport::addConfig
+        /// @copydoc GL3PlusSupport::addConfig
         void addConfig();
 
-        /// @copydoc see GL3PlusSupport::validateConfig
+        /// @copydoc GL3PlusSupport::validateConfig
         String validateConfig();
 
-        /// @copydoc see GL3PlusSupport::setConfigOption
+        /// @copydoc GL3PlusSupport::setConfigOption
         void setConfigOption( const String &name, const String &value );
 
         /// @copydoc GL3PlusSupport::createWindow
         Window *createWindow( bool autoCreateWindow, GL3PlusRenderSystem *renderSystem,
                               const String &windowTitle );
 
-        /// @copydoc RenderSystem::createRenderWindow
+        /// @copydoc Root::createRenderWindow
         Window *newWindow( const String &name, uint32 width, uint32 height, bool fullScreen,
                            const NameValuePairList *miscParams = 0 );
 
-        /// @copydoc see GL3PlusSupport::start
+        /// @copydoc GL3PlusSupport::start
         void start();
 
-        /// @copydoc see GL3PlusSupport::stop
+        /// @copydoc GL3PlusSupport::stop
         void stop();
 
-        /// @copydoc see GL3PlusSupport::getProcAddress
+        /// @copydoc GL3PlusSupport::getProcAddress
         void *getProcAddress( const char *procname ) const;
 
         ::EGLContext createNewContext( EGLDisplay eglDisplay, EGLConfig eglCfg,

--- a/RenderSystems/GL3Plus/include/windowing/EGL/OgreEGLWindow.h
+++ b/RenderSystems/GL3Plus/include/windowing/EGL/OgreEGLWindow.h
@@ -73,30 +73,30 @@ namespace Ogre
                                       uint32 width, uint32 height, uint32 frequencyNumerator,
                                       uint32 frequencyDenominator );
 
-        /** @copydoc see RenderWindow::destroy */
+        /** @copydoc Window::destroy */
         virtual void destroy();
 
-        /** @copydoc see RenderWindow::isClosed */
+        /** @copydoc Window::isClosed */
         virtual bool isClosed() const;
 
-        /** @copydoc see RenderWindow::isVisible */
+        /** @copydoc Window::isVisible */
         bool isVisible() const;
 
         virtual void _setVisible( bool visible );
 
-        /** @copydoc see RenderWindow::isHidden */
+        /** @copydoc Window::isHidden */
         bool isHidden() const { return mHidden; }
 
-        /** @copydoc see RenderWindow::setHidden */
+        /** @copydoc Window::setHidden */
         void setHidden( bool hidden );
 
-        /** @copydoc see RenderWindow::resize */
+        /** @copydoc Window::requestResolution */
         void requestResolution( uint32 width, uint32 height );
 
-        /** @copydoc see RenderWindow::windowMovedOrResized */
+        /** @copydoc Window::windowMovedOrResized */
         void windowMovedOrResized();
 
-        /** @copydoc see RenderWindow::swapBuffers */
+        /** @copydoc Window::swapBuffers */
         void swapBuffers();
 
         /**

--- a/RenderSystems/GL3Plus/include/windowing/EGL/PBuffer/OgreEglPBufferSupport.h
+++ b/RenderSystems/GL3Plus/include/windowing/EGL/PBuffer/OgreEglPBufferSupport.h
@@ -73,36 +73,36 @@ namespace Ogre
         EglPBufferSupport();
         ~EglPBufferSupport();
 
-        /// @copydoc see GL3PlusSupport::addConfig
+        /// @copydoc GL3PlusSupport::addConfig
         void addConfig();
 
-        /// @copydoc see GL3PlusSupport::validateConfig
+        /// @copydoc GL3PlusSupport::validateConfig
         String validateConfig();
 
-        /// @copydoc see RenderSystem::getPriorityConfigOption
+        /// @copydoc RenderSystem::getPriorityConfigOption
         virtual const char *getPriorityConfigOption( size_t idx ) const;
 
-        /// @copydoc see RenderSystem::getPriorityConfigOption
+        /// @copydoc RenderSystem::getPriorityConfigOption
         virtual size_t getNumPriorityConfigOptions() const;
 
-        /// @copydoc see GL3PlusSupport::setConfigOption
+        /// @copydoc GL3PlusSupport::setConfigOption
         void setConfigOption( const String &name, const String &value );
 
         /// @copydoc GL3PlusSupport::createWindow
         Window *createWindow( bool autoCreateWindow, GL3PlusRenderSystem *renderSystem,
                               const String &windowTitle );
 
-        /// @copydoc RenderSystem::createRenderWindow
+        /// @copydoc Root::createRenderWindow
         Window *newWindow( const String &name, uint32 width, uint32 height, bool fullScreen,
                            const NameValuePairList *miscParams = 0 );
 
-        /// @copydoc see GL3PlusSupport::start
+        /// @copydoc GL3PlusSupport::start
         void start();
 
-        /// @copydoc see GL3PlusSupport::stop
+        /// @copydoc GL3PlusSupport::stop
         void stop();
 
-        /// @copydoc see GL3PlusSupport::getProcAddress
+        /// @copydoc GL3PlusSupport::getProcAddress
         void *getProcAddress( const char *procname ) const;
 
         const DeviceData *getCurrentDevice();

--- a/RenderSystems/GL3Plus/include/windowing/EGL/PBuffer/OgreEglPBufferWindow.h
+++ b/RenderSystems/GL3Plus/include/windowing/EGL/PBuffer/OgreEglPBufferWindow.h
@@ -91,27 +91,27 @@ namespace Ogre
                                       uint32 width, uint32 height, uint32 frequencyNumerator,
                                       uint32 frequencyDenominator );
 
-        /** @copydoc see RenderWindow::destroy */
+        /** @copydoc Window::destroy */
         virtual void destroy();
 
-        /** @copydoc see RenderWindow::isClosed */
+        /** @copydoc Window::isClosed */
         virtual bool isClosed() const;
 
-        /** @copydoc see RenderWindow::isVisible */
+        /** @copydoc Window::isVisible */
         bool isVisible() const;
 
         virtual void _setVisible( bool visible );
 
-        /** @copydoc see RenderWindow::isHidden */
+        /** @copydoc Window::isHidden */
         bool isHidden() const { return mHidden; }
 
-        /** @copydoc see RenderWindow::setHidden */
+        /** @copydoc Window::setHidden */
         void setHidden( bool hidden );
 
-        /** @copydoc see RenderWindow::resize */
+        /** @copydoc Window::requestResolution */
         void requestResolution( uint32 width, uint32 height );
 
-        /** @copydoc see RenderWindow::swapBuffers */
+        /** @copydoc Window::swapBuffers */
         void swapBuffers();
 
         /**

--- a/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXGLSupport.h
+++ b/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXGLSupport.h
@@ -45,33 +45,33 @@ namespace Ogre
         Atom mAtomFullScreen;
         Atom mAtomState;
 
-        /** @copydoc see GL3PlusSupport::addConfig */
+        /** @copydoc GL3PlusSupport::addConfig */
         void addConfig() override;
 
-        /** @copydoc see GL3PlusSupport::validateConfig */
+        /** @copydoc GL3PlusSupport::validateConfig */
         String validateConfig() override;
 
-        /** @copydoc see GL3PlusSupport::setConfigOption */
+        /** @copydoc GL3PlusSupport::setConfigOption */
         void setConfigOption( const String &name, const String &value ) override;
 
         /// @copydoc GL3PlusSupport::createWindow
         Window *createWindow( bool autoCreateWindow, GL3PlusRenderSystem *renderSystem,
                               const String &windowTitle ) override;
 
-        /// @copydoc RenderSystem::createRenderWindow
+        /// @copydoc Root::createRenderWindow
         Window *newWindow( const String &name, uint32 width, uint32 height, bool fullScreen,
                            const NameValuePairList *miscParams = 0 ) override;
 
-        /** @copydoc see GL3PlusSupport::start */
+        /** @copydoc GL3PlusSupport::start */
         void start() override;
 
-        /** @copydoc see GL3PlusSupport::stop */
+        /** @copydoc GL3PlusSupport::stop */
         void stop() override;
 
-        /** @copydoc see GL3PlusSupport::initialiseExtensions */
+        /** @copydoc GL3PlusSupport::initialiseExtensions */
         void initialiseExtensions() override;
 
-        /** @copydoc see GL3PlusSupport::getProcAddress */
+        /** @copydoc GL3PlusSupport::getProcAddress */
         void *getProcAddress( const char *procname ) const override;
 
         // The remaining functions are internal to the GLX Rendersystem:

--- a/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXWindow.h
+++ b/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXWindow.h
@@ -69,30 +69,30 @@ namespace Ogre
                                       uint32 width, uint32 height, uint32 frequencyNumerator,
                                       uint32 frequencyDenominator ) override;
 
-        /** @copydoc see RenderWindow::destroy */
+        /** @copydoc Window::destroy */
         virtual void destroy() override;
 
-        /** @copydoc see RenderWindow::isClosed */
+        /** @copydoc Window::isClosed */
         virtual bool isClosed() const override;
 
-        /** @copydoc see RenderWindow::isVisible */
+        /** @copydoc Window::isVisible */
         bool isVisible() const override;
 
         virtual void _setVisible( bool visible ) override;
 
-        /** @copydoc see RenderWindow::isHidden */
+        /** @copydoc Window::isHidden */
         bool isHidden() const override { return mHidden; }
 
-        /** @copydoc see RenderWindow::setHidden */
+        /** @copydoc Window::setHidden */
         void setHidden( bool hidden ) override;
 
-        /** @copydoc see RenderWindow::resize */
+        /** @copydoc Window::requestResolution */
         void requestResolution( uint32 width, uint32 height ) override;
 
-        /** @copydoc see RenderWindow::windowMovedOrResized */
+        /** @copydoc Window::windowMovedOrResized */
         void windowMovedOrResized() override;
 
-        /** @copydoc see RenderWindow::swapBuffers */
+        /** @copydoc Window::swapBuffers */
         void swapBuffers() override;
 
         /**

--- a/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaWindow.h
+++ b/RenderSystems/GL3Plus/include/windowing/OSX/OgreOSXCocoaWindow.h
@@ -82,43 +82,43 @@ namespace Ogre
         CocoaWindow( const String &title, uint32 widthPt, uint32 heightPt, bool fullscreenMode );
         virtual ~CocoaWindow();
 
-        /** @copydoc see Window::_initialize */
+        /** @copydoc Window::_initialize */
         void _initialize( TextureGpuManager *textureManager ) override;
 
-        /** @copydoc see Window::setVSync */
+        /** @copydoc Window::setVSync */
         // void setVSync(bool vSync, uint32 vSyncInterval) override;
 
-        /** @copydoc see Window::getViewPointToPixelScale */
+        /** @copydoc Window::getViewPointToPixelScale */
         float getViewPointToPixelScale() const override;
 
-        /** @copydoc see Window::destroy */
+        /** @copydoc Window::destroy */
         void destroy() override;
 
-        /** @copydoc see Window::isVisible */
+        /** @copydoc Window::isVisible */
         bool isVisible() const override;
 
-        /** @copydoc see Window::_setVisible */
+        /** @copydoc Window::_setVisible */
         void _setVisible( bool visible ) override;
 
-        /** @copydoc see Window::isClosed */
+        /** @copydoc Window::isClosed */
         bool isClosed() const override;
 
-        /** @copydoc see Window::isHidden */
+        /** @copydoc Window::isHidden */
         bool isHidden() const override { return mHidden; }
 
-        /** @copydoc see RenderWindow::setHidden */
+        /** @copydoc Window::setHidden */
         void setHidden( bool hidden ) override;
 
-        /** @copydoc see Window::reposition */
+        /** @copydoc Window::reposition */
         void reposition( int leftPt, int topPt ) override;
 
-        /** @copydoc see Window::swapBuffers */
+        /** @copydoc Window::swapBuffers */
         void swapBuffers() override;
 
-        /** @copydoc see Window::windowMovedOrResized */
+        /** @copydoc Window::windowMovedOrResized */
         void windowMovedOrResized() override;
 
-        /** @copydoc see Window::getCustomAttribute */
+        /** @copydoc Window::getCustomAttribute */
         /**
            @remarks
            * Get custom attribute; the following attributes are valid:

--- a/RenderSystems/GL3Plus/include/windowing/OgreGlSwitchableSupport.h
+++ b/RenderSystems/GL3Plus/include/windowing/OgreGlSwitchableSupport.h
@@ -67,36 +67,36 @@ namespace Ogre
         GlSwitchableSupport();
         ~GlSwitchableSupport();
 
-        /// @copydoc see GL3PlusSupport::addConfig
+        /// @copydoc GL3PlusSupport::addConfig
         void addConfig();
 
-        /// @copydoc see GL3PlusSupport::validateConfig
+        /// @copydoc GL3PlusSupport::validateConfig
         String validateConfig();
 
-        /// @copydoc see GL3PlusSupport::setConfigOption
+        /// @copydoc GL3PlusSupport::setConfigOption
         void setConfigOption( const String &name, const String &value );
 
-        /// @copydoc see RenderSystem::getPriorityConfigOption
+        /// @copydoc RenderSystem::getPriorityConfigOption
         virtual const char *getPriorityConfigOption( size_t idx ) const;
 
-        /// @copydoc see RenderSystem::getPriorityConfigOption
+        /// @copydoc RenderSystem::getPriorityConfigOption
         virtual size_t getNumPriorityConfigOptions() const;
 
         /// @copydoc GL3PlusSupport::createWindow
         Window *createWindow( bool autoCreateWindow, GL3PlusRenderSystem *renderSystem,
                               const String &windowTitle );
 
-        /// @copydoc RenderSystem::createRenderWindow
+        /// @copydoc Root::createRenderWindow
         Window *newWindow( const String &name, uint32 width, uint32 height, bool fullScreen,
                            const NameValuePairList *miscParams = 0 );
 
-        /// @copydoc see GL3PlusSupport::start
+        /// @copydoc GL3PlusSupport::start
         void start();
 
-        /// @copydoc see GL3PlusSupport::stop
+        /// @copydoc GL3PlusSupport::stop
         void stop();
 
-        /// @copydoc see GL3PlusSupport::getProcAddress
+        /// @copydoc GL3PlusSupport::getProcAddress
         void *getProcAddress( const char *procname ) const;
 
         uint8 findSelectedInterfaceIdx() const;

--- a/RenderSystems/GL3Plus/include/windowing/SDL/OgreSDLGLSupport.h
+++ b/RenderSystems/GL3Plus/include/windowing/SDL/OgreSDLGLSupport.h
@@ -26,7 +26,7 @@ namespace Ogre
         virtual RenderWindow *createWindow( bool autoCreateWindow, GL3PlusRenderSystem *renderSystem,
                                             const String &windowTitle );
 
-        /// @copydoc RenderSystem::createRenderWindow
+        /// @copydoc Root::createRenderWindow
         virtual RenderWindow *newWindow( const String &name, unsigned int width, unsigned int height,
                                          bool fullScreen, const NameValuePairList *miscParams = 0 );
 

--- a/RenderSystems/GL3Plus/include/windowing/SDL/OgreSDLWindow.h
+++ b/RenderSystems/GL3Plus/include/windowing/SDL/OgreSDLWindow.h
@@ -70,9 +70,7 @@ namespace Ogre
         /** Overridden - see RenderTarget. */
         void copyContentsToMemory( const Box &src, const PixelBox &dst, FrameBuffer buffer );
 
-        /** @copydoc see RenderWindow::setVSyncEnabled */
         void setVSyncEnabled( bool vsync );
-        /** @copydoc see RenderWindow::isVSyncEnabled */
         bool isVSyncEnabled() const;
 
         /** Overridden - see RenderTarget.

--- a/RenderSystems/GLES2/include/OgreGLES2DepthBuffer.h
+++ b/RenderSystems/GLES2/include/OgreGLES2DepthBuffer.h
@@ -28,11 +28,10 @@ THE SOFTWARE.
 #ifndef __GLES2DepthBuffer_H__
 #define __GLES2DepthBuffer_H__
 
-#include "OgreGLES2Prerequisites.h"
 #include "OgreDepthBuffer.h"
+#include "OgreGLES2Prerequisites.h"
 
-
-namespace Ogre 
+namespace Ogre
 {
     class GLES2Context;
     class GLES2RenderSystem;
@@ -52,30 +51,29 @@ namespace Ogre
         GLuint createRenderBuffer( GLenum format );
 
     public:
-        GLES2DepthBuffer( uint16 poolId, GLES2RenderSystem *renderSystem,
-                          GLES2Context *creatorContext,
-                          GLenum depthFormat, GLenum stencilFormat,
-                          uint32 width, uint32 height, uint32 fsaa, uint32 multiSampleQuality,
-                          PixelFormat pixelFormat, bool isDepthTexture, bool isManual );
+        GLES2DepthBuffer( uint16 poolId, GLES2RenderSystem *renderSystem, GLES2Context *creatorContext,
+                          GLenum depthFormat, GLenum stencilFormat, uint32 width, uint32 height,
+                          uint32 fsaa, uint32 multiSampleQuality, PixelFormat pixelFormat,
+                          bool isDepthTexture, bool isManual );
         ~GLES2DepthBuffer();
 
         virtual bool isCompatible( RenderTarget *renderTarget, bool exactFormatMatch ) const;
 
         void bindToFramebuffer( GLenum target = GL_FRAMEBUFFER );
 
-        GLES2Context* getGLContext() const { return mCreatorContext; }
-        GLuint getDepthBuffer() const  { return mDepthBufferName; }
+        GLES2Context *getGLContext() const { return mCreatorContext; }
+        GLuint getDepthBuffer() const { return mDepthBufferName; }
         GLuint getStencilBuffer() const { return mStencilBufferName; }
 
         bool hasSeparateStencilBuffer() const;
 
     protected:
-        uint32                      mMultiSampleQuality;
-        GLES2Context                *mCreatorContext;
-        GLuint                      mDepthBufferName;
-        GLuint                      mStencilBufferName;
+        uint32 mMultiSampleQuality;
+        GLES2Context *mCreatorContext;
+        GLuint mDepthBufferName;
+        GLuint mStencilBufferName;
 
         virtual bool copyToImpl( DepthBuffer *destination );
     };
-}
+}  // namespace Ogre
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2DepthBuffer.h
+++ b/RenderSystems/GLES2/include/OgreGLES2DepthBuffer.h
@@ -59,7 +59,6 @@ namespace Ogre
                           PixelFormat pixelFormat, bool isDepthTexture, bool isManual );
         ~GLES2DepthBuffer();
 
-        /// @copydoc DepthBuffer::isCompatible
         virtual bool isCompatible( RenderTarget *renderTarget, bool exactFormatMatch ) const;
 
         void bindToFramebuffer( GLenum target = GL_FRAMEBUFFER );

--- a/RenderSystems/GLES2/include/OgreGLES2DepthTexture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2DepthTexture.h
@@ -104,7 +104,6 @@ namespace v1
 
         virtual bool requiresTextureFlipping() const        { return true; }
 
-        /// @copydoc RenderTarget::getForceDisableColourWrites
         virtual bool getForceDisableColourWrites() const    { return true; }
 
         /// Depth buffers never resolve; only colour buffers do. (we need mFsaaResolveDirty to be always

--- a/RenderSystems/GLES2/include/OgreGLES2DepthTexture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2DepthTexture.h
@@ -37,15 +37,15 @@ namespace Ogre
     {
     public:
         // Constructor
-        GLES2DepthTexture( bool shareableDepthBuffer, ResourceManager* creator, const String& name,
-                             ResourceHandle handle, const String& group, bool isManual,
-                             ManualResourceLoader* loader, GLES2Support& support );
+        GLES2DepthTexture( bool shareableDepthBuffer, ResourceManager *creator, const String &name,
+                           ResourceHandle handle, const String &group, bool isManual,
+                           ManualResourceLoader *loader, GLES2Support &support );
 
         virtual ~GLES2DepthTexture();
 
         void _setGlTextureName( GLuint textureName );
 
-        bool getShareableDepthBuffer() const        { return mShareableDepthBuffer; }
+        bool getShareableDepthBuffer() const { return mShareableDepthBuffer; }
 
     protected:
         bool mShareableDepthBuffer;
@@ -68,48 +68,47 @@ namespace Ogre
         virtual void _autogenerateMipmaps() {}
     };
 
-namespace v1
-{
-    class _OgreGLES2Export GLES2DepthPixelBuffer : public HardwarePixelBuffer
+    namespace v1
     {
-    protected:
-        RenderTexture   *mDummyRenderTexture;
+        class _OgreGLES2Export GLES2DepthPixelBuffer : public HardwarePixelBuffer
+        {
+        protected:
+            RenderTexture *mDummyRenderTexture;
 
-        virtual PixelBox lockImpl( const Box &lockBox, LockOptions options );
-        virtual void unlockImpl();
+            virtual PixelBox lockImpl( const Box &lockBox, LockOptions options );
+            virtual void unlockImpl();
 
-        /// Notify HardwarePixelBuffer of destruction of render target.
-        virtual void _clearSliceRTT( size_t zoffset );
+            /// Notify HardwarePixelBuffer of destruction of render target.
+            virtual void _clearSliceRTT( size_t zoffset );
 
-    public:
-        GLES2DepthPixelBuffer( GLES2DepthTexture *parentTexture, const String &baseName,
-                                 uint32 width, uint32 height, uint32 depth, PixelFormat format );
-        virtual ~GLES2DepthPixelBuffer();
+        public:
+            GLES2DepthPixelBuffer( GLES2DepthTexture *parentTexture, const String &baseName,
+                                   uint32 width, uint32 height, uint32 depth, PixelFormat format );
+            virtual ~GLES2DepthPixelBuffer();
 
-        virtual void blitFromMemory( const PixelBox &src, const Box &dstBox );
-        virtual void blitToMemory( const Box &srcBox, const PixelBox &dst );
-        virtual RenderTexture* getRenderTarget( size_t slice=0 );
-    };
-}
+            virtual void blitFromMemory( const PixelBox &src, const Box &dstBox );
+            virtual void blitToMemory( const Box &srcBox, const PixelBox &dst );
+            virtual RenderTexture *getRenderTarget( size_t slice = 0 );
+        };
+    }  // namespace v1
 
-    class _OgreGLES2Export GLES2DepthTextureTarget : public RenderTexture //GLES2RenderTexture
+    class _OgreGLES2Export GLES2DepthTextureTarget : public RenderTexture  // GLES2RenderTexture
     {
         GLES2DepthTexture *mUltimateTextureOwner;
 
     public:
-        GLES2DepthTextureTarget( GLES2DepthTexture *ultimateTextureOwner,
-                                   const String &name, v1::HardwarePixelBuffer *buffer,
-                                   uint32 zoffset );
+        GLES2DepthTextureTarget( GLES2DepthTexture *ultimateTextureOwner, const String &name,
+                                 v1::HardwarePixelBuffer *buffer, uint32 zoffset );
         virtual ~GLES2DepthTextureTarget();
 
-        virtual bool requiresTextureFlipping() const        { return true; }
+        virtual bool requiresTextureFlipping() const { return true; }
 
-        virtual bool getForceDisableColourWrites() const    { return true; }
+        virtual bool getForceDisableColourWrites() const { return true; }
 
         /// Depth buffers never resolve; only colour buffers do. (we need mFsaaResolveDirty to be always
         /// true so that the proper path is taken in GLES2Texture::getGLID)
-        virtual void setFsaaResolveDirty()  {}
-        virtual void setFsaaResolved()          {}
+        virtual void setFsaaResolveDirty() {}
+        virtual void setFsaaResolved() {}
 
         virtual void setDepthBufferPool( uint16 poolId );
 
@@ -120,8 +119,8 @@ namespace v1
         virtual void getFormatsForPso( PixelFormat outFormats[OGRE_MAX_MULTIPLE_RENDER_TARGETS],
                                        bool outHwGamma[OGRE_MAX_MULTIPLE_RENDER_TARGETS] ) const;
 
-        void getCustomAttribute( const String& name, void* pData );
+        void getCustomAttribute( const String &name, void *pData );
     };
-}
+}  // namespace Ogre
 
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2HardwarePixelBuffer.h
+++ b/RenderSystems/GLES2/include/OgreGLES2HardwarePixelBuffer.h
@@ -32,13 +32,15 @@ THE SOFTWARE.
 #include "OgreGLES2Prerequisites.h"
 #include "OgreHardwarePixelBuffer.h"
 
-namespace Ogre {
-namespace v1 {
-    class _OgreGLES2Export GLES2HardwarePixelBuffer: public HardwarePixelBuffer
+namespace Ogre
+{
+    namespace v1
     {
+        class _OgreGLES2Export GLES2HardwarePixelBuffer : public HardwarePixelBuffer
+        {
         protected:
             /// Lock a box
-            PixelBox lockImpl(const Box &lockBox,  LockOptions options);
+            PixelBox lockImpl( const Box &lockBox, LockOptions options );
 
             /// Unlock a box
             void unlockImpl();
@@ -46,7 +48,7 @@ namespace v1 {
             // Internal buffer; either on-card or in system memory, freed/allocated on demand
             // depending on buffer usage
             PixelBox mBuffer;
-            GLenum mGLInternalFormat; // GL internal format
+            GLenum mGLInternalFormat;  // GL internal format
             LockOptions mCurrentLockOptions;
 
             // Buffer allocation/freeage
@@ -55,46 +57,45 @@ namespace v1 {
             void freeBuffer();
 
             // Upload a box of pixels to this buffer on the card
-            virtual void upload(const PixelBox &data, const Box &dest);
+            virtual void upload( const PixelBox &data, const Box &dest );
 
             // Download a box of pixels from the card
-            virtual void download(const PixelBox &data);
-        
+            virtual void download( const PixelBox &data );
+
         public:
             /// Should be called by HardwareBufferManager
-            GLES2HardwarePixelBuffer(uint32 mWidth, uint32 mHeight, uint32 mDepth,
-                                  PixelFormat mFormat, bool hwGamma,
-                                  HardwareBuffer::Usage usage);
+            GLES2HardwarePixelBuffer( uint32 mWidth, uint32 mHeight, uint32 mDepth, PixelFormat mFormat,
+                                      bool hwGamma, HardwareBuffer::Usage usage );
 
-            void blitFromMemory(const PixelBox &src, const Box &dstBox);
+            void blitFromMemory( const PixelBox &src, const Box &dstBox );
 
-            void blitToMemory(const Box &srcBox, const PixelBox &dst);
+            void blitToMemory( const Box &srcBox, const PixelBox &dst );
 
             virtual ~GLES2HardwarePixelBuffer();
 
             /** Bind surface to frame buffer. Needs FBO extension.
-            */
-            virtual void bindToFramebuffer(GLenum attachment, uint32 zoffset);
+             */
+            virtual void bindToFramebuffer( GLenum attachment, uint32 zoffset );
             GLenum getGLFormat() { return mGLInternalFormat; }
-    };
+        };
 
-     /** Renderbuffer surface.  Needs FBO extension.
-     */
-    class _OgreGLES2Export GLES2RenderBuffer: public GLES2HardwarePixelBuffer
-    {
+        /** Renderbuffer surface.  Needs FBO extension.
+         */
+        class _OgreGLES2Export GLES2RenderBuffer : public GLES2HardwarePixelBuffer
+        {
         public:
-            GLES2RenderBuffer(GLenum format, uint32 width, uint32 height, GLsizei numSamples);
+            GLES2RenderBuffer( GLenum format, uint32 width, uint32 height, GLsizei numSamples );
             virtual ~GLES2RenderBuffer();
 
             /// @copydoc GLES2HardwarePixelBuffer::bindToFramebuffer
-            virtual void bindToFramebuffer(GLenum attachment, uint32 zoffset);
+            virtual void bindToFramebuffer( GLenum attachment, uint32 zoffset );
 
         protected:
             // In case this is a render buffer
             GLuint mRenderbufferID;
             GLsizei mNumSamples;
-    };
-}
-}
+        };
+    }  // namespace v1
+}  // namespace Ogre
 
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2HardwarePixelBuffer.h
+++ b/RenderSystems/GLES2/include/OgreGLES2HardwarePixelBuffer.h
@@ -66,10 +66,8 @@ namespace v1 {
                                   PixelFormat mFormat, bool hwGamma,
                                   HardwareBuffer::Usage usage);
 
-            /// @copydoc HardwarePixelBuffer::blitFromMemory
             void blitFromMemory(const PixelBox &src, const Box &dstBox);
 
-            /// @copydoc HardwarePixelBuffer::blitToMemory
             void blitToMemory(const Box &srcBox, const PixelBox &dst);
 
             virtual ~GLES2HardwarePixelBuffer();

--- a/RenderSystems/GLES2/include/OgreGLES2NullTexture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2NullTexture.h
@@ -99,7 +99,6 @@ namespace v1
 
         virtual bool requiresTextureFlipping() const { return true; }
 
-        /// @copydoc RenderTarget::getForceDisableColourWrites
         virtual bool getForceDisableColourWrites() const    { return true; }
 
         /// Null buffers never resolve; only colour buffers do. (we need mFsaaResolveDirty to be always

--- a/RenderSystems/GLES2/include/OgreGLES2NullTexture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2NullTexture.h
@@ -37,14 +37,13 @@ namespace Ogre
     {
     public:
         // Constructor
-        GLES2NullTexture( ResourceManager* creator, const String& name,
-                             ResourceHandle handle, const String& group, bool isManual,
-                             ManualResourceLoader* loader, GLES2Support& support );
+        GLES2NullTexture( ResourceManager *creator, const String &name, ResourceHandle handle,
+                          const String &group, bool isManual, ManualResourceLoader *loader,
+                          GLES2Support &support );
 
         virtual ~GLES2NullTexture();
 
     protected:
-
         /// @copydoc Texture::createInternalResourcesImpl
         virtual void createInternalResourcesImpl();
         /// @copydoc Resource::freeInternalResourcesImpl
@@ -63,54 +62,53 @@ namespace Ogre
         void _createSurfaceList();
     };
 
-namespace v1
-{
-    class _OgreGLES2Export GLES2NullPixelBuffer : public HardwarePixelBuffer
+    namespace v1
     {
-    protected:
-        RenderTexture   *mDummyRenderTexture;
+        class _OgreGLES2Export GLES2NullPixelBuffer : public HardwarePixelBuffer
+        {
+        protected:
+            RenderTexture *mDummyRenderTexture;
 
-        virtual PixelBox lockImpl( const Box &lockBox, LockOptions options );
-        virtual void unlockImpl();
+            virtual PixelBox lockImpl( const Box &lockBox, LockOptions options );
+            virtual void unlockImpl();
 
-        /// Notify HardwarePixelBuffer of destruction of render target.
-        virtual void _clearSliceRTT( size_t zoffset );
+            /// Notify HardwarePixelBuffer of destruction of render target.
+            virtual void _clearSliceRTT( size_t zoffset );
 
-    public:
-        GLES2NullPixelBuffer( GLES2NullTexture *parentTexture, const String &baseName,
-                                 uint32 width, uint32 height, uint32 Null, PixelFormat format );
-        virtual ~GLES2NullPixelBuffer();
+        public:
+            GLES2NullPixelBuffer( GLES2NullTexture *parentTexture, const String &baseName, uint32 width,
+                                  uint32 height, uint32 Null, PixelFormat format );
+            virtual ~GLES2NullPixelBuffer();
 
-        virtual void blitFromMemory( const PixelBox &src, const Box &dstBox );
-        virtual void blitToMemory( const Box &srcBox, const PixelBox &dst );
-        virtual RenderTexture* getRenderTarget( size_t slice=0 );
-    };
-}
+            virtual void blitFromMemory( const PixelBox &src, const Box &dstBox );
+            virtual void blitToMemory( const Box &srcBox, const PixelBox &dst );
+            virtual RenderTexture *getRenderTarget( size_t slice = 0 );
+        };
+    }  // namespace v1
 
-    class _OgreGLES2Export GLES2NullTextureTarget : public RenderTexture //GLES2RenderTexture
+    class _OgreGLES2Export GLES2NullTextureTarget : public RenderTexture  // GLES2RenderTexture
     {
         GLES2NullTexture *mUltimateTextureOwner;
 
     public:
-        GLES2NullTextureTarget( GLES2NullTexture *ultimateTextureOwner,
-                                   const String &name, v1::HardwarePixelBuffer *buffer,
-                                   uint32 zoffset );
+        GLES2NullTextureTarget( GLES2NullTexture *ultimateTextureOwner, const String &name,
+                                v1::HardwarePixelBuffer *buffer, uint32 zoffset );
         virtual ~GLES2NullTextureTarget();
 
         virtual bool requiresTextureFlipping() const { return true; }
 
-        virtual bool getForceDisableColourWrites() const    { return true; }
+        virtual bool getForceDisableColourWrites() const { return true; }
 
         /// Null buffers never resolve; only colour buffers do. (we need mFsaaResolveDirty to be always
         /// true so that the proper path is taken in GLES2Texture::getGLID)
-        virtual void setFsaaResolveDirty()  {}
-        virtual void setFsaaResolved()          {}
+        virtual void setFsaaResolveDirty() {}
+        virtual void setFsaaResolved() {}
 
         /// Notifies the ultimate texture owner the buffer changed
         virtual bool attachDepthBuffer( DepthBuffer *depthBuffer, bool exactFormatMatch );
 
-        void getCustomAttribute( const String& name, void* pData );
+        void getCustomAttribute( const String &name, void *pData );
     };
-}
+}  // namespace Ogre
 
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
+++ b/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
@@ -217,14 +217,12 @@ namespace Ogre {
             RenderWindow* _createRenderWindow(const String &name, unsigned int width, unsigned int height, 
                 bool fullScreen, const NameValuePairList *miscParams = 0);
 
-            /// @copydoc RenderSystem::_createDepthBufferFor
             DepthBuffer* _createDepthBufferFor( RenderTarget *renderTarget, bool exactMatchFormat );
 
             /// Mimics D3D9RenderSystem::_getDepthStencilFormatFor, if no FBO RTT manager, outputs GL_NONE
             void _getDepthStencilFormatFor( GLenum internalColourFormat, GLenum *depthFormat,
                                             GLenum *stencilFormat );
 
-            /// @copydoc RenderSystem::createMultiRenderTarget
             virtual MultiRenderTarget * createMultiRenderTarget(const String & name);
 
             /** See
@@ -465,9 +463,7 @@ namespace Ogre {
             void bindGpuProgramParameters(GpuProgramType gptype, GpuProgramParametersSharedPtr params, uint16 mask);
             void bindGpuProgramPassIterationParameters(GpuProgramType gptype);
 
-            /// @copydoc RenderSystem::_setSceneBlending
             void _setSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor, SceneBlendOperation op );
-            /// @copydoc RenderSystem::_setSeparateSceneBlending
             void _setSeparateSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor, SceneBlendFactor sourceFactorAlpha, SceneBlendFactor destFactorAlpha, SceneBlendOperation op, SceneBlendOperation alphaOp );
             /// @copydoc RenderSystem::getDisplayMonitorCount
             unsigned int getDisplayMonitorCount() const;

--- a/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
+++ b/RenderSystems/GLES2/include/OgreGLES2RenderSystem.h
@@ -31,470 +31,479 @@ THE SOFTWARE.
 
 #include "OgreGLES2Prerequisites.h"
 
+#include "OgreGLES2PixelFormatToShaderType.h"
+#include "OgreHlmsSamplerblock.h"
 #include "OgreMaterialManager.h"
 #include "OgreRenderSystem.h"
-#include "OgreHlmsSamplerblock.h"
-#include "OgreGLES2PixelFormatToShaderType.h"
 
-namespace Ogre {
+namespace Ogre
+{
     class GLES2Context;
     class GLES2Support;
     class GLES2RTTManager;
     class GLES2GpuProgramManager;
     class GLSLESShaderFactory;
-    namespace v1 {
-    class HardwareBufferManager;
+    namespace v1
+    {
+        class HardwareBufferManager;
     }
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID || OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
     class GLES2ManagedResourceManager;
 #endif
-    
+
     /**
       Implementation of GL ES 2.x as a rendering system.
      */
     class _OgreGLES2Export GLES2RenderSystem : public RenderSystem
     {
-        private:
-            /// View matrix to set world against
-            Matrix4 mViewMatrix;
-            Matrix4 mWorldMatrix;
-            Matrix4 mTextureMatrix;
+    private:
+        /// View matrix to set world against
+        Matrix4 mViewMatrix;
+        Matrix4 mWorldMatrix;
+        Matrix4 mTextureMatrix;
 
-            /// Last min & mip filtering options, so we can combine them
-            FilterOptions mMinFilter;
-            FilterOptions mMipFilter;
+        /// Last min & mip filtering options, so we can combine them
+        FilterOptions mMinFilter;
+        FilterOptions mMipFilter;
 
-            /// Holds texture type settings for every stage
-            GLenum mTextureTypes[OGRE_MAX_TEXTURE_LAYERS];
+        /// Holds texture type settings for every stage
+        GLenum mTextureTypes[OGRE_MAX_TEXTURE_LAYERS];
 
-            GLfloat mLargestSupportedAnisotropy;
+        GLfloat mLargestSupportedAnisotropy;
 
-            /// Number of fixed-function texture units
-            unsigned short mFixedFunctionTextureUnits;
+        /// Number of fixed-function texture units
+        unsigned short mFixedFunctionTextureUnits;
 
-            /// Store last colour write state
-            uint8 mBlendChannelMask;
+        /// Store last colour write state
+        uint8 mBlendChannelMask;
 
-            /// Store last depth write state
-            bool mDepthWrite;
+        /// Store last depth write state
+        bool mDepthWrite;
 
-            /// Store last scissor enable state
-            bool mScissorsEnabled;
+        /// Store last scissor enable state
+        bool mScissorsEnabled;
 
-            GLfloat mAutoTextureMatrix[16];
+        GLfloat mAutoTextureMatrix[16];
 
-            bool mUseAutoTextureMatrix;
+        bool mUseAutoTextureMatrix;
 
-            /// GL support class, used for creating windows etc.
-            GLES2Support *mGLSupport;
+        /// GL support class, used for creating windows etc.
+        GLES2Support *mGLSupport;
 
-            /* The main GL context - main thread only */
-            GLES2Context *mMainContext;
+        /* The main GL context - main thread only */
+        GLES2Context *mMainContext;
 
-            /* The current GL context  - main thread only */
-            GLES2Context *mCurrentContext;
+        /* The current GL context  - main thread only */
+        GLES2Context *mCurrentContext;
 
-            typedef list<GLES2Context*>::type GLES2ContextList;
-            /// List of background thread contexts
-            GLES2ContextList mBackgroundContextList;
+        typedef list<GLES2Context *>::type GLES2ContextList;
+        /// List of background thread contexts
+        GLES2ContextList mBackgroundContextList;
 
-            /// For rendering legacy objects.
-            GLuint  mGlobalVao;
-            v1::VertexData  *mCurrentVertexBuffer;
-            v1::IndexData   *mCurrentIndexBuffer;
-            GLenum          mCurrentPolygonMode;
+        /// For rendering legacy objects.
+        GLuint mGlobalVao;
+        v1::VertexData *mCurrentVertexBuffer;
+        v1::IndexData *mCurrentIndexBuffer;
+        GLenum mCurrentPolygonMode;
 
-            GLES2GpuProgramManager *mGpuProgramManager;
-            GLSLESShaderFactory* mGLSLESShaderFactory;
-            v1::HardwareBufferManager* mHardwareBufferManager;
+        GLES2GpuProgramManager *mGpuProgramManager;
+        GLSLESShaderFactory *mGLSLESShaderFactory;
+        v1::HardwareBufferManager *mHardwareBufferManager;
 
-            /** Manager object for creating render textures.
-                Direct render to texture via GL_OES_framebuffer_object is preferable 
-                to pbuffers, which depend on the GL support used and are generally 
-                unwieldy and slow. However, FBO support for stencil buffers is poor.
-              */
-            GLES2RTTManager *mRTTManager;
+        /** Manager object for creating render textures.
+            Direct render to texture via GL_OES_framebuffer_object is preferable
+            to pbuffers, which depend on the GL support used and are generally
+            unwieldy and slow. However, FBO support for stencil buffers is poor.
+          */
+        GLES2RTTManager *mRTTManager;
 
-            /** These variables are used for caching RenderSystem state.
-                They are cached because OpenGL state changes can be quite expensive,
-                which is especially important on mobile or embedded systems.
-            */
-            GLenum mActiveTextureUnit;
-        
-            /// Check if the GL system has already been initialised
-            bool mGLInitialised;
-            bool mUseAdjacency;
+        /** These variables are used for caching RenderSystem state.
+            They are cached because OpenGL state changes can be quite expensive,
+            which is especially important on mobile or embedded systems.
+        */
+        GLenum mActiveTextureUnit;
 
-            bool mHasDiscardFramebuffer;
+        /// Check if the GL system has already been initialised
+        bool mGLInitialised;
+        bool mUseAdjacency;
 
-            // local data member of _render that were moved here to improve performance
-            // (save allocations)
-            vector<GLuint>::type mRenderAttribsBound;
-            vector<GLuint>::type mRenderInstanceAttribsBound;
+        bool mHasDiscardFramebuffer;
 
-            GLint getCombinedMinMipFilter() const;
+        // local data member of _render that were moved here to improve performance
+        // (save allocations)
+        vector<GLuint>::type mRenderAttribsBound;
+        vector<GLuint>::type mRenderInstanceAttribsBound;
 
-            /// @copydoc RenderSystem::getPixelFormatToShaderType
-            virtual const PixelFormatToShaderType* getPixelFormatToShaderType() const;
+        GLint getCombinedMinMipFilter() const;
 
-            unsigned char *mSwIndirectBufferPtr;
+        /// @copydoc RenderSystem::getPixelFormatToShaderType
+        virtual const PixelFormatToShaderType *getPixelFormatToShaderType() const;
 
-            GLES2HlmsPso const    *mPso;
+        unsigned char *mSwIndirectBufferPtr;
 
-            GLuint  mNullColourFramebuffer;
+        GLES2HlmsPso const *mPso;
 
-            GLES2PixelFormatToShaderType mPixelFormatToShaderType;
+        GLuint mNullColourFramebuffer;
 
-            GLint getTextureAddressingMode(TextureAddressingMode tam) const;
-            GLenum getBlendMode(SceneBlendFactor ogreBlend) const;
-            GLenum getBlendOperation(SceneBlendOperation op) const;
+        GLES2PixelFormatToShaderType mPixelFormatToShaderType;
 
-            bool activateGLTextureUnit(size_t unit);
-            void bindVertexElementToGpu( const v1::VertexElement &elem,
-                                         v1::HardwareVertexBufferSharedPtr vertexBuffer,
-                                         const size_t vertexStart,
-                                         vector<GLuint>::type &attribsBound,
-                                         vector<GLuint>::type &instanceAttribsBound,
-                                         bool updateVAO);
+        GLint getTextureAddressingMode( TextureAddressingMode tam ) const;
+        GLenum getBlendMode( SceneBlendFactor ogreBlend ) const;
+        GLenum getBlendOperation( SceneBlendOperation op ) const;
 
-            void correctViewport( GLint x, GLint &y, GLint &w, GLint &h, RenderTarget *renderTarget );
+        bool activateGLTextureUnit( size_t unit );
+        void bindVertexElementToGpu( const v1::VertexElement &elem,
+                                     v1::HardwareVertexBufferSharedPtr vertexBuffer,
+                                     const size_t vertexStart, vector<GLuint>::type &attribsBound,
+                                     vector<GLuint>::type &instanceAttribsBound, bool updateVAO );
 
-            // Mipmap count of the actual bounded texture
-            size_t mCurTexMipCount;
+        void correctViewport( GLint x, GLint &y, GLint &w, GLint &h, RenderTarget *renderTarget );
 
-        public:
-            // Default constructor / destructor
-            GLES2RenderSystem();
-            virtual ~GLES2RenderSystem();
-        
-            friend class ShaderGeneratorTechniqueResolverListener;
+        // Mipmap count of the actual bounded texture
+        size_t mCurTexMipCount;
 
-            // ----------------------------------
-            // Overridden RenderSystem functions
-            // ----------------------------------
-            /** See
-              RenderSystem
-             */
-            const String& getName() const;
-            /** See
-              RenderSystem
-             */
-            const String& getFriendlyName() const;
-            /** See
-              RenderSystem
-             */
-            ConfigOptionMap& getConfigOptions();
-            /** See
-              RenderSystem
-             */
-            void setConfigOption(const String &name, const String &value);
-            /** See
-              RenderSystem
-             */
-            String validateConfigOptions();
-            /** See
-              RenderSystem
-             */
-            RenderWindow* _initialise(bool autoCreateWindow, const String& windowTitle = "OGRE Render Window");
-            /** See
-              RenderSystem
-             */
-            virtual RenderSystemCapabilities* createRenderSystemCapabilities() const;
-            /** See
-              RenderSystem
-             */
-            void initialiseFromRenderSystemCapabilities(RenderSystemCapabilities* caps, RenderTarget* primary);
-            /** See
-              RenderSystem
-             */
-            void reinitialise(); // Used if settings changed mid-rendering
-            /** See
-              RenderSystem
-             */
-            void shutdown();
+    public:
+        // Default constructor / destructor
+        GLES2RenderSystem();
+        virtual ~GLES2RenderSystem();
 
-            /// @copydoc RenderSystem::_createRenderWindow
-            RenderWindow* _createRenderWindow(const String &name, unsigned int width, unsigned int height, 
-                bool fullScreen, const NameValuePairList *miscParams = 0);
+        friend class ShaderGeneratorTechniqueResolverListener;
 
-            DepthBuffer* _createDepthBufferFor( RenderTarget *renderTarget, bool exactMatchFormat );
+        // ----------------------------------
+        // Overridden RenderSystem functions
+        // ----------------------------------
+        /** See
+          RenderSystem
+         */
+        const String &getName() const;
+        /** See
+          RenderSystem
+         */
+        const String &getFriendlyName() const;
+        /** See
+          RenderSystem
+         */
+        ConfigOptionMap &getConfigOptions();
+        /** See
+          RenderSystem
+         */
+        void setConfigOption( const String &name, const String &value );
+        /** See
+          RenderSystem
+         */
+        String validateConfigOptions();
+        /** See
+          RenderSystem
+         */
+        RenderWindow *_initialise( bool autoCreateWindow,
+                                   const String &windowTitle = "OGRE Render Window" );
+        /** See
+          RenderSystem
+         */
+        virtual RenderSystemCapabilities *createRenderSystemCapabilities() const;
+        /** See
+          RenderSystem
+         */
+        void initialiseFromRenderSystemCapabilities( RenderSystemCapabilities *caps,
+                                                     RenderTarget *primary );
+        /** See
+          RenderSystem
+         */
+        void reinitialise();  // Used if settings changed mid-rendering
+        /** See
+          RenderSystem
+         */
+        void shutdown();
 
-            /// Mimics D3D9RenderSystem::_getDepthStencilFormatFor, if no FBO RTT manager, outputs GL_NONE
-            void _getDepthStencilFormatFor( GLenum internalColourFormat, GLenum *depthFormat,
-                                            GLenum *stencilFormat );
+        /// @copydoc RenderSystem::_createRenderWindow
+        RenderWindow *_createRenderWindow( const String &name, unsigned int width, unsigned int height,
+                                           bool fullScreen, const NameValuePairList *miscParams = 0 );
 
-            virtual MultiRenderTarget * createMultiRenderTarget(const String & name);
+        DepthBuffer *_createDepthBufferFor( RenderTarget *renderTarget, bool exactMatchFormat );
 
-            /** See
-              RenderSystem
-             */
-            void destroyRenderWindow(RenderWindow* pWin);
-            /** See
-              RenderSystem
-             */
-            String getErrorDescription(long errorNumber) const;
-            /** See
-              RenderSystem
-             */
-            VertexElementType getColourVertexElementType() const;
+        /// Mimics D3D9RenderSystem::_getDepthStencilFormatFor, if no FBO RTT manager, outputs GL_NONE
+        void _getDepthStencilFormatFor( GLenum internalColourFormat, GLenum *depthFormat,
+                                        GLenum *stencilFormat );
 
-            // -----------------------------
-            // Low-level overridden members
-            // -----------------------------
-            /** See
-             RenderSystem
-             */
-            void _useLights(const LightList& lights, unsigned short limit) { };   // Not supported
-            /** See
-             RenderSystem
-             */
-            bool areFixedFunctionLightsInViewSpace() const { return true; }
-            /** See
-             RenderSystem
-             */
-            void _setWorldMatrix(const Matrix4 &m);
-            /** See
-             RenderSystem
-             */
-            void _setViewMatrix(const Matrix4 &m);
-            /** See
-             RenderSystem
-             */
-            void _setProjectionMatrix(const Matrix4 &m);
-            /** See
-             RenderSystem
-             */
-            void _setSurfaceParams(const ColourValue &ambient,
-                                   const ColourValue &diffuse, const ColourValue &specular,
-                                   const ColourValue &emissive, Real shininess,
-                                   TrackVertexColourType tracking) {}
-            /** See
-             RenderSystem
-             */
-            void _setPointParameters(Real size, bool attenuationEnabled,
-                                     Real constant, Real linear, Real quadratic, Real minSize, Real maxSize) {}
-            /** See
-             RenderSystem
-             */
-            void _setPointSpritesEnabled(bool enabled) {}
-            /** See
-             RenderSystem
-             */
-            void _setTexture(size_t unit, bool enabled, Texture *tex, bool bDepthReadOnly);
-            /** See
-             RenderSystem
-             */
-            void _setTextureCoordCalculation(size_t stage, TexCoordCalcMethod m,
-                    const Frustum* frustum = 0) { };   // Not supported
-            /** See
-             RenderSystem
-             */
-            void _setTextureBlendMode(size_t stage, const LayerBlendModeEx& bm) { };   // Not supported
-            /** See
-             RenderSystem
-             */
-            void _setTextureMatrix(size_t stage, const Matrix4& xform) { };   // Not supported
-        
-            virtual void queueBindUAV( uint32 slot, TexturePtr texture,
-                                       ResourceAccess::ResourceAccess access = ResourceAccess::ReadWrite,
-                                       int32 mipmapLevel = 0, int32 textureArrayIndex = 0,
-                                       PixelFormat pixelFormat = PF_UNKNOWN );
-            virtual void queueBindUAV( uint32 slot, UavBufferPacked *buffer,
-                                       ResourceAccess::ResourceAccess access = ResourceAccess::ReadWrite,
-                                       size_t offset = 0, size_t sizeBytes = 0 );
+        virtual MultiRenderTarget *createMultiRenderTarget( const String &name );
 
-            virtual void clearUAVs();
- 
-            virtual void _bindTextureUavCS( uint32 slot, Texture *texture,
-                                            ResourceAccess::ResourceAccess access,
-                                            int32 mipmapLevel, int32 textureArrayIndex,
-                                            PixelFormat pixelFormat );
-            virtual void _setTextureCS( uint32 slot, bool enabled, Texture *texPtr );
-            virtual void _setHlmsSamplerblockCS( uint8 texUnit, const HlmsSamplerblock *samplerblock );
+        /** See
+          RenderSystem
+         */
+        void destroyRenderWindow( RenderWindow *pWin );
+        /** See
+          RenderSystem
+         */
+        String getErrorDescription( long errorNumber ) const;
+        /** See
+          RenderSystem
+         */
+        VertexElementType getColourVertexElementType() const;
 
-            /** See
-             RenderSystem
-             */
-            void _setViewport(Viewport *vp);
+        // -----------------------------
+        // Low-level overridden members
+        // -----------------------------
+        /** See
+         RenderSystem
+         */
+        void _useLights( const LightList &lights, unsigned short limit ){};  // Not supported
+        /** See
+         RenderSystem
+         */
+        bool areFixedFunctionLightsInViewSpace() const { return true; }
+        /** See
+         RenderSystem
+         */
+        void _setWorldMatrix( const Matrix4 &m );
+        /** See
+         RenderSystem
+         */
+        void _setViewMatrix( const Matrix4 &m );
+        /** See
+         RenderSystem
+         */
+        void _setProjectionMatrix( const Matrix4 &m );
+        /** See
+         RenderSystem
+         */
+        void _setSurfaceParams( const ColourValue &ambient, const ColourValue &diffuse,
+                                const ColourValue &specular, const ColourValue &emissive, Real shininess,
+                                TrackVertexColourType tracking )
+        {
+        }
+        /** See
+         RenderSystem
+         */
+        void _setPointParameters( Real size, bool attenuationEnabled, Real constant, Real linear,
+                                  Real quadratic, Real minSize, Real maxSize )
+        {
+        }
+        /** See
+         RenderSystem
+         */
+        void _setPointSpritesEnabled( bool enabled ) {}
+        /** See
+         RenderSystem
+         */
+        void _setTexture( size_t unit, bool enabled, Texture *tex, bool bDepthReadOnly );
+        /** See
+         RenderSystem
+         */
+        void _setTextureCoordCalculation( size_t stage, TexCoordCalcMethod m,
+                                          const Frustum *frustum = 0 ){};  // Not supported
+        /** See
+         RenderSystem
+         */
+        void _setTextureBlendMode( size_t stage, const LayerBlendModeEx &bm ){};  // Not supported
+        /** See
+         RenderSystem
+         */
+        void _setTextureMatrix( size_t stage, const Matrix4 &xform ){};  // Not supported
 
-            virtual void _hlmsPipelineStateObjectCreated( HlmsPso *newPso );
-            virtual void _hlmsPipelineStateObjectDestroyed( HlmsPso *pso );
-            virtual void _hlmsMacroblockCreated( HlmsMacroblock *newBlock );
-            virtual void _hlmsMacroblockDestroyed( HlmsMacroblock *block );
-            virtual void _hlmsBlendblockCreated( HlmsBlendblock *newBlock );
-            virtual void _hlmsBlendblockDestroyed( HlmsBlendblock *block );
-            virtual void _hlmsSamplerblockCreated( HlmsSamplerblock *newBlock );
-            virtual void _hlmsSamplerblockDestroyed( HlmsSamplerblock *block );
-            void _setHlmsMacroblock( const HlmsMacroblock *macroblock, const GLES2HlmsPso *pso );
-            void _setHlmsBlendblock( const HlmsBlendblock *blendblock, const GLES2HlmsPso *pso );
-            virtual void _setHlmsSamplerblock( uint8 texUnit, const HlmsSamplerblock *samplerblock );
-            virtual void _setPipelineStateObject( const HlmsPso *pso );
+        virtual void queueBindUAV( uint32 slot, TexturePtr texture,
+                                   ResourceAccess::ResourceAccess access = ResourceAccess::ReadWrite,
+                                   int32 mipmapLevel = 0, int32 textureArrayIndex = 0,
+                                   PixelFormat pixelFormat = PF_UNKNOWN );
+        virtual void queueBindUAV( uint32 slot, UavBufferPacked *buffer,
+                                   ResourceAccess::ResourceAccess access = ResourceAccess::ReadWrite,
+                                   size_t offset = 0, size_t sizeBytes = 0 );
 
-            virtual void _setIndirectBuffer( IndirectBufferPacked *indirectBuffer );
-            virtual void _setComputePso( const HlmsComputePso *pso );
+        virtual void clearUAVs();
 
-            /** See
-             RenderSystem
-             */
-            void _beginFrame();
-            /** See
-             RenderSystem
-             */
-            void _endFrame();
-            /** See
-             RenderSystem
-             */
-            void _setDepthBias(float constantBias, float slopeScaleBias);
-            /** See
-             RenderSystem
-             */
-            void _setDepthBufferCheckEnabled(bool enabled = true);
-            /** See
-             RenderSystem
-             */
-            void _setDepthBufferWriteEnabled(bool enabled = true);
-            /** See
-             RenderSystem
-             */
-            void _makeProjectionMatrix(const Radian& fovy, Real aspect, Real nearPlane, Real farPlane,
-                    Matrix4& dest, bool forGpuProgram = false);
-            /** See
-             RenderSystem
-             */
-            void _makeProjectionMatrix(Real left, Real right, Real bottom, Real top, 
-                    Real nearPlane, Real farPlane, Matrix4& dest, bool forGpuProgram = false);
-            /** See
-             RenderSystem
-             */
-            void _makeOrthoMatrix(const Radian& fovy, Real aspect, Real nearPlane, Real farPlane,
-                    Matrix4& dest, bool forGpuProgram = false);
-            /** See
-             RenderSystem
-             */
-            void _applyObliqueDepthProjection(Matrix4& matrix, const Plane& plane, 
-                    bool forGpuProgram);
-            /** See
-             RenderSystem
-             */
-            void setClipPlane (ushort index, Real A, Real B, Real C, Real D);
-            /** See
-             RenderSystem
-             */
-            void enableClipPlane (ushort index, bool enable);
-            /** See
-             RenderSystem
-             */
-            virtual void setStencilBufferParams( uint32 refValue, const StencilParams &stencilParams );
-            /** See
-             RenderSystem
-             */
-            virtual bool hasAnisotropicMipMapFilter() const { return false; }   
-            /** See
-             RenderSystem
-             */
-            void _render(const v1::RenderOperation& op);
+        virtual void _bindTextureUavCS( uint32 slot, Texture *texture,
+                                        ResourceAccess::ResourceAccess access, int32 mipmapLevel,
+                                        int32 textureArrayIndex, PixelFormat pixelFormat );
+        virtual void _setTextureCS( uint32 slot, bool enabled, Texture *texPtr );
+        virtual void _setHlmsSamplerblockCS( uint8 texUnit, const HlmsSamplerblock *samplerblock );
 
-            virtual void _dispatch( const HlmsComputePso &pso );
+        /** See
+         RenderSystem
+         */
+        void _setViewport( Viewport *vp );
 
-            virtual void _setVertexArrayObject( const VertexArrayObject *vao );
-            virtual void _render( const CbDrawCallIndexed *cmd );
-            virtual void _render( const CbDrawCallStrip *cmd );
-            virtual void _renderEmulated( const CbDrawCallIndexed *cmd );
-            virtual void _renderEmulated( const CbDrawCallStrip *cmd );
-            virtual void _renderEmulatedNoBaseInstance( const CbDrawCallIndexed *cmd );
-            virtual void _renderEmulatedNoBaseInstance( const CbDrawCallStrip *cmd );
+        virtual void _hlmsPipelineStateObjectCreated( HlmsPso *newPso );
+        virtual void _hlmsPipelineStateObjectDestroyed( HlmsPso *pso );
+        virtual void _hlmsMacroblockCreated( HlmsMacroblock *newBlock );
+        virtual void _hlmsMacroblockDestroyed( HlmsMacroblock *block );
+        virtual void _hlmsBlendblockCreated( HlmsBlendblock *newBlock );
+        virtual void _hlmsBlendblockDestroyed( HlmsBlendblock *block );
+        virtual void _hlmsSamplerblockCreated( HlmsSamplerblock *newBlock );
+        virtual void _hlmsSamplerblockDestroyed( HlmsSamplerblock *block );
+        void _setHlmsMacroblock( const HlmsMacroblock *macroblock, const GLES2HlmsPso *pso );
+        void _setHlmsBlendblock( const HlmsBlendblock *blendblock, const GLES2HlmsPso *pso );
+        virtual void _setHlmsSamplerblock( uint8 texUnit, const HlmsSamplerblock *samplerblock );
+        virtual void _setPipelineStateObject( const HlmsPso *pso );
 
-            virtual void _startLegacyV1Rendering();
-            virtual void _setRenderOperation( const v1::CbRenderOp *cmd );
-            virtual void _render( const v1::CbDrawCallIndexed *cmd );
-            virtual void _render( const v1::CbDrawCallStrip *cmd );
-            virtual void _renderNoBaseInstance( const v1::CbDrawCallIndexed *cmd );
-            virtual void _renderNoBaseInstance( const v1::CbDrawCallStrip *cmd );
+        virtual void _setIndirectBuffer( IndirectBufferPacked *indirectBuffer );
+        virtual void _setComputePso( const HlmsComputePso *pso );
 
-            virtual void clearFrameBuffer(unsigned int buffers,
-                const ColourValue& colour = ColourValue::Black,
-                Real depth = 1.0f, unsigned short stencil = 0);
-            virtual void discardFrameBuffer( unsigned int buffers );
-            HardwareOcclusionQuery* createHardwareOcclusionQuery();
-            Real getHorizontalTexelOffset() { return 0.0; }               // No offset in GL
-            Real getVerticalTexelOffset() { return 0.0; }                 // No offset in GL
-            Real getMinimumDepthInputValue() { return -1.0f; }            // Range [-1.0f, 1.0f]
-            Real getMaximumDepthInputValue() { return 1.0f; }             // Range [-1.0f, 1.0f]
-            OGRE_MUTEX(mThreadInitMutex);
-            void registerThread();
-            void unregisterThread();
-            void preExtraThreadsStarted();
-            void postExtraThreadsStarted();
-            void setClipPlanesImpl(const Ogre::PlaneList& planeList) {}
+        /** See
+         RenderSystem
+         */
+        void _beginFrame();
+        /** See
+         RenderSystem
+         */
+        void _endFrame();
+        /** See
+         RenderSystem
+         */
+        void _setDepthBias( float constantBias, float slopeScaleBias );
+        /** See
+         RenderSystem
+         */
+        void _setDepthBufferCheckEnabled( bool enabled = true );
+        /** See
+         RenderSystem
+         */
+        void _setDepthBufferWriteEnabled( bool enabled = true );
+        /** See
+         RenderSystem
+         */
+        void _makeProjectionMatrix( const Radian &fovy, Real aspect, Real nearPlane, Real farPlane,
+                                    Matrix4 &dest, bool forGpuProgram = false );
+        /** See
+         RenderSystem
+         */
+        void _makeProjectionMatrix( Real left, Real right, Real bottom, Real top, Real nearPlane,
+                                    Real farPlane, Matrix4 &dest, bool forGpuProgram = false );
+        /** See
+         RenderSystem
+         */
+        void _makeOrthoMatrix( const Radian &fovy, Real aspect, Real nearPlane, Real farPlane,
+                               Matrix4 &dest, bool forGpuProgram = false );
+        /** See
+         RenderSystem
+         */
+        void _applyObliqueDepthProjection( Matrix4 &matrix, const Plane &plane, bool forGpuProgram );
+        /** See
+         RenderSystem
+         */
+        void setClipPlane( ushort index, Real A, Real B, Real C, Real D );
+        /** See
+         RenderSystem
+         */
+        void enableClipPlane( ushort index, bool enable );
+        /** See
+         RenderSystem
+         */
+        virtual void setStencilBufferParams( uint32 refValue, const StencilParams &stencilParams );
+        /** See
+         RenderSystem
+         */
+        virtual bool hasAnisotropicMipMapFilter() const { return false; }
+        /** See
+         RenderSystem
+         */
+        void _render( const v1::RenderOperation &op );
 
-            // ----------------------------------
-            // GLES2RenderSystem specific members
-            // ----------------------------------
-            bool hasMinGLVersion(int major, int minor) const;
-            bool checkExtension(const String& ext) const;
-        
-            /** Returns the main context */
-            GLES2Context* _getMainContext() { return mMainContext; }
-            /** Unregister a render target->context mapping. If the context of target 
-             is the current context, change the context to the main context so it
-             can be destroyed safely. 
-             
-             @note This is automatically called by the destructor of 
-             GLES2Context.
-             */
-            void _unregisterContext(GLES2Context *context);
-            /** Switch GL context, dealing with involved internal cached states too
-             */
-            void _switchContext(GLES2Context *context);
-            /** One time initialization for the RenderState of a context. Things that
-             only need to be set once, like the LightingModel can be defined here.
-             */
-            void _oneTimeContextInitialization();
-            void initialiseContext(RenderWindow* primary);
-            /**
-             * Set current render target to target, enabling its GL context if needed
-             */
-            void _setRenderTarget(RenderTarget *target, uint8 viewportRenderTargetFlags);
+        virtual void _dispatch( const HlmsComputePso &pso );
 
-            GLES2Support* getGLES2Support() { return mGLSupport; }
-            GLint convertCompareFunction(CompareFunction func) const;
-            GLint convertStencilOp(StencilOperation op, bool invert = false) const;
+        virtual void _setVertexArrayObject( const VertexArrayObject *vao );
+        virtual void _render( const CbDrawCallIndexed *cmd );
+        virtual void _render( const CbDrawCallStrip *cmd );
+        virtual void _renderEmulated( const CbDrawCallIndexed *cmd );
+        virtual void _renderEmulated( const CbDrawCallStrip *cmd );
+        virtual void _renderEmulatedNoBaseInstance( const CbDrawCallIndexed *cmd );
+        virtual void _renderEmulatedNoBaseInstance( const CbDrawCallStrip *cmd );
 
-            void bindGpuProgramParameters(GpuProgramType gptype, GpuProgramParametersSharedPtr params, uint16 mask);
-            void bindGpuProgramPassIterationParameters(GpuProgramType gptype);
+        virtual void _startLegacyV1Rendering();
+        virtual void _setRenderOperation( const v1::CbRenderOp *cmd );
+        virtual void _render( const v1::CbDrawCallIndexed *cmd );
+        virtual void _render( const v1::CbDrawCallStrip *cmd );
+        virtual void _renderNoBaseInstance( const v1::CbDrawCallIndexed *cmd );
+        virtual void _renderNoBaseInstance( const v1::CbDrawCallStrip *cmd );
 
-            void _setSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor, SceneBlendOperation op );
-            void _setSeparateSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor, SceneBlendFactor sourceFactorAlpha, SceneBlendFactor destFactorAlpha, SceneBlendOperation op, SceneBlendOperation alphaOp );
-            /// @copydoc RenderSystem::getDisplayMonitorCount
-            unsigned int getDisplayMonitorCount() const;
+        virtual void clearFrameBuffer( unsigned int buffers,
+                                       const ColourValue &colour = ColourValue::Black, Real depth = 1.0f,
+                                       unsigned short stencil = 0 );
+        virtual void discardFrameBuffer( unsigned int buffers );
+        HardwareOcclusionQuery *createHardwareOcclusionQuery();
+        Real getHorizontalTexelOffset() { return 0.0; }     // No offset in GL
+        Real getVerticalTexelOffset() { return 0.0; }       // No offset in GL
+        Real getMinimumDepthInputValue() { return -1.0f; }  // Range [-1.0f, 1.0f]
+        Real getMaximumDepthInputValue() { return 1.0f; }   // Range [-1.0f, 1.0f]
+        OGRE_MUTEX( mThreadInitMutex );
+        void registerThread();
+        void unregisterThread();
+        void preExtraThreadsStarted();
+        void postExtraThreadsStarted();
+        void setClipPlanesImpl( const Ogre::PlaneList &planeList ) {}
 
-            void _setSceneBlendingOperation(SceneBlendOperation op);
-            void _setSeparateSceneBlendingOperation(SceneBlendOperation op, SceneBlendOperation alphaOp);
+        // ----------------------------------
+        // GLES2RenderSystem specific members
+        // ----------------------------------
+        bool hasMinGLVersion( int major, int minor ) const;
+        bool checkExtension( const String &ext ) const;
 
-            void _destroyDepthBuffer(RenderWindow* pRenderWnd);
-        
-            /// @copydoc RenderSystem::beginProfileEvent
-            virtual void beginProfileEvent( const String &eventName );
-            
-            /// @copydoc RenderSystem::endProfileEvent
-            virtual void endProfileEvent();
-            
-            /// @copydoc RenderSystem::markProfileEvent
-            virtual void markProfileEvent( const String &eventName );
+        /** Returns the main context */
+        GLES2Context *_getMainContext() { return mMainContext; }
+        /** Unregister a render target->context mapping. If the context of target
+         is the current context, change the context to the main context so it
+         can be destroyed safely.
+
+         @note This is automatically called by the destructor of
+         GLES2Context.
+         */
+        void _unregisterContext( GLES2Context *context );
+        /** Switch GL context, dealing with involved internal cached states too
+         */
+        void _switchContext( GLES2Context *context );
+        /** One time initialization for the RenderState of a context. Things that
+         only need to be set once, like the LightingModel can be defined here.
+         */
+        void _oneTimeContextInitialization();
+        void initialiseContext( RenderWindow *primary );
+        /**
+         * Set current render target to target, enabling its GL context if needed
+         */
+        void _setRenderTarget( RenderTarget *target, uint8 viewportRenderTargetFlags );
+
+        GLES2Support *getGLES2Support() { return mGLSupport; }
+        GLint convertCompareFunction( CompareFunction func ) const;
+        GLint convertStencilOp( StencilOperation op, bool invert = false ) const;
+
+        void bindGpuProgramParameters( GpuProgramType gptype, GpuProgramParametersSharedPtr params,
+                                       uint16 mask );
+        void bindGpuProgramPassIterationParameters( GpuProgramType gptype );
+
+        void _setSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor,
+                                SceneBlendOperation op );
+        void _setSeparateSceneBlending( SceneBlendFactor sourceFactor, SceneBlendFactor destFactor,
+                                        SceneBlendFactor sourceFactorAlpha,
+                                        SceneBlendFactor destFactorAlpha, SceneBlendOperation op,
+                                        SceneBlendOperation alphaOp );
+        /// @copydoc RenderSystem::getDisplayMonitorCount
+        unsigned int getDisplayMonitorCount() const;
+
+        void _setSceneBlendingOperation( SceneBlendOperation op );
+        void _setSeparateSceneBlendingOperation( SceneBlendOperation op, SceneBlendOperation alphaOp );
+
+        void _destroyDepthBuffer( RenderWindow *pRenderWnd );
+
+        /// @copydoc RenderSystem::beginProfileEvent
+        virtual void beginProfileEvent( const String &eventName );
+
+        /// @copydoc RenderSystem::endProfileEvent
+        virtual void endProfileEvent();
+
+        /// @copydoc RenderSystem::markProfileEvent
+        virtual void markProfileEvent( const String &eventName );
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID || OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
-            void resetRenderer(RenderWindow* pRenderWnd);
-        
-            static GLES2ManagedResourceManager* getResourceManager();
+        void resetRenderer( RenderWindow *pRenderWnd );
+
+        static GLES2ManagedResourceManager *getResourceManager();
+
     private:
-            static GLES2ManagedResourceManager* mResourceManager;
+        static GLES2ManagedResourceManager *mResourceManager;
 #endif
 
-            virtual void initGPUProfiling();
-            virtual void deinitGPUProfiling();
-            virtual void beginGPUSampleProfile( const String &name, uint32 *hashCache );
-            virtual void endGPUSampleProfile( const String &name );
+        virtual void initGPUProfiling();
+        virtual void deinitGPUProfiling();
+        virtual void beginGPUSampleProfile( const String &name, uint32 *hashCache );
+        virtual void endGPUSampleProfile( const String &name );
     };
-}
+}  // namespace Ogre
 
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2Texture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2Texture.h
@@ -49,7 +49,6 @@ namespace Ogre {
             virtual ~GLES2Texture();
 
             void createRenderTexture();
-            /// @copydoc Texture::getBuffer
             v1::HardwarePixelBufferSharedPtr getBuffer(size_t face, size_t mipmap);
 
             // Takes the OGRE texture type (1d/2d/3d/cube) and returns the appropriate GL one

--- a/RenderSystems/GLES2/include/OgreGLES2Texture.h
+++ b/RenderSystems/GLES2/include/OgreGLES2Texture.h
@@ -29,87 +29,84 @@ THE SOFTWARE.
 #ifndef __GLES2Texture_H__
 #define __GLES2Texture_H__
 
+#include "OgreGLES2ManagedResource.h"
 #include "OgreGLES2Prerequisites.h"
 #include "OgreGLES2Support.h"
+#include "OgreHardwarePixelBuffer.h"
 #include "OgrePlatform.h"
 #include "OgreRenderTexture.h"
 #include "OgreTexture.h"
-#include "OgreHardwarePixelBuffer.h"
-#include "OgreGLES2ManagedResource.h"
 
-namespace Ogre {
+namespace Ogre
+{
     class _OgreGLES2Export GLES2Texture : public Texture MANAGED_RESOURCE
     {
-        public:
-            // Constructor
-            GLES2Texture(ResourceManager* creator, const String& name, ResourceHandle handle,
-                const String& group, bool isManual, ManualResourceLoader* loader, 
-                GLES2Support& support);
+    public:
+        // Constructor
+        GLES2Texture( ResourceManager *creator, const String &name, ResourceHandle handle,
+                      const String &group, bool isManual, ManualResourceLoader *loader,
+                      GLES2Support &support );
 
-            virtual ~GLES2Texture();
+        virtual ~GLES2Texture();
 
-            void createRenderTexture();
-            v1::HardwarePixelBufferSharedPtr getBuffer(size_t face, size_t mipmap);
+        void createRenderTexture();
+        v1::HardwarePixelBufferSharedPtr getBuffer( size_t face, size_t mipmap );
 
-            // Takes the OGRE texture type (1d/2d/3d/cube) and returns the appropriate GL one
-            GLenum getGLES2TextureTarget() const;
+        // Takes the OGRE texture type (1d/2d/3d/cube) and returns the appropriate GL one
+        GLenum getGLES2TextureTarget() const;
 
-            GLuint getGLID() const
-            {
-                return mTextureID;
-            }
-            
-            void getCustomAttribute(const String& name, void* pData);
+        GLuint getGLID() const { return mTextureID; }
 
-        protected:
-            /// @copydoc Texture::createInternalResourcesImpl
-            void createInternalResourcesImpl();
-            /// @copydoc Resource::prepareImpl
-            void prepareImpl();
-            /// @copydoc Resource::unprepareImpl
-            void unprepareImpl();
-            /// @copydoc Resource::loadImpl
-            void loadImpl();
-            /// @copydoc Resource::freeInternalResourcesImpl
-            void freeInternalResourcesImpl();
+        void getCustomAttribute( const String &name, void *pData );
 
-            /** Internal method, create GLHardwarePixelBuffers for every face and
-             mipmap level. This method must be called after the GL texture object was created,
-             the number of mipmaps was set (GL_TEXTURE_MAX_LEVEL) and glTexImageXD was called to
-             actually allocate the buffer
-             */
-            void _createSurfaceList();
+    protected:
+        /// @copydoc Texture::createInternalResourcesImpl
+        void createInternalResourcesImpl();
+        /// @copydoc Resource::prepareImpl
+        void prepareImpl();
+        /// @copydoc Resource::unprepareImpl
+        void unprepareImpl();
+        /// @copydoc Resource::loadImpl
+        void loadImpl();
+        /// @copydoc Resource::freeInternalResourcesImpl
+        void freeInternalResourcesImpl();
 
-            virtual void _autogenerateMipmaps();
+        /** Internal method, create GLHardwarePixelBuffers for every face and
+         mipmap level. This method must be called after the GL texture object was created,
+         the number of mipmaps was set (GL_TEXTURE_MAX_LEVEL) and glTexImageXD was called to
+         actually allocate the buffer
+         */
+        void _createSurfaceList();
 
-            /// Used to hold images between calls to prepare and load.
-            typedef SharedPtr<vector<Image>::type > LoadedImages;
+        virtual void _autogenerateMipmaps();
 
-            /** Vector of images that were pulled from disk by
-             prepareLoad but have yet to be pushed into texture memory
-             by loadImpl.  Images should be deleted by loadImpl and unprepareImpl.
-             */
-            LoadedImages mLoadedImages;
+        /// Used to hold images between calls to prepare and load.
+        typedef SharedPtr<vector<Image>::type> LoadedImages;
 
-            /// Create gl texture
-            void _createGLTexResource();
-        
+        /** Vector of images that were pulled from disk by
+         prepareLoad but have yet to be pushed into texture memory
+         by loadImpl.  Images should be deleted by loadImpl and unprepareImpl.
+         */
+        LoadedImages mLoadedImages;
+
+        /// Create gl texture
+        void _createGLTexResource();
+
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID || OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
-            /** See AndroidResource. */
-            virtual void notifyOnContextLost();
-        
-            /** See AndroidResource. */
-            virtual void notifyOnContextReset();
+        /** See AndroidResource. */
+        virtual void notifyOnContextLost();
+
+        /** See AndroidResource. */
+        virtual void notifyOnContextReset();
 #endif
 
-            GLuint mTextureID;
-            GLES2Support& mGLSupport;
-            
-            /// Vector of pointers to subsurfaces
-            typedef vector<v1::HardwarePixelBufferSharedPtr>::type SurfaceList;
-            SurfaceList mSurfaceList;
+        GLuint mTextureID;
+        GLES2Support &mGLSupport;
 
+        /// Vector of pointers to subsurfaces
+        typedef vector<v1::HardwarePixelBufferSharedPtr>::type SurfaceList;
+        SurfaceList mSurfaceList;
     };
-}
+}  // namespace Ogre
 
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2TextureBuffer.h
+++ b/RenderSystems/GLES2/include/OgreGLES2TextureBuffer.h
@@ -44,10 +44,8 @@ namespace v1 {
                            GLint format, GLint face, GLint level, Usage usage, bool softwareMipmap, bool writeGamma, uint fsaa);
         virtual ~GLES2TextureBuffer();
 
-        /// @copydoc HardwarePixelBuffer::bindToFramebuffer
         virtual void bindToFramebuffer(GLenum attachment, uint32 zoffset);
 
-        /// @copydoc HardwarePixelBuffer::getRenderTarget
         RenderTexture* getRenderTarget(size_t slice);
 
         /// Upload a box of pixels to this buffer on the card
@@ -68,7 +66,6 @@ namespace v1 {
         // Copy from framebuffer
         void copyFromFramebuffer(uint32 zoffset);
 
-        /// @copydoc HardwarePixelBuffer::blit
         void blit(const HardwarePixelBufferSharedPtr &src, const Box &srcBox, const Box &dstBox);
         // Blitting implementation
         void blitFromTexture(GLES2TextureBuffer *src, const Box &srcBox, const Box &dstBox);

--- a/RenderSystems/GLES2/include/OgreGLES2TextureBuffer.h
+++ b/RenderSystems/GLES2/include/OgreGLES2TextureBuffer.h
@@ -31,71 +31,71 @@
 
 #include "OgreGLES2HardwarePixelBuffer.h"
 
-namespace Ogre {
-namespace v1 {
-    /** Texture surface.
-     */
-    class _OgreGLES2Export GLES2TextureBuffer: public GLES2HardwarePixelBuffer
+namespace Ogre
+{
+    namespace v1
     {
-    public:
-        /** Texture constructor */
-        GLES2TextureBuffer(const String &baseName, GLenum target, GLuint id,
-                           GLint width, GLint height, GLint depth, GLint internalFormat,
-                           GLint format, GLint face, GLint level, Usage usage, bool softwareMipmap, bool writeGamma, uint fsaa);
-        virtual ~GLES2TextureBuffer();
-
-        virtual void bindToFramebuffer(GLenum attachment, uint32 zoffset);
-
-        RenderTexture* getRenderTarget(size_t slice);
-
-        /// Upload a box of pixels to this buffer on the card
-        virtual void upload(const PixelBox &data, const Box &dest);
-
-        /// Download a box of pixels from the card
-        virtual void download(const PixelBox &data);
-
-        /// Hardware implementation of blitFromMemory
-        virtual void blitFromMemory(const PixelBox &src_orig, const Box &dstBox);
-
-        /// Notify TextureBuffer of destruction of render target
-        void _clearSliceRTT(size_t zoffset)
+        /** Texture surface.
+         */
+        class _OgreGLES2Export GLES2TextureBuffer : public GLES2HardwarePixelBuffer
         {
-            mSliceTRT[zoffset] = 0;
-        }
+        public:
+            /** Texture constructor */
+            GLES2TextureBuffer( const String &baseName, GLenum target, GLuint id, GLint width,
+                                GLint height, GLint depth, GLint internalFormat, GLint format,
+                                GLint face, GLint level, Usage usage, bool softwareMipmap,
+                                bool writeGamma, uint fsaa );
+            virtual ~GLES2TextureBuffer();
 
-        // Copy from framebuffer
-        void copyFromFramebuffer(uint32 zoffset);
+            virtual void bindToFramebuffer( GLenum attachment, uint32 zoffset );
 
-        void blit(const HardwarePixelBufferSharedPtr &src, const Box &srcBox, const Box &dstBox);
-        // Blitting implementation
-        void blitFromTexture(GLES2TextureBuffer *src, const Box &srcBox, const Box &dstBox);
-        
+            RenderTexture *getRenderTarget( size_t slice );
+
+            /// Upload a box of pixels to this buffer on the card
+            virtual void upload( const PixelBox &data, const Box &dest );
+
+            /// Download a box of pixels from the card
+            virtual void download( const PixelBox &data );
+
+            /// Hardware implementation of blitFromMemory
+            virtual void blitFromMemory( const PixelBox &src_orig, const Box &dstBox );
+
+            /// Notify TextureBuffer of destruction of render target
+            void _clearSliceRTT( size_t zoffset ) { mSliceTRT[zoffset] = 0; }
+
+            // Copy from framebuffer
+            void copyFromFramebuffer( uint32 zoffset );
+
+            void blit( const HardwarePixelBufferSharedPtr &src, const Box &srcBox, const Box &dstBox );
+            // Blitting implementation
+            void blitFromTexture( GLES2TextureBuffer *src, const Box &srcBox, const Box &dstBox );
+
 #if OGRE_PLATFORM == OGRE_PLATFORM_ANDROID || OGRE_PLATFORM == OGRE_PLATFORM_EMSCRIPTEN
-    // Friends.
-    protected:
-        friend class GLES2Texture;
-            
-        void updateTextureId(GLuint textureID);
+            // Friends.
+        protected:
+            friend class GLES2Texture;
+
+            void updateTextureId( GLuint textureID );
 #endif
-            
-    protected:
-        // In case this is a texture level
-        GLenum mTarget;
-        GLenum mFaceTarget; // same as mTarget in case of GL_TEXTURE_xD, but cubemap face for cubemaps
-        GLuint mTextureID;
-        GLuint mBufferId;
-        GLint mFace;
-        GLint mLevel;
-        bool mSoftwareMipmap;
-            
-        typedef vector<RenderTexture*>::type SliceTRT;
-        SliceTRT mSliceTRT;
 
-        void buildMipmaps(const PixelBox &data);
-    };
+        protected:
+            // In case this is a texture level
+            GLenum mTarget;
+            GLenum
+                mFaceTarget;  // same as mTarget in case of GL_TEXTURE_xD, but cubemap face for cubemaps
+            GLuint mTextureID;
+            GLuint mBufferId;
+            GLint mFace;
+            GLint mLevel;
+            bool mSoftwareMipmap;
 
-}
-}
+            typedef vector<RenderTexture *>::type SliceTRT;
+            SliceTRT mSliceTRT;
+
+            void buildMipmaps( const PixelBox &data );
+        };
+
+    }  // namespace v1
+}  // namespace Ogre
 
 #endif
- 

--- a/RenderSystems/GLES2/include/OgreGLES2TextureManager.h
+++ b/RenderSystems/GLES2/include/OgreGLES2TextureManager.h
@@ -30,38 +30,40 @@ THE SOFTWARE.
 #define __GLES2TextureManager_H__
 
 #include "OgreGLES2Prerequisites.h"
-#include "OgreTextureManager.h"
-#include "OgreGLES2Texture.h"
 #include "OgreGLES2Support.h"
+#include "OgreGLES2Texture.h"
+#include "OgreTextureManager.h"
 
-namespace Ogre {
+namespace Ogre
+{
     /** GL ES-specific implementation of a TextureManager */
     class _OgreGLES2Export GLES2TextureManager : public TextureManager
     {
-        public:
-            GLES2TextureManager(GLES2Support& support);
-            virtual ~GLES2TextureManager();
+    public:
+        GLES2TextureManager( GLES2Support &support );
+        virtual ~GLES2TextureManager();
 
-            GLuint getWarningTextureID() { return mWarningTextureID; }
+        GLuint getWarningTextureID() { return mWarningTextureID; }
 
-            PixelFormat getNativeFormat(TextureType ttype, PixelFormat format, int usage);
+        PixelFormat getNativeFormat( TextureType ttype, PixelFormat format, int usage );
 
-            bool isHardwareFilteringSupported(TextureType ttype, PixelFormat format, int usage,
-                                              bool preciseFormatOnly = false);
+        bool isHardwareFilteringSupported( TextureType ttype, PixelFormat format, int usage,
+                                           bool preciseFormatOnly = false );
+
     protected:
         friend class GLES2RenderSystem;
-        
+
         /// @copydoc ResourceManager::createImpl
-        Resource* createImpl(const String& name, ResourceHandle handle,
-                             const String& group, bool isManual, ManualResourceLoader* loader, 
-                             const NameValuePairList* createParams);
-        
+        Resource *createImpl( const String &name, ResourceHandle handle, const String &group,
+                              bool isManual, ManualResourceLoader *loader,
+                              const NameValuePairList *createParams );
+
         /// Internal method to create a warning texture (bound when a texture unit is blank)
         void createWarningTexture();
-        
-        GLES2Support& mGLSupport;
+
+        GLES2Support &mGLSupport;
         GLuint mWarningTextureID;
     };
-}
+}  // namespace Ogre
 
 #endif

--- a/RenderSystems/GLES2/include/OgreGLES2TextureManager.h
+++ b/RenderSystems/GLES2/include/OgreGLES2TextureManager.h
@@ -44,10 +44,8 @@ namespace Ogre {
 
             GLuint getWarningTextureID() { return mWarningTextureID; }
 
-            /// @copydoc TextureManager::getNativeFormat
             PixelFormat getNativeFormat(TextureType ttype, PixelFormat format, int usage);
 
-            /// @copydoc TextureManager::isHardwareFilteringSupported
             bool isHardwareFilteringSupported(TextureType ttype, PixelFormat format, int usage,
                                               bool preciseFormatOnly = false);
     protected:

--- a/RenderSystems/Vulkan/include/OgreVulkanRootLayout.h
+++ b/RenderSystems/Vulkan/include/OgreVulkanRootLayout.h
@@ -133,14 +133,14 @@ namespace Ogre
         using RootLayout::getDescBindingRanges;
         using RootLayout::validateArrayBindings;
 
-        /// @copydoc VulkanRootLayout::copyFrom
+        /// @copydoc RootLayout::copyFrom
         void copyFrom( const RootLayout &rootLayout, bool bIncludeArrayBindings = true );
 
         /// Performs outRootLayout.copyFrom( this )
         /// This function is necessary because RootLayout is a protected base class
         void copyTo( RootLayout &outRootLayout, bool bIncludeArrayBindings );
 
-        /// @copydoc VulkanRootLayout::parseRootLayout
+        /// @copydoc RootLayout::parseRootLayout
         void parseRootLayout( const char *rootLayout, const bool bCompute, const String &filename );
 
         /** Generates all the macros for compiling shaders, based on our layout


### PR DESCRIPTION
In most cases, an @copydoc target warning could be corrected by just updating the name of the target.

In a few cases, the target is a protected method, which we are currently not generating documentation for, so I literally copied the documentation.

And in some cases, the target seems to be a method that no longer exists, so I could see nothing to do but remove the @copydoc.