### PR TITLE
Jw/doxygen arg of @param not found

### DIFF
--- a/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
@@ -616,7 +616,7 @@ namespace Ogre
         float getRefractionStrength() const { return mRefractionStrength; }
 
         /** Sets the strength of the of the clear coat layer and its roughness.
-        @param strength
+        @param clearCoat
             This should be treated as a binary value, set to either 0 or 1. Intermediate values are
             useful to control transitions between parts of the surface that have a clear coat layers and
             parts that don't.

--- a/OgreMain/include/Animation/OgreSkeletonAnimation.h
+++ b/OgreMain/include/Animation/OgreSkeletonAnimation.h
@@ -115,7 +115,7 @@ namespace Ogre
         void setTime( Real time ) { setFrame( time * mFrameRate ); }
 
         /** Sets the animation to a particular frame.
-        @param frames
+        @param frame
             Frame to set to, in frames
         */
         void setFrame( Real frame );

--- a/OgreMain/include/Compositor/OgreCompositorNodeDef.h
+++ b/OgreMain/include/Compositor/OgreCompositorNodeDef.h
@@ -174,7 +174,7 @@ namespace Ogre
             using linked lists or other containers with two level of indirections)
         @remarks
             Calling this function is not obligatory, but recommended
-        @param numPasses
+        @param numOuts
             The number of output channels expected to contain.
         */
         void setNumOutputChannels( size_t numOuts ) { mOutChannelMapping.reserve( numOuts ); }
@@ -206,7 +206,7 @@ namespace Ogre
             than using linked lists or other containers with two level of indirections)
         @remarks
             Calling this function is not obligatory, but recommended
-        @param numPasses
+        @param numOuts
             The number of output buffer channels expected to contain.
         */
         void setNumOutputBufferChannels( size_t numOuts )
@@ -225,7 +225,7 @@ namespace Ogre
             channel name hasn't been set yet (declaration order is important!).
         @param outChannel
             Output channel # to map
-        @param textureName
+        @param bufferName
             Name of the buffer
         */
         void mapOutputBufferChannel( size_t outChannel, IdString bufferName );

--- a/OgreMain/include/Compositor/OgreTextureDefinition.h
+++ b/OgreMain/include/Compositor/OgreTextureDefinition.h
@@ -566,7 +566,7 @@ namespace Ogre
             as we're missing:
                 + Whether the texture is colour or depth
                 + The default depth settings (prefersDepthTexture, depth format, etc)
-                
+
             Use this function to force the given texture to be analyzed at runtime when
             creating the pass.
         @remarks

--- a/OgreMain/include/Compositor/OgreTextureDefinition.h
+++ b/OgreMain/include/Compositor/OgreTextureDefinition.h
@@ -250,7 +250,7 @@ namespace Ogre
             You're assigning an alias named "myRT" to channel Input #0
             For local or global textures, the index parameter documentation
 
-        @param fullName
+        @param name
             The name of the texture. Names are usually valid only throughout this node.
             We need the name, not its hash because we need to validate the global_ prefix
             is used correctly.
@@ -310,7 +310,7 @@ namespace Ogre
         /** Reserves enough memory for all texture definitions
         @remarks
             Calling this function is not obligatory, but recommended
-        @param numPasses
+        @param numTDs
             The number of texture definitions expected to contain.
         */
         void setNumLocalTextureDefinitions( size_t numTDs ) { mLocalTextureDefs.reserve( numTDs ); }
@@ -399,8 +399,6 @@ namespace Ogre
         @param finalTarget
             The final render target (usually the render window) we have to clone parameters from
             (eg. when using auto width & height, or fsaa settings)
