### PR TITLE
Add parameter to skip material assignment to Items on creation

### DIFF
--- a/OgreMain/include/OgreAny.h
+++ b/OgreMain/include/OgreAny.h
@@ -150,7 +150,7 @@ namespace Ogre
                 return OGRE_NEW_T( holder, MEMCATEGORY_GENERAL )( held );
             }
 
-            void writeToStream( std::ostream &o ) override { o << held; }
+            void writeToStream( std::ostream &o ) override {  }
 
         public:  // representation
             ValueType held;

--- a/OgreMain/include/OgreAny.h
+++ b/OgreMain/include/OgreAny.h
@@ -150,7 +150,7 @@ namespace Ogre
                 return OGRE_NEW_T( holder, MEMCATEGORY_GENERAL )( held );
             }
 
-            void writeToStream( std::ostream &o ) override {  }
+            void writeToStream( std::ostream &o ) override { o << held; }
 
         public:  // representation
             ValueType held;

--- a/OgreMain/include/OgreItem.h
+++ b/OgreMain/include/OgreItem.h
@@ -97,8 +97,7 @@ namespace Ogre
         /** Private constructor.
          */
         Item( IdType id, ObjectMemoryManager *objectMemoryManager, SceneManager *manager,
-              const MeshPtr &mesh );
-
+              const MeshPtr &mesh, bool bUseMeshMat = true );
         /** The Mesh that this Item is based on.
          */
         MeshPtr mMesh;
@@ -118,7 +117,7 @@ namespace Ogre
         bool mInitialised;
 
         /** Builds a list of SubItems based on the SubMeshes contained in the Mesh. */
-        void buildSubItems( vector<String>::type *materialsList = 0 );
+        void buildSubItems( vector<String>::type *materialsList = 0, bool bUseMeshMat = true );
 
     public:
         /** Default destructor.
@@ -256,7 +255,7 @@ namespace Ogre
             internal structures and try to rebuild them. Useful if you changed the
             content of a Mesh or Skeleton at runtime.
         */
-        void _initialise( bool forceReinitialise = false );
+        void _initialise( bool forceReinitialise = false, bool bUseMeshMat = true );
         /** Tear down the internal structures of this Item, rendering it uninitialised. */
         void _deinitialise();
 

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -1385,10 +1385,11 @@ namespace Ogre
                 meshName The name of the Mesh it is to be based on (e.g. 'knot.oof'). The
                 mesh will be loaded if it is not already.
         */
-        virtual Item *createItem(
-            const String       &meshName,
-            const String       &groupName = ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME,
-            SceneMemoryMgrTypes sceneType = SCENE_DYNAMIC );
+         virtual Item *createItem(
+            const String &      meshName,
+            const String &      groupName = ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME,
+            SceneMemoryMgrTypes sceneType = SCENE_DYNAMIC, bool bUseMeshMat = true );
+        
 
         /** Create an Item (instance of a discrete mesh).
             @param

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -1385,11 +1385,10 @@ namespace Ogre
                 meshName The name of the Mesh it is to be based on (e.g. 'knot.oof'). The
                 mesh will be loaded if it is not already.
         */
-         virtual Item *createItem(
-            const String &      meshName,
-            const String &      groupName = ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME,
+        virtual Item *createItem(
+            const String       &meshName,
+            const String       &groupName = ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME,
             SceneMemoryMgrTypes sceneType = SCENE_DYNAMIC, bool bUseMeshMat = true );
-        
 
         /** Create an Item (instance of a discrete mesh).
             @param

--- a/OgreMain/src/OgreItem.cpp
+++ b/OgreMain/src/OgreItem.cpp
@@ -55,14 +55,15 @@ namespace Ogre
     }
     //-----------------------------------------------------------------------
     Item::Item( IdType id, ObjectMemoryManager *objectMemoryManager, SceneManager *manager,
-                const MeshPtr &mesh ) :
+                const MeshPtr &mesh, bool bUseMeshMat /*= true */ ) :
         MovableObject( id, objectMemoryManager, manager, 10u ),
         mMesh( mesh ),
         mInitialised( false )
     {
-        _initialise();
+        _initialise(false, bUseMeshMat);
         mObjectData.mQueryFlags[mObjectData.mIndex] = SceneManager::QUERY_ENTITY_DEFAULT_MASK;
     }
+
     //-----------------------------------------------------------------------
     void Item::loadingComplete( Resource *res )
     {
@@ -72,7 +73,7 @@ namespace Ogre
         }
     }
     //-----------------------------------------------------------------------
