### PR TITLE
Change bitwise operations to logical

### DIFF
--- a/OgreMain/include/Math/Simple/C/OgreAabb.inl
+++ b/OgreMain/include/Math/Simple/C/OgreAabb.inl
@@ -106,8 +106,8 @@ namespace Ogre
         //   abs( center.y - center2.y ) <= halfSize.y + halfSize2.y &&
         //   abs( center.z - center2.z ) <= halfSize.z + halfSize2.z )
         //TODO: Profile whether '&&' or '&' is faster. Probably varies per architecture.
-        return ( Math::Abs( dist.x ) <= sumHalfSizes.x ) &
-                ( Math::Abs( dist.y ) <= sumHalfSizes.y ) &
+        return ( Math::Abs( dist.x ) <= sumHalfSizes.x ) &&
+                ( Math::Abs( dist.y ) <= sumHalfSizes.y ) &&
                 ( Math::Abs( dist.z ) <= sumHalfSizes.z );
     }
     //-----------------------------------------------------------------------------------
@@ -127,8 +127,8 @@ namespace Ogre
         // nan instead and return false, when it should return true)
 
         //TODO: Profile whether '&&' or '&' is faster. Probably varies per architecture.
-        return ( Math::Abs( dist.x ) + other.mHalfSize.x <= mHalfSize.x ) &
-                ( Math::Abs( dist.y ) + other.mHalfSize.y <= mHalfSize.y ) &
+        return ( Math::Abs( dist.x ) + other.mHalfSize.x <= mHalfSize.x ) &&
+                ( Math::Abs( dist.y ) + other.mHalfSize.y <= mHalfSize.y ) &&
                 ( Math::Abs( dist.z ) + other.mHalfSize.z <= mHalfSize.z );
     }
     //-----------------------------------------------------------------------------------
@@ -139,8 +139,8 @@ namespace Ogre
         // ( abs( dist.x ) <= mHalfSize.x &&
         //   abs( dist.y ) <= mHalfSize.y &&
         //   abs( dist.z ) <= mHalfSize.z )
-        return ( Math::Abs( dist.x ) <= mHalfSize.x ) &
-                ( Math::Abs( dist.y ) <= mHalfSize.y ) &
+        return ( Math::Abs( dist.x ) <= mHalfSize.x ) &&
+                ( Math::Abs( dist.y ) <= mHalfSize.y ) &&
                 ( Math::Abs( dist.z ) <= mHalfSize.z );
     }
     //-----------------------------------------------------------------------------------

--- a/OgreMain/src/OgreRootLayout.cpp
+++ b/OgreMain/src/OgreRootLayout.cpp
@@ -205,7 +205,7 @@ namespace Ogre
                     }
                 }
 
-                const bool texTypesInUse = mDescBindingRanges[i][DescBindingTypes::TexBuffer].isInUse() |
+                const bool texTypesInUse = mDescBindingRanges[i][DescBindingTypes::TexBuffer].isInUse() ||
                                            mDescBindingRanges[i][DescBindingTypes::Texture].isInUse();
                 if( texTypesInUse )
                 {
@@ -238,7 +238,7 @@ namespace Ogre
                     }
                 }
 
-                const bool uavTypesInUse = mDescBindingRanges[i][DescBindingTypes::UavBuffer].isInUse() |
+                const bool uavTypesInUse = mDescBindingRanges[i][DescBindingTypes::UavBuffer].isInUse() ||
                                            mDescBindingRanges[i][DescBindingTypes::UavTexture].isInUse();
                 if( uavTypesInUse )
                 {


### PR DESCRIPTION
Newest versions of clang warn on this via warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]

The comments indicate that maybe this was done for performance reasons.  I think without profiling/benchmarking to prove otherwise, it probably makes sense to prefer logical operations in these cases.

Signed-off-by: Michael Carroll <michael@openrobotics.org>