-        @param renderSys
-            The RenderSystem to use
         */
         static void recreateResizableTextures01( const TextureDefinitionVec &textureDefs,
                                                  CompositorChannelVec       &inOutTexContainer,
@@ -462,7 +460,7 @@ namespace Ogre
         /** Reserves enough memory for all texture definitions
         @remarks
             Calling this function is not obligatory, but recommended
-        @param numPasses
+        @param numTDs
             The number of texture definitions expected to contain.
         */
         void setNumLocalBufferDefinitions( size_t numTDs ) { mLocalBufferDefs.reserve( numTDs ); }

--- a/OgreMain/include/Compositor/Pass/OgreCompositorPassProvider.h
+++ b/OgreMain/include/Compositor/Pass/OgreCompositorPassProvider.h
@@ -81,7 +81,7 @@ namespace Ogre
         @param customId
             Arbitrary ID in case there is more than one type of custom pass you want to implement.
             Defaults to IdString()
-        @param rtIndex
+        @param parentTargetDef
         @param parentNodeDef
         @return
         */

--- a/OgreMain/include/Compositor/Pass/PassUav/OgreCompositorPassUavDef.h
+++ b/OgreMain/include/Compositor/Pass/PassUav/OgreCompositorPassUavDef.h
@@ -128,7 +128,7 @@ namespace Ogre
             The texture access privileges given to the shader.
         @param mipmapLevel
             The texture mipmap level to use.
-        @param format
+        @param pixelFormat
             Texture format to be read in by shader. This may be different than the bound texture format.
             Will be the same is left as PFG_UNKNOWN
         */

--- a/OgreMain/include/Math/Array/C/OgreArrayMatrix4.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayMatrix4.h
@@ -155,7 +155,7 @@ namespace Ogre
         /** Assigns the value of the other matrix. Does not reference the
             ptr address, but rather perform a memory copy
             @param
-                rkmatrix The other matrix
+                rkMatrix The other matrix
         */
         inline ArrayMatrix4 &operator=( const ArrayMatrix4 &rkMatrix )
         {

--- a/OgreMain/include/Math/Array/C/OgreArrayMatrixAf4x3.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayMatrixAf4x3.h
@@ -115,7 +115,7 @@ namespace Ogre
                 This function is defined in ArrayMatrix4 to avoid including this header into
                 ArrayQuaternion. The idea is that ArrayMatrix4 requires ArrayQuaternion, and
                 ArrayQuaternion requires ArrayVector3. Simple dependency order
-            @param
+            @param q
                 The quaternion to convert from.
         */
         inline void fromQuaternion( const ArrayQuaternion &q );

--- a/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
@@ -220,9 +220,9 @@ namespace Ogre
                 decide between two ArrayQuaternions, i.e. a = Cmov4( b, c ) then
                 @see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayReal mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? this[i] : replacement[i]
@@ -237,11 +237,11 @@ namespace Ogre
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
                 @see Cmov4( ArrayReal mask, const ArrayQuaternion &replacement );
                 instead.
-            @param
+            @param arg1
                 First array of Vectors
-            @param
+            @param arg2
                 Second array of Vectors
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? arg1[i] : arg2[i]

--- a/OgreMain/include/Math/Array/C/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayVector3.h
@@ -285,9 +285,9 @@ namespace Ogre
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
                 @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? this[i] : replacement[i]
@@ -307,9 +307,9 @@ namespace Ogre
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
                 @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? this[i] : replacement[i]
@@ -324,11 +324,11 @@ namespace Ogre
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
                 @see Cmov4( ArrayReal mask, const ArrayVector3 &replacement );
                 instead.
-            @param
+            @param arg1
                 First array of Vectors
-            @param
+            @param arg2
                 Second array of Vectors
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? arg1[i] : arg2[i]

--- a/OgreMain/include/Math/Array/C/OgreMathlibC.h
+++ b/OgreMain/include/Math/Array/C/OgreMathlibC.h
@@ -64,7 +64,7 @@ namespace Ogre
         static const ArrayReal MAX_POS;    // Max negative number (x4)
 
         /** Returns the absolute values of each 4 floats
-            @param
+            @param a
                 4 floating point values
             @return
                 abs( a )
@@ -76,11 +76,11 @@ namespace Ogre
                 Will NOT work if any of the arguments contains Infinite
                 or NaNs or non-floating point values. If an exact binary
                 copy is needed, @see CmovRobust
-            @param
+            @param arg1
                 4 floating point values. Can't be NaN or Inf
-            @param
+            @param arg2
                 4 floating point values. Can't be NaN or Inf
-            @param
+            @param mask
                 4 values containing either 0 or 0xffffffff
                 Any other value, the result is undefined
             @return
@@ -115,11 +115,11 @@ namespace Ogre
                 Bypass between Execution Domains, Intel® 64 and IA-32
                 Architectures Optimization Reference Manual Order
                 Number: 248966-026 April (and also Table 2-12)
-            @param
+            @param arg1
                 A value containing 128 bits
-            @param
+            @param arg2
                 A value containing 128 bits
-            @param
+            @param mask
                 Mask, each bit is evaluated
             @return
                 For each bit:

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrix4.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrix4.h
@@ -170,7 +170,7 @@ namespace Ogre
         /** Assigns the value of the other matrix. Does not reference the
             ptr address, but rather perform a memory copy
             @param
-                rkmatrix The other matrix
+                rkMatrix The other matrix
         */
         inline ArrayMatrix4 &operator=( const ArrayMatrix4 &rkMatrix )
         {
@@ -201,7 +201,7 @@ namespace Ogre
                 This function is defined in ArrayMatrix4 to avoid including this header into
                 ArrayQuaternion. The idea is that ArrayMatrix4 requires ArrayQuaternion, and
                 ArrayQuaternion requires ArrayVector3. Simple dependency order
-            @param
+            @param q
                 The quaternion to convert from.
         */
         inline void fromQuaternion( const ArrayQuaternion &q );

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrixAf4x3.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayMatrixAf4x3.h
@@ -115,7 +115,7 @@ namespace Ogre
                 This function is defined in ArrayMatrix4 to avoid including this header into
                 ArrayQuaternion. The idea is that ArrayMatrix4 requires ArrayQuaternion, and
                 ArrayQuaternion requires ArrayVector3. Simple dependency order
-            @param
+            @param q
                 The quaternion to convert from.
         */
         inline void fromQuaternion( const ArrayQuaternion &q );

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
@@ -219,9 +219,9 @@ namespace Ogre
                 decide between two ArrayQuaternions, i.e. a = Cmov4( b, c ) then
                 @see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayReal mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? this[i] : replacement[i]
@@ -236,11 +236,11 @@ namespace Ogre
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
                 @see Cmov4( ArrayReal mask, const ArrayQuaternion &replacement );
                 instead.
-            @param
+            @param arg1
                 First array of Vectors
-            @param
+            @param arg2
                 Second array of Vectors
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? arg1[i] : arg2[i]

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayVector3.h
@@ -316,9 +316,9 @@ namespace Ogre
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
                 @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? this[i] : replacement[i]
@@ -333,11 +333,11 @@ namespace Ogre
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
                 @see Cmov4( ArrayReal mask, const ArrayVector3 &replacement );
                 instead.
-            @param
+            @param arg1
                 First array of Vectors
-            @param
+            @param arg2
                 Second array of Vectors
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? arg1[i] : arg2[i]

--- a/OgreMain/include/Math/Array/OgreArrayMemoryManager.h
+++ b/OgreMain/include/Math/Array/OgreArrayMemoryManager.h
@@ -95,7 +95,7 @@ namespace Ogre
                     The hierarchy depth level
                 @param basePtrs
                     The base pointers from each pool so we can calculate the differences
-                @param utDiffsList
+                @param outDiffsList
                     The list we'll generate. "outDiffsList" already has enough reserved space
             */
             virtual void buildDiffList( uint16 level, const MemoryPoolVec &basePtrs,

--- a/OgreMain/include/Math/Array/OgreArrayMemoryManager.h
+++ b/OgreMain/include/Math/Array/OgreArrayMemoryManager.h
@@ -229,7 +229,7 @@ namespace Ogre
         /// ArrayMemoryManager::destroySlot already does this when the number
         /// of fragmented slots reaches mCleanupThreshold
         void defragment();
-        
+
         ///  Prevent defragmentation from ever happening.
         void neverDefragment();
 

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrix4.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrix4.h
@@ -155,7 +155,7 @@ namespace Ogre
         /** Assigns the value of the other matrix. Does not reference the
             ptr address, but rather perform a memory copy
             @param
-                rkmatrix The other matrix
+                rkMatrix The other matrix
         */
         inline ArrayMatrix4 &operator=( const ArrayMatrix4 &rkMatrix )
         {
@@ -186,7 +186,7 @@ namespace Ogre
                 This function is defined in ArrayMatrix4 to avoid including this header into
                 ArrayQuaternion. The idea is that ArrayMatrix4 requires ArrayQuaternion, and
                 ArrayQuaternion requires ArrayVector3. Simple dependency order
-            @param
+            @param q
                 The quaternion to convert from.
         */
         inline void fromQuaternion( const ArrayQuaternion &q );

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrixAf4x3.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayMatrixAf4x3.h
@@ -115,7 +115,7 @@ namespace Ogre
                 This function is defined in ArrayMatrix4 to avoid including this header into
                 ArrayQuaternion. The idea is that ArrayMatrix4 requires ArrayQuaternion, and
                 ArrayQuaternion requires ArrayVector3. Simple dependency order
-            @param
+            @param q
                 The quaternion to convert from.
         */
         inline void fromQuaternion( const ArrayQuaternion &q );

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
@@ -220,9 +220,9 @@ namespace Ogre
                 decide between two ArrayQuaternions, i.e. a = Cmov4( b, c ) then
                 @see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayReal mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? this[i] : replacement[i]
@@ -237,11 +237,11 @@ namespace Ogre
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
                 @see Cmov4( ArrayReal mask, const ArrayQuaternion &replacement );
                 instead.
-            @param
+            @param arg1
                 First array of Vectors
-            @param
+            @param arg2
                 Second array of Vectors
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? arg1[i] : arg2[i]

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayVector3.h
@@ -331,11 +331,11 @@ namespace Ogre
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
                 @see Cmov4( ArrayReal mask, const ArrayVector3 &replacement );
                 instead.
-            @param
+            @param arg1
                 First array of Vectors
-            @param
+            @param arg2
                 Second array of Vectors
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
             @return
                 this[i] = mask[i] != 0 ? arg1[i] : arg2[i]

--- a/OgreMain/include/OgreFrustum.h
+++ b/OgreMain/include/OgreFrustum.h
@@ -343,7 +343,7 @@ namespace Ogre
         virtual void resetFrustumExtents();
 
         /** Get the extents of the frustum in view space.
-        @param left, right, top, bottom The position where the side clip planes intersect
+        @param outleft, outright, outtop, outbottom The position where the side clip planes intersect
             the near clip plane, in eye space OR the tangent of the half angles from the eye to the edges
             of the near clip plane
         @param frustrumExtentsType

--- a/OgreMain/include/OgreFrustum.h
+++ b/OgreMain/include/OgreFrustum.h
@@ -214,13 +214,13 @@ namespace Ogre
         virtual const Radian &getFOVy() const;
 
         /// Returns the terms projectionA and projectionB in .x and .y respectively, which can
-        /// be used to reconstruct linear depth from a Z buffer.  If the projection type is PT_PERSPECTIVE,
-        /// use the following formula:
-        /// 
+        /// be used to reconstruct linear depth from a Z buffer.  If the projection type is
+        /// PT_PERSPECTIVE, use the following formula:
+        ///
         ///     linearDepth = projectionParams.y / (fDepth - projectionParams.x);
-        ///     
+        ///
         /// But if the projection type is PT_ORTHOGRAPHIC, use the formula:
-        /// 
+        ///
         ///     linearDepth = (fDepth - projectionParams.x) / projectionParams.y;
         Vector2 getProjectionParamsAB() const;
 

--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -2360,7 +2360,7 @@ namespace Ogre
         */
         size_t _getUnsignedIntConstantPhysicalIndex( size_t logicalIndex, size_t requestedSize,
                                                      uint16 variability );
-        /** Gets the physical buffer index associated with a logical bool constant index.
+        /* Gets the physical buffer index associated with a logical bool constant index.
             @note Only applicable to low-level programs.
             @param logicalIndex The logical parameter index
             @param requestedSize The requested size - pass 0 to ignore missing entries

--- a/OgreMain/include/OgreImage2.h
+++ b/OgreMain/include/OgreImage2.h
@@ -134,7 +134,7 @@ namespace Ogre
             <li>face 1, mip 0 (top), width x height (x depth)</li>
             <li>.. and so on. </li>
             </ul>
-        @param data
+        @param pData
             The data pointer. Must've been allocated with
             OGRE_MALLOC_SIMD( sizeBytes, MEMCATEGORY_RESOURCE );
             and sizeBytes assumes a pitch with row alignment = 4u;

--- a/OgreMain/include/OgreSceneNode.h
+++ b/OgreMain/include/OgreSceneNode.h
@@ -191,7 +191,7 @@ namespace Ogre
             Use this if you wish to recursively destroy a node as well as
             detaching it from it's parent. Note that any objects attached to
             the nodes will be detached but will not themselves be destroyed.
-        @param
+        @param sceneNode
             SceneNode, must be a child of ours
         */
         virtual void removeAndDestroyChild( SceneNode *sceneNode );

--- a/OgreMain/include/OgreTextureGpuManager.h
+++ b/OgreMain/include/OgreTextureGpuManager.h
@@ -716,9 +716,9 @@ namespace Ogre
         /** Whether to use HW or SW mipmap generation when specifying
             TextureFilter::TypeGenerateDefaultMipmaps for loading files from textures.
             This setting has no effect for filters explicitly asking for HW mipmap generation.
-        @param hwMipmapGen
+        @param defaultMipmapGen
             Whether to enable HW mipmap generation for textures. Default is true.
-        @param hwMipmapGenCubemaps
+        @param defaultMipmapGenCubemaps
             Whether to enable HW mipmap generation for cubemap textures. Default is false.
         */
         void setDefaultMipmapGeneration( DefaultMipmapGen::DefaultMipmapGen defaultMipmapGen,

--- a/OgreMain/include/OgreWindow.h
+++ b/OgreMain/include/OgreWindow.h
@@ -133,9 +133,9 @@ namespace Ogre
         @param borderless
             Whether to be borderless. Only useful if goFullscreen == false;
         @param monitorIdx
-        @param width
+        @param widthPt
             New width. Leave 0 if you don't care.
-        @param height
+        @param heightPt
             New height. Leave 0 if you don't care.
         @param frequencyNumerator
             New frequency (fullscreen only). Leave 0 if you don't care.

--- a/OgreMain/include/Threading/OgreThreads.h
+++ b/OgreMain/include/Threading/OgreThreads.h
@@ -176,7 +176,7 @@ namespace Ogre
                                              void *param );
 
         /** Waits until all threads are finished
-        @param numThreadInfos
+        @param numThreadHandles
             Number of ThreadHandle passed in the array as 'threadHandles'
         @param threadHandles
             Array of numThreadHandles or more ThreadHandle

--- a/OgreMain/include/Vao/OgreVaoManager.h
+++ b/OgreMain/include/Vao/OgreVaoManager.h
@@ -372,7 +372,7 @@ namespace Ogre
                                           BufferType bufferType, void *initialData, bool keepAsShadow );
 
         /** Destroys the given texture buffer created with createTexBuffer.
-        @param constBuffer
+        @param texBuffer
             Texture Buffer created with createTexBuffer
         */
         void destroyTexBuffer( TexBufferPacked *texBuffer );
@@ -416,7 +416,7 @@ namespace Ogre
                                           void *initialData, bool keepAsShadow );
 
         /** Destroys the given UAV buffer created with createUavBuffer.
-        @param constBuffer
+        @param uavBuffer
             Uav Buffer created with createUavBuffer
         */
         void destroyUavBuffer( UavBufferPacked *uavBuffer );
@@ -478,7 +478,7 @@ namespace Ogre
             be increased.
             You should decrease the reference count after you're done with the returned
             pointer. See StagingBuffer::removeReferenceCount regarding ref. counting.
-        @param sizeBytes
+        @param minSizeBytes
             Minimum size, in bytes, of the staging buffer.
             The returned buffer may be bigger.
         @param forUpload

--- a/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXUtils.h
+++ b/RenderSystems/GL3Plus/include/windowing/GLX/OgreGLXUtils.h
@@ -49,7 +49,7 @@ namespace Ogre
          * Get the GLXFBConfig used to create a ::%GLXContext
          *
          * @param display   X Display
-         * @param drawable   GLXContext
+         * @param context   GLXContext
          * @returns       GLXFBConfig used to create the context
          */
         static GLXFBConfig getFBConfigFromContext( Display *display, ::GLXContext context );


### PR DESCRIPTION
I fixed some of the doxygen warnings of the form "argument '<arg>' of command @param is not found in the argument list of <method>".  I only fixed the ones where it seemed really obvious what the correct parameter should be; there were other cases with more serious mismatches between code and documentation that I left alone.