### PR TITLE
Fix pkgconfig for HLMS PBS and Unlit

### DIFF
--- a/CMake/ConfigureBuild.cmake
+++ b/CMake/ConfigureBuild.cmake
@@ -328,7 +328,7 @@ if (UNIX)
     install(FILES ${OGRE_BINARY_DIR}/pkgconfig/OGRE-Volume.pc DESTINATION ${OGRE_LIB_DIRECTORY}/pkgconfig)
   endif ()
 
-  if (OGRE_BUILD_COMPONENT_HLMS)
+  if (OGRE_BUILD_COMPONENT_HLMS_PBS AND OGRE_BUILD_COMPONENT_HLMS_UNLIT)
     configure_file(${OGRE_TEMPLATES_DIR}/OGRE-Hlms.pc.in ${OGRE_BINARY_DIR}/pkgconfig/OGRE-Hlms.pc @ONLY)
     install(FILES ${OGRE_BINARY_DIR}/pkgconfig/OGRE-Hlms.pc DESTINATION ${OGRE_LIB_DIRECTORY}/pkgconfig)
   endif ()


### PR DESCRIPTION
The pkgconfig currently won't be generated as OGRE_COMPONENT_BUILD_HLMS isn't set anywhere in the CMake.
This updates the logic to check for PBS and Unlit to control generation.

Signed-off-by: Michael Carroll <michael@openrobotics.org>