### PR TITLE
Fix a compile error in MS Visual Studio 2022 when using C++20

### DIFF
--- a/OgreMain/include/OgreMemorySTLAllocator.h
+++ b/OgreMain/include/OgreMemorySTLAllocator.h
@@ -115,7 +115,7 @@ namespace Ogre
         }
 
         /// memory allocation (elements, used by STL)
-#if __cplusplus >= 201703L
+#if( __cplusplus >= 201703L ) || ( _MSVC_LANG >= 201703L )
         inline pointer allocate( size_type count ){
 #else
         inline pointer allocate( size_type count, typename std::allocator<void>::const_pointer ptr = 0 )


### PR DESCRIPTION
The root of the problem is that VS does not use an updated value of __cplusplus, but rather uses a different builtin macro _MSVC_LANG to represent the C++ version.

The actual error message in Visual Studio was: error C2039: 'const_pointer' is not a member of 'std::allocator<void>', pointing at line 121 of OgreMemorySTLAllocator.h.