-    void Item::_initialise( bool forceReinitialise )
+    void Item::_initialise( bool forceReinitialise /*= false*/, bool bUseMeshMat /*= true */ )
     {
         vector<String>::type prevMaterialsList;
         if( forceReinitialise )
@@ -109,8 +110,9 @@ namespace Ogre
 
         mLodMesh = mMesh->_getLodValueArray();
 
+
         // Build main subItem list
-        buildSubItems( prevMaterialsList.empty() ? 0 : &prevMaterialsList );
+        buildSubItems( prevMaterialsList.empty() ? 0 : &prevMaterialsList, bUseMeshMat );
 
         {
             // Without filling the renderables list, the RenderQueue won't
@@ -138,6 +140,8 @@ namespace Ogre
 
         mInitialised = true;
     }
+
+
     //-----------------------------------------------------------------------
     void Item::_deinitialise()
     {
@@ -267,19 +271,21 @@ namespace Ogre
     //-----------------------------------------------------------------------
     const String &Item::getMovableType() const { return ItemFactory::FACTORY_TYPE_NAME; }
     //-----------------------------------------------------------------------
-    void Item::buildSubItems( vector<String>::type *materialsList )
+    void Item::buildSubItems( vector<String>::type *materialsList, bool bUseMeshMat/* = true*/)
     {
         // Create SubEntities
         unsigned numSubMeshes = mMesh->getNumSubMeshes();
         mSubItems.reserve( numSubMeshes );
+        const Ogre::String defaultDatablock;
         for( unsigned i = 0; i < numSubMeshes; ++i )
         {
             SubMesh *subMesh = mMesh->getSubMesh( i );
             mSubItems.push_back( SubItem( this, subMesh ) );
 
             // Try first Hlms materials, then the low level ones.
+
             mSubItems.back().setDatablockOrMaterialName(
-                materialsList ? ( *materialsList )[i] : subMesh->mMaterialName, mMesh->getGroup() );
+                materialsList ? ( *materialsList )[i] : (bUseMeshMat ? subMesh->mMaterialName : defaultDatablock), mMesh->getGroup() );
         }
     }
     //-----------------------------------------------------------------------
@@ -344,12 +350,12 @@ namespace Ogre
     {
         // must have mesh parameter
         MeshPtr pMesh;
+        bool useMeshMat = true;
         if( params != 0 )
         {
             String groupName = ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME;
 
             NameValuePairList::const_iterator ni;
-
             ni = params->find( "resourceGroup" );
             if( ni != params->end() )
             {
@@ -362,6 +368,12 @@ namespace Ogre
                 // Get mesh (load if required)
                 pMesh = MeshManager::getSingleton().load( ni->second, groupName );
             }
+
+            ni = params->find( "useMeshMat" );
+            if( ni != params->end() )
+            {
+                useMeshMat = StringConverter::parseBool( ni->second );
+            }
         }
         if( !pMesh )
         {
@@ -370,7 +382,7 @@ namespace Ogre
                          "ItemFactory::createInstance" );
         }
 
-        return OGRE_NEW Item( id, objectMemoryManager, manager, pMesh );
+        return OGRE_NEW Item( id, objectMemoryManager, manager, pMesh, useMeshMat );
     }
     //-----------------------------------------------------------------------
     void ItemFactory::destroyInstance( MovableObject *obj ) { OGRE_DELETE obj; }

--- a/OgreMain/src/OgreItem.cpp
+++ b/OgreMain/src/OgreItem.cpp
@@ -60,7 +60,7 @@ namespace Ogre
         mMesh( mesh ),
         mInitialised( false )
     {
-        _initialise(false, bUseMeshMat);
+        _initialise( false, bUseMeshMat );
         mObjectData.mQueryFlags[mObjectData.mIndex] = SceneManager::QUERY_ENTITY_DEFAULT_MASK;
     }
 
@@ -110,7 +110,6 @@ namespace Ogre
 
         mLodMesh = mMesh->_getLodValueArray();
 
-
         // Build main subItem list
         buildSubItems( prevMaterialsList.empty() ? 0 : &prevMaterialsList, bUseMeshMat );
 
@@ -140,7 +139,6 @@ namespace Ogre
 
         mInitialised = true;
     }
-
 
     //-----------------------------------------------------------------------
     void Item::_deinitialise()
@@ -271,7 +269,7 @@ namespace Ogre
     //-----------------------------------------------------------------------
     const String &Item::getMovableType() const { return ItemFactory::FACTORY_TYPE_NAME; }
     //-----------------------------------------------------------------------
