### PR TITLE
Jw/doxygen misc warnings

### DIFF
--- a/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
+++ b/Components/Hlms/Pbs/include/OgreHlmsPbsDatablock.h
@@ -259,12 +259,12 @@ namespace Ogre
     public:
         /** Valid parameters in params:
         @param params
-            + fresnel <value [g, b]>
+            + fresnel \<value [g, b]>
                 The IOR. See setIndexOfRefraction()
                 When specifying three values, the fresnel is separate for each
                 colour component
 
-            + fresnel_coeff <value [g, b]>
+            + fresnel_coeff \<value [g, b]>
                 Directly sets the fresnel values, instead of using IORs
                 "F0" in most books about PBS
 
@@ -273,76 +273,76 @@ namespace Ogre
                 Note: Values extremely close to zero could cause NaNs and
                 INFs in the pixel shader, also depends on the GPU's precision.
 
-            + background_diffuse <r g b a>
+            + background_diffuse \<r g b a>
                 Specifies diffuse colour to use as a background when diffuse texture are not present.
-                Does not replace 'diffuse <r g b>'
+                Does not replace 'diffuse \<r g b>'
                 Default: background_diffuse 1 1 1 1
 
-            + diffuse <r g b>
+            + diffuse \<r g b>
                 Specifies the RGB diffuse colour. "kD" in most books about PBS
                 Default: diffuse 1 1 1 1
                 Note: Internally the diffuse colour is divided by PI.
 
-            + diffuse_map <texture name>
+            + diffuse_map \<texture name>
                 Name of the diffuse texture for the base image (optional)
 
-            + diffuse_map_grayscale <true, false>
+            + diffuse_map_grayscale \<true, false>
                 When set to true diffuse map would be sampled with .rrra swizzle
                 Default: false
 
-            + specular <r g b>
+            + specular \<r g b>
                 Specifies the RGB specular colour. "kS" in most books about PBS
                 Default: specular 1 1 1 1
 
-            + specular_map <texture name>
+            + specular_map \<texture name>
                 Name of the specular texture for the base image (optional).
 
-            + roughness_map <texture name>
+            + roughness_map \<texture name>
                 Name of the roughness texture for the base image (optional)
                 Note: Only the Red channel will be used, and the texture will be converted to
                 an efficient monochrome representation.
 
-            + normal_map <texture name>
+            + normal_map \<texture name>
                 Name of the normal texture for the base image (optional) for normal mapping
 
-            + detail_weight_map <texture name>
+            + detail_weight_map \<texture name>
                 Texture that when present, will be used as mask/weight for the 4 detail maps.
                 The R channel is used for detail map #0; the G for detail map #1, B for #2,
                 and Alpha for #3.
                 This affects both the diffuse and normal-mapped detail maps.
 
-            + detail_map0 <texture name>
+            + detail_map0 \<texture name>
               Similar: detail_map1, detail_map2, detail_map3
                 Name of the detail map to be used on top of the diffuse colour.
                 There can be gaps (i.e. set detail maps 0 and 2 but not 1)
 
-            + detail_blend_mode0 <blend_mode>
+            + detail_blend_mode0 \<blend_mode>
               Similar: detail_blend_mode1, detail_blend_mode2, detail_blend_mode3
                 Blend mode to use for each detail map. Valid values are:
                     "NormalNonPremul", "NormalPremul", "Add", "Subtract", "Multiply",
                     "Multiply2x", "Screen", "Overlay", "Lighten", "Darken",
                     "GrainExtract", "GrainMerge", "Difference"
 
-            + detail_offset_scale0 <offset_u> <offset_v> <scale_u> <scale_v>
+            + detail_offset_scale0 \<offset_u> \<offset_v> \<scale_u> \<scale_v>
               Similar: detail_offset_scale1, detail_offset_scale2, detail_offset_scale3
                 Sets the UV offset and scale of the detail maps.
 
-            + detail_normal_map0 <texture name>
+            + detail_normal_map0 \<texture name>
               Similar: detail_normal_map1, detail_normal_map2, detail_normal_map3
                 Name of the detail map's normal map to be used.
                 It's not affected by blend mode. May be used even if
                 there is no detail_map
 
-            + detail_normal_offset_scale0 <offset_u> <offset_v> <scale_u> <scale_v>
+            + detail_normal_offset_scale0 \<offset_u> \<offset_v> \<scale_u> \<scale_v>
               Similar: detail_normal_offset_scale1, detail_normal_offset_scale2,
                        detail_normal_offset_scale3
                 Sets the UV offset and scale of the detail normal maps.
 
-            + reflection_map <texture name>
+            + reflection_map \<texture name>
                 Name of the reflection map. Must be a cubemap. Doesn't use an UV set because
                 the tex. coords are automatically calculated.
 
-            + uv_diffuse_map <uv>
+            + uv_diffuse_map \<uv>
               Similar: uv_specular_map, uv_normal_map, uv_detail_mapN, uv_detail_normal_mapN,
                        uv_detail_weight_map
               where N is a number between 0 and 3.
@@ -353,10 +353,10 @@ namespace Ogre
               Specifies the transparency amount. Value in range [0; 1]
               where 0 = full transparency and 1 = fully opaque.
 
-            + transparency_mode <transparent, none, fade>
+            + transparency_mode \<transparent, none, fade>
               Specifies the transparency mode. @see TransparencyModes
 
-            + alpha_from_textures <true, false>
+            + alpha_from_textures \<true, false>
               When set to false transparency calculations ignore the alpha channel in
               the textures
         */

