### PR TITLE
Unregister Windows class when destroying

### DIFF
--- a/RenderSystems/GL3Plus/src/windowing/win32/OgreWin32Window.cpp
+++ b/RenderSystems/GL3Plus/src/windowing/win32/OgreWin32Window.cpp
@@ -742,6 +742,11 @@ namespace Ogre
         mHDC = 0; // no release thanks to CS_OWNDC wndclass style
         mHwnd = 0;
 
+        if (mClassRegistered)
+        {
+            UnregisterClassA("OgreGLWindow", nullptr);
+        }
+
         if (mDeviceName != NULL)
         {
             delete[] mDeviceName;


### PR DESCRIPTION
This prevents issues with repeated library loads in the same process.

Signed-off-by: Michael Carroll <michael@openrobotics.org>