### PR TITLE
fix custom projection

### DIFF
--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -113,7 +113,7 @@ namespace Ogre
         Vector2 retVal;
 
         const RenderSystem *renderSystem = Root::getSingleton().getRenderSystem();
-        if(getProjectionType() == PT_PERSPECTIVE)
+        if( getProjectionType() == PT_PERSPECTIVE )
         {
             if( !renderSystem->isReverseDepth() )
             {
@@ -130,13 +130,13 @@ namespace Ogre
         {
             if( !renderSystem->isReverseDepth() )
             {
-                retVal.x = -nearPlane / ( farPlane - nearPlane );                // projectionA
-                retVal.y = Real( -1.0 ) / ( farPlane - nearPlane );              // projectionB
+                retVal.x = -nearPlane / ( farPlane - nearPlane );    // projectionA
+                retVal.y = Real( -1.0 ) / ( farPlane - nearPlane );  // projectionB
             }
             else
             {
-                retVal.x = farPlane / ( farPlane - nearPlane );                   // projectionA
-                retVal.y = Real( -1.0 ) / ( farPlane - nearPlane );               // projectionB
+                retVal.x = farPlane / ( farPlane - nearPlane );      // projectionA
+                retVal.y = Real( -1.0 ) / ( farPlane - nearPlane );  // projectionB
             }
         }
 

--- a/OgreMain/src/OgreFrustum.cpp
+++ b/OgreMain/src/OgreFrustum.cpp
@@ -562,7 +562,7 @@ namespace Ogre
 
         RenderSystem *renderSystem = Root::getSingleton().getRenderSystem();
         // API specific for Gpu Programs
-        if( !mObliqueDepthProjection )
+        if( !mObliqueDepthProjection && !mCustomProjMatrix )
         {
             renderSystem->_makeRsProjectionMatrix( mProjMatrix, mProjMatrixRSDepth, mNearDist, mFarDist,
                                                    mProjType );


### PR DESCRIPTION
When a custom projection matrix is in use, `Frustum::updateFrustumImpl` should call `renderSystem->_convertProjectionMatrix` rather than `renderSystem->_makeRsProjectionMatrix`, because the latter can overwrite customized entries of the projection matrix.