--- a/Components/SceneFormat/include/OgreSceneFormatImporter.h
+++ b/Components/SceneFormat/include/OgreSceneFormatImporter.h
@@ -232,8 +232,6 @@ namespace Ogre
             IrradianceVolume pointer. Input cannot be null. Output *outIrradianceVolume may be null.
             May be null if the imported scene didn't have IR/IV enabled,
             or if the ownership has already been released.
-        @return
-            InstantRadiosity pointer.
         */
         void getInstantRadiosity( bool releaseOwnership, InstantRadiosity **outInstantRadiosity,
                                   IrradianceVolume **outIrradianceVolume );

--- a/Docs/src/manual/compositor.md
+++ b/Docs/src/manual/compositor.md
@@ -1190,7 +1190,7 @@ A locally unique name must be assigned (and cannot start with *global\_* prefix)
 The dimensions of the render texture. You can either specify a fixed width and height,
 or you can request that the texture is based on the physical dimensions of the viewport
 to which the compositor is attached. The options for the latter are ’target_width’,
-’target_height’, ’target_width_scaled <factor>’ and ’target_height_scaled <factor>’ -
+’target_height’, ’target_width_scaled \<factor\>’ and ’target_height_scaled \<factor\>’ -
 where ’factor’ is the amount by which you wish to multiply the size of the main target
 to derive the dimensions.
 

--- a/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
@@ -184,8 +184,6 @@ namespace Ogre
                 memory reside in the heap (it makes better usage of the memory). Long story short,
                 prefer calling this function to using an operator when just updating an ArrayVector3 is
                 involved. (It's fine using operators for ArrayVector3s)
-            @param
-
         */
         static inline void mul( const ArrayQuaternion &inQ, ArrayVector3 &inOutVec );
 

--- a/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
@@ -205,9 +205,12 @@ namespace Ogre
         static inline ArrayQuaternion nlerp( ArrayReal fT, const ArrayQuaternion &rkP,
                                              const ArrayQuaternion &rkQ );
 
-        /** Conditional move update. @see MathlibC::Cmov4
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibC::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -216,7 +219,7 @@ namespace Ogre
                 i.e. a = Cmov4( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayQuaternions, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayReal mask );
+                see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayMaskR mask );
                 instead.
             @param replacement
                 Vectors to be used as replacement if the mask is zero.
@@ -225,13 +228,16 @@ namespace Ogre
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
 
-        /** Conditional move. @see MathlibC::Cmov4
-            Selects between arg1 & arg2 according to mask
+        /** Conditional move.
+            Selects between arg1 & arg2 according to mask:
+
+            this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
+            @see MathlibC::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
-                @see Cmov4( ArrayReal mask, const ArrayQuaternion &replacement );
+                see Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
                 instead.
             @param arg1
                 First array of Vectors
@@ -239,8 +245,6 @@ namespace Ogre
                 Second array of Vectors
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
         */
         inline static ArrayQuaternion Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2,
                                              ArrayMaskR mask );

--- a/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayQuaternion.h
@@ -224,8 +224,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
 

--- a/OgreMain/include/Math/Array/C/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayVector3.h
@@ -289,8 +289,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
 
@@ -311,8 +309,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void CmovRobust( ArrayMaskR mask, const ArrayVector3 &replacement );
 

--- a/OgreMain/include/Math/Array/C/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/C/OgreArrayVector3.h
@@ -272,9 +272,12 @@ namespace Ogre
         */
         inline Vector3 collapseMax() const;
 
-        /** Conditional move update. @see MathlibC::Cmov4
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibC::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -283,7 +286,7 @@ namespace Ogre
                 i.e. a = Cmov4( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
+                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayMaskR mask );
                 instead.
             @param replacement
                 Vectors to be used as replacement if the mask is zero.
@@ -292,9 +295,12 @@ namespace Ogre
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
 
-        /** Conditional move update. @see MathlibC::CmovRobust
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibC::CmovRobust
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -303,7 +309,7 @@ namespace Ogre
                 i.e. a = CmovRobust( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
+                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayMaskR mask );
                 instead.
             @param replacement
                 Vectors to be used as replacement if the mask is zero.
@@ -312,13 +318,16 @@ namespace Ogre
         */
         inline void CmovRobust( ArrayMaskR mask, const ArrayVector3 &replacement );
 
