### PR TITLE
fix doxygen warnings about explicit link requests

### DIFF
--- a/Components/Hlms/Unlit/include/OgreHlmsUnlitDatablock.h
+++ b/Components/Hlms/Unlit/include/OgreHlmsUnlitDatablock.h
@@ -93,17 +93,17 @@ namespace Ogre
                 Default: Absent
                 Default (when present): diffuse 1 1 1 1
 
-            + diffuse_map [texture name] [#uv]
+            + diffuse_map [texture name] [\#uv]
                 Name of the diffuse texture for the base image (optional, otherwise a dummy is set)
-                The #uv parameter is optional, and specifies the texcoord set that will
+                The \#uv parameter is optional, and specifies the texcoord set that will
                 be used. Valid range is [0; 8)
                 If the Renderable doesn't have enough UV texcoords, HLMS will throw an exception.
 
                 Note: The UV set is evaluated when creating the Renderable cache.
 
-            + diffuse_map1 [texture name] [blendmode] [#uv]
+            + diffuse_map1 [texture name] [blendmode] [\#uv]
                 Name of the diffuse texture that will be layered on top of the base image.
-                The #uv parameter is optional. Valid range is [0; 8)
+                The \#uv parameter is optional. Valid range is [0; 8)
                 The blendmode parameter is optional. Valid values are:
                     NormalNonPremul, NormalPremul, Add, Subtract, Multiply,
                     Multiply2x, Screen, Overlay, Lighten, Darken, GrainExtract,
@@ -121,7 +121,7 @@ namespace Ogre
                 Note that not all mobile HW supports 16 textures at the same time, thus we will
                 just cut/ignore the extra textures that won't fit (we log a warning though).
 
-			+ animate <#tex_unit> [<#tex_unit> <#tex_unit> ... <#tex_unit>]
+			+ animate <\#tex_unit> [<\#tex_unit> <\#tex_unit> ... <\#tex_unit>]
                 Enables texture animation through a 4x4 matrix for the specified textures.
                 Default: All texture animation/manipulation disabled.
                 Example: animate 0 1 2 3 4 14 15

--- a/OgreMain/include/OgreHighLevelGpuProgram.h
+++ b/OgreMain/include/OgreHighLevelGpuProgram.h
@@ -147,27 +147,31 @@ namespace Ogre
 
         /** Whether we should parse the source code looking for include files and
             embedding the file. Disabled by default to avoid slowing down when
-            #include is not used. Not needed if the API natively supports it (D3D11).
+            `#include` is not used. Not needed if the API natively supports it (D3D11).
         @remarks
-            Single line comments are supported:
-                // #include "MyFile.h" --> won't be included.
-
-            Block comment lines are not supported, but may not matter if
-            the included file does not close the block:
-                / *
-                    #include "MyFile.h" --> file will be included anyway.
-                * /
-
-            Preprocessor macros are not supported, but should not matter:
-                #if SOME_MACRO
-                    #include "MyFile.h" --> file will be included anyway.
-                #endif
-        @par
+        Single line comments are supported:
+            @code
+            // #include "MyFile.h" --> won't be included.
+            @endcode
+        Block comment lines are not supported, but may not matter if
+        the included file does not close the block:
+            @code
+            /*
+                #include "MyFile.h" --> file will be included anyway.
+            */
+            @endcode
+        Preprocessor macros are not supported, but should not matter:
+            @code
+            #if SOME_MACRO
+                #include "MyFile.h" --> file will be included anyway.
+            #endif
+            @endcode
+        @remarks
             Recursive includes are supported (e.g. header includes a header)
-        @par
+        @remarks
             Beware included files mess up error reporting (wrong lines)
         @param bEnable
-            True to support #include. Must be toggled before loading the source file.
+            True to support `#include`. Must be toggled before loading the source file.
         */
         void setEnableIncludeHeader( bool bEnable );
         bool getEnableIncludeHeader() const;
@@ -177,7 +181,7 @@ namespace Ogre
             This parser doesn't yet have access to the entire PSO
             (i.e. Pixel Shader can't see Vertex Shader).
 
-            However it's still useful, specially @foreach()
+            However it's still useful, specially \@foreach()
         @remarks
             This is run after setEnableIncludeHeader
         @par

--- a/OgreMain/include/OgreHighLevelGpuProgram.h
+++ b/OgreMain/include/OgreHighLevelGpuProgram.h
@@ -145,6 +145,17 @@ namespace Ogre
         /** @copydoc GpuProgram::_getBindingDelegate */
         GpuProgram *_getBindingDelegate() override { return mAssemblerProgram.get(); }
 
+        // This snippet must not be indented, in order for the documentation
+        // of setEnableIncludeHeader to turn out looking right.  So
+        // clang-format must be prevented from changing it.
+        // clang-format off
+        // [setEnableIncludeHeader-doc-snippet]
+/*
+    #include "MyFile.h" --> file will be included anyway.
+*/
+        // [setEnableIncludeHeader-doc-snippet]
+        // clang-format on
+
         /** Whether we should parse the source code looking for include files and
             embedding the file. Disabled by default to avoid slowing down when
             `#include` is not used. Not needed if the API natively supports it (D3D11).
@@ -155,11 +166,7 @@ namespace Ogre
             @endcode
         Block comment lines are not supported, but may not matter if
         the included file does not close the block:
-            @code
-            /*
-                #include "MyFile.h" --> file will be included anyway.
-            */
-            @endcode
+            @snippet this setEnableIncludeHeader-doc-snippet
         Preprocessor macros are not supported, but should not matter:
             @code
             #if SOME_MACRO

--- a/OgreMain/include/OgreIteratorWrapper.h
+++ b/OgreMain/include/OgreIteratorWrapper.h
@@ -229,7 +229,7 @@ namespace Ogre
         typedef
             typename IteratorWrapper<T, IteratorType, typename T::mapped_type>::PointerType PointerType;
 
-        /// Unused, just to make it clear that map/set::value_type is not a ValueType
+        /// Unused, just to make it clear that `map`/`set::value_type` is not a ValueType
         typedef typename T::value_type PairType;
         /// Type you expect to get by funktions like peekNextKey
         typedef typename T::key_type KeyType;

--- a/RenderSystems/GL3Plus/include/GLSL/OgreGLSLPreprocessor.h
+++ b/RenderSystems/GL3Plus/include/GLSL/OgreGLSLPreprocessor.h
@@ -44,19 +44,18 @@ namespace Ogre
      * if the feature set it provides is enough for you.
      *
      * Here's a list of supported features:
-     * <ul>
-     * <li>Fast memory allocation-less operation (mostly).
-     * <li>Line continuation (backslash-newline) is swallowed.
-     * <li>Line numeration is fully preserved by inserting empty lines where
+     *
+     * - Fast memory allocation-less operation (mostly).
+     * - Line continuation (backslash-newline) is swallowed.
+     * - Line numeration is fully preserved by inserting empty lines where
      *     required. This is crucial if, say, GLSL compiler reports you an error
      *     with a line number.
-     * <li>#define: Parametrized and non-parametrized macros. Invoking a macro with
+     * - \#define: Parametrized and non-parametrized macros. Invoking a macro with
      *     less arguments than it takes assigns empty values to missing arguments.
-     * <li>#undef: Forget defined macros
-     * <li>#ifdef/#ifndef/#else/#endif: Conditional suppression of parts of code.
-     * <li>#if: Supports numeric expression of any complexity, also supports the
+     * - \#undef: Forget defined macros
+     * - \#ifdef/\#ifndef/\#else/\#endif: Conditional suppression of parts of code.
+     * - \#if: Supports numeric expression of any complexity, also supports the
      *     defined() pseudo-function.
-     * <ul>
      */
     class CPreprocessor
     {

--- a/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXGLSupport.h
+++ b/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXGLSupport.h
@@ -135,7 +135,7 @@ namespace Ogre
         bool loadIcon( const String &name, Pixmap *pix, Pixmap *mask );
 
         /**
-         * Get the GLXFBConfig used to create a ::GLXContext
+         * Get the GLXFBConfig used to create a ::%GLXContext
          *
          * @param drawable   GLXContext
          * @returns               GLXFBConfig used to create the context

--- a/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXUtils.h
+++ b/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXUtils.h
@@ -46,7 +46,7 @@ namespace Ogre
         static PFNGLXGETVISUALFROMFBCONFIGPROC getVisualFromFBConfig;
 
         /**
-         * Get the GLXFBConfig used to create a ::GLXContext
+         * Get the GLXFBConfig used to create a ::%GLXContext
          *
          * @param display   X Display
          * @param drawable   GLXContext

--- a/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESPreprocessor.h
+++ b/RenderSystems/GLES2/src/GLSLES/include/OgreGLSLESPreprocessor.h
@@ -44,19 +44,18 @@ namespace Ogre {
      * if the feature set it provides is enough for you.
      *
      * Here's a list of supported features:
-     * <ul>
-     * <li>Fast memory allocation-less operation (mostly).
-     * <li>Line continuation (backslash-newline) is swallowed.
-     * <li>Line numeration is fully preserved by inserting empty lines where
+     *
+     * - Fast memory allocation-less operation (mostly).
+     * - Line continuation (backslash-newline) is swallowed.
+     * - Line numeration is fully preserved by inserting empty lines where
      *     required. This is crucial if, say, GLSL compiler reports you an error
      *     with a line number.
-     * <li>#define: Parametrized and non-parametrized macros. Invoking a macro with
+     * - \#define: Parametrized and non-parametrized macros. Invoking a macro with
      *     less arguments than it takes assigns empty values to missing arguments.
-     * <li>#undef: Forget defined macros
-     * <li>#ifdef/#ifndef/#else/#endif: Conditional suppression of parts of code.
-     * <li>#if: Supports numeric expression of any complexity, also supports the
+     * - \#undef: Forget defined macros
+     * - \#ifdef/\#ifndef/\#else/\#endif: Conditional suppression of parts of code.
+     * - \#if: Supports numeric expression of any complexity, also supports the
      *     defined() pseudo-function.
-     * <ul>
      */
     class CPreprocessor
     {


### PR DESCRIPTION
I went through the doxygen warnings and fixed cases where it said "warning: explicit link request to 'something' could not be resolved".  Also fixed other formatting problems in docs of `HighLevelGpuProgram::setEnableIncludeHeader`.