### PR TITLE
Update SettingUpOgreAndroid.md

### DIFF
--- a/Docs/src/SettingUpOgre/SettingUpOgreAndroid.md
+++ b/Docs/src/SettingUpOgre/SettingUpOgreAndroid.md
@@ -48,7 +48,7 @@ cmake \
 make -j9
 make install
 
-cd ../../../
+cd ../../../../
 
 # Download ogre-next
 git clone --branch master https://github.com/OGRECave/ogre-next


### PR DESCRIPTION
Having "../../.." while in ogre-next-deps/build/Android/Release
will bring us to "ogre-next-deps" not it's parent directory.