-        /** Conditional move. @see MathlibC::Cmov4
-            Selects between arg1 & arg2 according to mask
+        /** Conditional move.
+            Selects between arg1 & arg2 according to mask:
+
+            this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
+            @see MathlibC::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
-                @see Cmov4( ArrayReal mask, const ArrayVector3 &replacement );
+                see Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
                 instead.
             @param arg1
                 First array of Vectors
@@ -326,8 +335,6 @@ namespace Ogre
                 Second array of Vectors
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
         */
         inline static ArrayVector3 Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2,
                                           ArrayMaskR mask );

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
@@ -204,9 +204,12 @@ namespace Ogre
         static inline ArrayQuaternion nlerp( ArrayReal fT, const ArrayQuaternion &rkP,
                                              const ArrayQuaternion &rkQ );
 
-        /** Conditional move update. @see MathlibNEON::Cmov4
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibNEON::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -215,7 +218,7 @@ namespace Ogre
                 i.e. a = Cmov4( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayQuaternions, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayReal mask );
+                see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayMaskR mask );
                 instead.
             @param replacement
                 Vectors to be used as replacement if the mask is zero.
@@ -224,13 +227,16 @@ namespace Ogre
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
 
-        /** Conditional move. @see MathlibNEON::Cmov4
-            Selects between arg1 & arg2 according to mask
+        /** Conditional move.
+            Selects between arg1 & arg2 according to mask:
+
+            this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
+            @see MathlibNEON::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
-                @see Cmov4( ArrayReal mask, const ArrayQuaternion &replacement );
+                see Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
                 instead.
             @param arg1
                 First array of Vectors
@@ -238,8 +244,6 @@ namespace Ogre
                 Second array of Vectors
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
         */
         inline static ArrayQuaternion Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2,
                                              ArrayMaskR mask );

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
@@ -183,8 +183,6 @@ namespace Ogre
                 memory reside in the heap (it makes better usage of the memory). Long story short,
                 prefer calling this function to using an operator when just updating an ArrayVector3 is
                 involved. (It's fine using operators for ArrayVector3s)
-            @param
-
         */
         static inline void mul( const ArrayQuaternion &inQ, ArrayVector3 &inOutVec );
 

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayQuaternion.h
@@ -223,8 +223,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
 

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayVector3.h
@@ -281,9 +281,12 @@ namespace Ogre
         */
         inline Vector3 collapseMax() const;
 
-        /** Conditional move update. @see MathlibNEON::Cmov4
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibNEON::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -292,18 +295,21 @@ namespace Ogre
                 i.e. a = Cmov4( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
-                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
+                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayMaskR mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
 
-        /** Conditional move update. @see MathlibNEON::CmovRobust
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibNEON::CmovRobust
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -312,7 +318,7 @@ namespace Ogre
                 i.e. a = CmovRobust( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
+                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayMaskR mask );
                 instead.
             @param replacement
                 Vectors to be used as replacement if the mask is zero.
@@ -321,13 +327,16 @@ namespace Ogre
         */
         inline void CmovRobust( ArrayMaskR mask, const ArrayVector3 &replacement );
 
-        /** Conditional move. @see MathlibNEON::Cmov4
-            Selects between arg1 & arg2 according to mask
+        /** Conditional move.
+            Selects between arg1 & arg2 according to mask:
+
+            this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
+            @see MathlibNEON::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
-                @see Cmov4( ArrayReal mask, const ArrayVector3 &replacement );
+                see Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
                 instead.
             @param arg1
                 First array of Vectors
@@ -335,8 +344,6 @@ namespace Ogre
                 Second array of Vectors
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
         */
         inline static ArrayVector3 Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2,
                                           ArrayMaskR mask );

--- a/OgreMain/include/Math/Array/NEON/Single/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreArrayVector3.h
@@ -298,8 +298,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
 
