### PR TITLE
Fix two very chatty warnings

### DIFF
--- a/OgreMain/include/OgreDescriptorSetTexture.h
+++ b/OgreMain/include/OgreDescriptorSetTexture.h
@@ -237,13 +237,9 @@ namespace Ogre
             };
 
         public:
-            Slot() { memset( this, 0, sizeof( *this ) ); }
+            Slot() : slotType( SlotTypeBuffer ), buffer{} {}
 
-            Slot( SlotType _slotType )
-            {
-                memset( this, 0, sizeof( *this ) );
-                slotType = _slotType;
-            }
+            Slot( SlotType _slotType ) : slotType( SlotTypeBuffer ), buffer{} { slotType = _slotType; }
 
             bool empty() const { return buffer.buffer == 0 && texture.texture == 0; }
 

--- a/OgreMain/include/OgreDescriptorSetUav.h
+++ b/OgreMain/include/OgreDescriptorSetUav.h
@@ -157,13 +157,9 @@ namespace Ogre
             };
 
         public:
-            Slot() { memset( this, 0, sizeof( *this ) ); }
+            Slot() : slotType( SlotTypeBuffer ), buffer{} {}
 
-            Slot( SlotType _slotType )
-            {
-                memset( this, 0, sizeof( *this ) );
-                slotType = _slotType;
-            }
+            Slot( SlotType _slotType ) : slotType( SlotTypeBuffer ), buffer{} { slotType = _slotType; }
 
             bool empty() const { return buffer.buffer == 0 && texture.texture == 0; }
 


### PR DESCRIPTION
Memset was being used on a non-trivial type, causing a flood of warnings when using the quickstart script on linux.

```
In file included from /home/ahmedtd/project/ogre-next/OgreMain/include/OgreHlmsComputeJob.h:31,
                 from /home/ahmedtd/project/ogre-next/OgreMain/src/OgreHlmsCompute.cpp:39:
/home/ahmedtd/project/ogre-next/OgreMain/include/OgreDescriptorSetTexture.h: In constructor ‘Ogre::DescriptorSetTexture2::Slot::Slot()’:
/home/ahmedtd/project/ogre-next/OgreMain/include/OgreDescriptorSetTexture.h:240:28: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct Ogre::DescriptorSetTexture2::Slot’; use assignment or value-initialization instead [-Wclass-memaccess]
  240 |             Slot() { memset( this, 0, sizeof( *this ) ); }
      |                      ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ahmedtd/project/ogre-next/OgreMain/include/OgreDescriptorSetTexture.h:228:28: note: ‘struct Ogre::DescriptorSetTexture2::Slot’ declared here
  228 |         struct _OgreExport Slot
      |                            ^~~~
```