### PR TITLE
Fix for FrameStats

### DIFF
--- a/OgreMain/src/OgreRoot.cpp
+++ b/OgreMain/src/OgreRoot.cpp
@@ -1143,7 +1143,7 @@ namespace Ogre
         }
 
         mFrameStats->addSample( mFrameStats->getLastTimeRawMicroseconds() +
-                                static_cast<uint64>( timeSinceLastFrame * 100000.0f ) );
+                                static_cast<uint64>( timeSinceLastFrame * 1000000.0f ) );
         now = mTimer->getMilliseconds();
         evt.timeSinceLastEvent = calculateEventTime( now, FETT_ANY );
 


### PR DESCRIPTION
Ogre::Root, incorrectly updates frameStats with wrong time, resulting in display of incorrect FPS by factor of 10. Correct factor for Microsecond is 1.000.000.
Bug is only when using bool Root::renderOneFrame( Real timeSinceLastFrame ).