@@ -320,8 +318,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void CmovRobust( ArrayMaskR mask, const ArrayVector3 &replacement );
 

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
@@ -184,8 +184,6 @@ namespace Ogre
                 memory reside in the heap (it makes better usage of the memory). Long story short,
                 prefer calling this function to using an operator when just updating an ArrayVector3 is
                 involved. (It's fine using operators for ArrayVector3s)
-            @param
-
         */
         static inline void mul( const ArrayQuaternion &inQ, ArrayVector3 &inOutVec );
 

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
@@ -205,9 +205,12 @@ namespace Ogre
         static inline ArrayQuaternion nlerp( ArrayReal fT, const ArrayQuaternion &rkP,
                                              const ArrayQuaternion &rkQ );
 
-        /** Conditional move update. @see MathlibSSE2::Cmov4
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibSSE2::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -216,7 +219,7 @@ namespace Ogre
                 i.e. a = Cmov4( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayQuaternions, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayReal mask );
+                see Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2, ArrayMaskR mask );
                 instead.
             @param replacement
                 Vectors to be used as replacement if the mask is zero.
@@ -225,13 +228,16 @@ namespace Ogre
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
 
-        /** Conditional move. @see MathlibSSE2::Cmov4
-            Selects between arg1 & arg2 according to mask
+        /** Conditional move.
+            Selects between arg1 & arg2 according to mask:
+
+            this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
+            @see MathlibSSE2::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
-                @see Cmov4( ArrayReal mask, const ArrayQuaternion &replacement );
+                see Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
                 instead.
             @param arg1
                 First array of Vectors
@@ -239,8 +245,6 @@ namespace Ogre
                 Second array of Vectors
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
         */
         inline static ArrayQuaternion Cmov4( const ArrayQuaternion &arg1, const ArrayQuaternion &arg2,
                                              ArrayMaskR mask );

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayQuaternion.h
@@ -224,8 +224,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayQuaternion &replacement );
 

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayVector3.h
@@ -296,8 +296,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
 
@@ -318,8 +316,6 @@ namespace Ogre
                 Vectors to be used as replacement if the mask is zero.
             @param
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? this[i] : replacement[i]
         */
         inline void CmovRobust( ArrayMaskR mask, const ArrayVector3 &replacement );
 

--- a/OgreMain/include/Math/Array/SSE2/Single/OgreArrayVector3.h
+++ b/OgreMain/include/Math/Array/SSE2/Single/OgreArrayVector3.h
@@ -279,9 +279,12 @@ namespace Ogre
         */
         inline Vector3 collapseMax() const;
 
-        /** Conditional move update. @see MathlibSSE2::Cmov4
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibSSE2::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -290,18 +293,21 @@ namespace Ogre
                 i.e. a = Cmov4( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
+                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayMaskR mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
         */
         inline void Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
 
-        /** Conditional move update. @see MathlibSSE2::CmovRobust
+        /** Conditional move update.
             Changes each of the four vectors contained in 'this' with
-            the replacement provided
+            the replacement provided:
+
+            this[i] = mask[i] != 0 ? this[i] : replacement[i]
+            @see MathlibSSE2::CmovRobust
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
@@ -310,22 +316,25 @@ namespace Ogre
                 i.e. a = CmovRobust( a, b )
                 If this vector hasn't been assigned yet any value and want to
                 decide between two ArrayVector3s, i.e. a = Cmov4( b, c ) then
-                @see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayReal mask );
+                see Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2, ArrayMaskR mask );
                 instead.
-            @param
+            @param replacement
                 Vectors to be used as replacement if the mask is zero.
-            @param
+            @param mask
                 mask filled with either 0's or 0xFFFFFFFF
         */
         inline void CmovRobust( ArrayMaskR mask, const ArrayVector3 &replacement );
 
-        /** Conditional move. @see MathlibSSE2::Cmov4
-            Selects between arg1 & arg2 according to mask
+        /** Conditional move.
+            Selects between arg1 & arg2 according to mask:
+
+            this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
+            @see MathlibSSE2::Cmov4
             @remarks
                 If mask param contains anything other than 0's or 0xffffffff's
                 the result is undefined.
                 If you wanted to do a = cmov4( a, b ), then consider using the update version
-                @see Cmov4( ArrayReal mask, const ArrayVector3 &replacement );
+                see Cmov4( ArrayMaskR mask, const ArrayVector3 &replacement );
                 instead.
             @param arg1
                 First array of Vectors
@@ -333,8 +342,6 @@ namespace Ogre
                 Second array of Vectors
             @param mask
                 mask filled with either 0's or 0xFFFFFFFF
-            @return
-                this[i] = mask[i] != 0 ? arg1[i] : arg2[i]
         */
         inline static ArrayVector3 Cmov4( const ArrayVector3 &arg1, const ArrayVector3 &arg2,
                                           ArrayMaskR mask );

--- a/OgreMain/include/OgreHlms.h
+++ b/OgreMain/include/OgreHlms.h
@@ -765,7 +765,7 @@ namespace Ogre
             The renderable the material will be used on.
         @param movableObject
             The MovableObject the material will be used on (usually the parent of renderable)
-        @return
+        @param outHash
             A hash. This hash references property parameters that are already cached.
         */
         virtual void calculateHashFor( Renderable *renderable, uint32 &outHash, uint32 &outCasterHash );


### PR DESCRIPTION
This fixes doxygen warnings of several kinds:

- Unsupported xml/html tag
- documented empty return type of
- unexpected end of comment block while parsing the argument of