-    void Item::buildSubItems( vector<String>::type *materialsList, bool bUseMeshMat/* = true*/)
+    void Item::buildSubItems( vector<String>::type *materialsList, bool bUseMeshMat /* = true*/ )
     {
         // Create SubEntities
         unsigned numSubMeshes = mMesh->getNumSubMeshes();
@@ -285,7 +283,9 @@ namespace Ogre
             // Try first Hlms materials, then the low level ones.
 
             mSubItems.back().setDatablockOrMaterialName(
-                materialsList ? ( *materialsList )[i] : (bUseMeshMat ? subMesh->mMaterialName : defaultDatablock), mMesh->getGroup() );
+                materialsList ? ( *materialsList )[i]
+                              : ( bUseMeshMat ? subMesh->mMaterialName : defaultDatablock ),
+                mMesh->getGroup() );
         }
     }
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreSTBICodec.cpp
+++ b/OgreMain/src/OgreSTBICodec.cpp
@@ -162,19 +162,21 @@ namespace Ogre
             memcpy( imgData->box.data, pixelData, imgData->box.bytesPerImage );
         else
         {
+            size_t realBytesPerRow = PixelFormatGpuUtils::getSizeBytes( imgData->box.width, 1u, 1u, 1u, PFG_RGB8_UNORM, rowAlignment );
+
             for( size_t y = 0; y < (size_t)height; ++y )
             {
                 uint8 *pDst = reinterpret_cast<uint8 *>( imgData->box.at( 0u, y, 0u ) );
-                uint8 const *pSrc = pixelData + y * imgData->box.bytesPerRow;
-                for( size_t x = 0; x << (size_t)width; ++x )
+                uint8 const *pSrc = pixelData + y * realBytesPerRow;
+                for( size_t x = 0; x < (size_t)width; ++x )
                 {
                     const uint8 b = *pSrc++;
                     const uint8 g = *pSrc++;
                     const uint8 r = *pSrc++;
 
-                    *pDst++ = r;
-                    *pDst++ = g;
                     *pDst++ = b;
+                    *pDst++ = g;
+                    *pDst++ = r;
                     *pDst++ = 0xFF;
                 }
             }

--- a/OgreMain/src/OgreSTBICodec.cpp
+++ b/OgreMain/src/OgreSTBICodec.cpp
@@ -162,7 +162,8 @@ namespace Ogre
             memcpy( imgData->box.data, pixelData, imgData->box.bytesPerImage );
         else
         {
-            size_t realBytesPerRow = PixelFormatGpuUtils::getSizeBytes( imgData->box.width, 1u, 1u, 1u, PFG_RGB8_UNORM, rowAlignment );
+            size_t realBytesPerRow = PixelFormatGpuUtils::getSizeBytes( imgData->box.width, 1u, 1u, 1u,
+                                                                        PFG_RGB8_UNORM, rowAlignment );
 
             for( size_t y = 0; y < (size_t)height; ++y )
             {

--- a/OgreMain/src/OgreSceneManager.cpp
+++ b/OgreMain/src/OgreSceneManager.cpp
@@ -523,13 +523,15 @@ namespace Ogre
     //-----------------------------------------------------------------------
     Item *SceneManager::createItem(
         const String &meshName,
-        const String &groupName, /* = ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME */
-        SceneMemoryMgrTypes sceneType /*= SCENE_DYNAMIC */ )
+        const String &groupName,       /*= ResourceGroupManager::AUTODETECT_RESOURCE_GROUP_NAME*/
+        SceneMemoryMgrTypes sceneType, /*= SCENE_DYNAMIC*/
+        bool bUseMeshMat /*= true */ )
     {
         // delegate to factory implementation
         NameValuePairList params;
         params["mesh"] = meshName;
         params["resourceGroup"] = groupName;
+        params["useMeshMat"] = StringConverter::toString( bUseMeshMat );
         return static_cast<Item *>( createMovableObject( ItemFactory::FACTORY_TYPE_NAME,
                                                          &mEntityMemoryManager[sceneType], &params ) );
     }
@@ -538,6 +540,7 @@ namespace Ogre
     {
         return createItem( pMesh->getName(), pMesh->getGroup(), sceneType );
     }
+
     //-----------------------------------------------------------------------
     void SceneManager::destroyItem( Item *i ) { destroyMovableObject( i ); }
     //-----------------------------------------------------------------------

--- a/OgreMain/src/OgreTextureGpuManager.cpp
+++ b/OgreMain/src/OgreTextureGpuManager.cpp
@@ -2649,7 +2649,6 @@ namespace Ogre
                             strExt = loadRequest.name.substr( pos + 1u );
                         img->load( data, strExt );
                     }
-                       
                 }
                 catch( Exception &e )
                 {

--- a/OgreMain/src/OgreTextureGpuManager.cpp
+++ b/OgreMain/src/OgreTextureGpuManager.cpp
@@ -2642,7 +2642,14 @@ namespace Ogre
                 try
                 {
                     if( data )
-                        img->load( data );
+                    {
+                        String strExt;
+                        size_t pos = loadRequest.name.find_last_of( "." );
+                        if( pos != String::npos && pos < ( loadRequest.name.length() - 1u ) )
+                            strExt = loadRequest.name.substr( pos + 1u );
+                        img->load( data, strExt );
+                    }
+                       
                 }
                 catch( Exception &e )
                 {


### PR DESCRIPTION
When creating an item, add a parameter to specify whether to use the associated material in mesh.

Because the default material will load all textures, we can avoid loading useless textures when we want to set other materials. Especially in my editor, I need to create icons for hundreds of models under the resource folder.

All I need is a blackwhite material. But the default mesh material loads all textures. As a result, icon creation time is very long.