### PR TITLE
Remove unused variable: fAutoConstantBiasScale

### DIFF
--- a/OgreMain/src/Compositor/OgreCompositorShadowNode.cpp
+++ b/OgreMain/src/Compositor/OgreCompositorShadowNode.cpp
@@ -992,22 +992,6 @@ namespace Ogre
     {
         const ShadowTextureDefinition &shadowMapDef =
             mDefinition->mShadowMapTexDefinitions[shadowMapIdx];
-
-        float fAutoConstantBiasScale = 1.0f;
-        if( shadowMapDef.autoNormalOffsetBiasScale != 0.0f )
-        {
-            Light const *light = mShadowMapCastingLights[shadowMapDef.light].light;
-            OGRE_ASSERT_HIGH( light && "Can't call this function if isShadowMapIdxActive is false!" );
-
-            const Camera *texCamera = mShadowMapCameras[shadowMapIdx].camera;
-            if( texCamera->getProjectionType() == PT_ORTHOGRAPHIC )
-            {
-                const Real orthoSize =
-                    std::max( texCamera->getOrthoWindowWidth(), texCamera->getOrthoWindowHeight() );
-                float autoFactor = orthoSize / light->getShadowFarDistance();
-                fAutoConstantBiasScale = 1.0f + autoFactor * shadowMapDef.autoNormalOffsetBiasScale;
-            }
-        }
         return shadowMapDef.normalOffsetBias;
     }
     //-----------------------------------------------------------------------------------


### PR DESCRIPTION
The compiler flags this as an unused variable.  As it turns out, most of
the function body is a no-op, so I removed it as well.

Alternatively, there may be some additional logic that should have been here that was missed? 

Signed-off-by: Michael Carroll <michael@openrobotics.org>