### PR TITLE
Backport HLMS exports for 2.3

### DIFF
--- a/Components/Hlms/Pbs/CMakeLists.txt
+++ b/Components/Hlms/Pbs/CMakeLists.txt
@@ -40,6 +40,8 @@ if( OGRE_BUILD_COMPONENT_PLANAR_REFLECTIONS )
 	ogre_add_component_include_dir( PlanarReflections )
 endif()
 
+add_definitions( -DOgreHlmsPbs_EXPORTS )
+
 ogre_add_library(${OGRE_NEXT}HlmsPbs ${OGRE_COMP_LIB_TYPE} ${HEADER_FILES} ${SOURCE_FILES})
 set_target_properties(${OGRE_NEXT}HlmsPbs PROPERTIES VERSION ${OGRE_SOVERSION} SOVERSION ${OGRE_SOVERSION})
 target_link_libraries(${OGRE_NEXT}HlmsPbs ${OGRE_NEXT}Main)

--- a/Components/Hlms/Unlit/CMakeLists.txt
+++ b/Components/Hlms/Unlit/CMakeLists.txt
@@ -26,6 +26,8 @@ file(
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Common/include)
 
+add_definitions( -DOgreHlmsUnlit_EXPORTS )
+
 ogre_add_library(${OGRE_NEXT}HlmsUnlit ${OGRE_COMP_LIB_TYPE} ${HEADER_FILES} ${SOURCE_FILES})
 set_target_properties(${OGRE_NEXT}HlmsUnlit PROPERTIES VERSION ${OGRE_SOVERSION} SOVERSION ${OGRE_SOVERSION})
 target_link_libraries(${OGRE_NEXT}HlmsUnlit ${OGRE_NEXT}Main)


### PR DESCRIPTION
Will help Windows build without patching 

Taken from: https://github.com/conda-forge/ogre-next-feedstock/blob/main/recipe/backport_hlms_bugfix.patch

Co-authored-by: Matias N. Goldberg <dark_sylinc@yahoo.com.ar>
Signed-off-by: Michael Carroll <michael@openrobotics.org>