### PR TITLE
Fixed bug in "OgreColourInterpolatorAffector" incorrectly in first frame

### DIFF
--- a/PlugIns/ParticleFX/include/OgreColourInterpolatorAffector.h
+++ b/PlugIns/ParticleFX/include/OgreColourInterpolatorAffector.h
@@ -85,7 +85,7 @@ namespace Ogre
         static CmdTimeAdjust   msTimeCmd[MAX_STAGES];
 
 		/** See ParticleAffector. */
-		void _initParticle(Ogre::Particle* pParticle);
+		void _initParticle( Ogre::Particle *pParticle ) override;
 
     protected:
         ColourValue mColourAdj[MAX_STAGES];

--- a/PlugIns/ParticleFX/include/OgreColourInterpolatorAffector.h
+++ b/PlugIns/ParticleFX/include/OgreColourInterpolatorAffector.h
@@ -84,6 +84,9 @@ namespace Ogre
         static CmdColourAdjust msColourCmd[MAX_STAGES];
         static CmdTimeAdjust   msTimeCmd[MAX_STAGES];
 
+		/** See ParticleAffector. */
+		void _initParticle(Ogre::Particle* pParticle);
+
     protected:
         ColourValue mColourAdj[MAX_STAGES];
         Real        mTimeAdj[MAX_STAGES];

--- a/PlugIns/ParticleFX/src/OgreColourInterpolatorAffector.cpp
+++ b/PlugIns/ParticleFX/src/OgreColourInterpolatorAffector.cpp
@@ -136,6 +136,12 @@ namespace Ogre
     //-----------------------------------------------------------------------
     Real ColourInterpolatorAffector::getTimeAdjust( size_t index ) const { return mTimeAdj[index]; }
 
+	//-----------------------------------------------------------------------
+	void ColourInterpolatorAffector::_initParticle(Ogre::Particle* pParticle)
+	{
+		pParticle->mColour = mColourAdj[0];
+	}
+
     //-----------------------------------------------------------------------
     //-----------------------------------------------------------------------
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Fixed bug in "OgreColourInterpolatorAffector", which is not at all applied for the first frame after particle creation. Bug is visible at lower framerates specially when fading-in a particle.