### PR TITLE
Also use __PPC__ and __PPC64__ to detect PPC platforms

### DIFF
--- a/OgreMain/include/OgrePlatform.h
+++ b/OgreMain/include/OgrePlatform.h
@@ -65,7 +65,8 @@ THE SOFTWARE.
 #if defined( __i386__ ) || defined( __x86_64__ ) || defined( _M_IX86 ) || defined( _M_X64 ) || \
     defined( _M_AMD64 ) || defined( __e2k__ )
 #    define OGRE_CPU OGRE_CPU_X86
-#elif defined( __ppc__ ) || defined( __ppc64__ ) || defined( _M_PPC )
+#elif defined( __ppc__ ) || defined( __PPC__ ) || defined( __ppc64__ ) || defined( __PPC64__ ) || \
+      defined( _M_PPC )
 #    define OGRE_CPU OGRE_CPU_PPC
 #elif defined( __arm__ ) || defined( __arm64__ ) || defined( __aarch64__ ) || defined( _M_ARM ) || \
     defined( _M_ARM64 )
@@ -78,9 +79,9 @@ THE SOFTWARE.
 
 /* Find the arch type */
 #if defined( __x86_64__ ) || defined( _M_X64 ) || defined( _M_X64 ) || defined( _M_AMD64 ) || \
-    defined( __ppc64__ ) || defined( __arm64__ ) || defined( __aarch64__ ) || defined( _M_ARM64 ) || \
-    defined( __mips64 ) || defined( __mips64_ ) || defined( __alpha__ ) || defined( __ia64__ ) || \
-    defined( __e2k__ ) || defined( __s390__ ) || defined( __s390x__ )
+    defined( __ppc64__ ) || defined( __PPC64__ ) || defined( __arm64__ ) || defined( __aarch64__ ) || \
+    defined( _M_ARM64 ) || defined( __mips64 ) || defined( __mips64_ ) || defined( __alpha__ ) || \
+    defined( __ia64__ ) || defined( __e2k__ ) || defined( __s390__ ) || defined( __s390x__ )
 #    define OGRE_ARCH_TYPE OGRE_ARCHITECTURE_64
 #else
 #    define OGRE_ARCH_TYPE OGRE_ARCHITECTURE_32


### PR DESCRIPTION
While building the latest ogre-next for ppc64le, I had problems building as ogre is using `__ppc__` and `__ppc64__` to detect if it is running on ppc. However, at least on my system (see https://github.com/conda-forge/ogre-next-feedstock/pull/13#issuecomment-1327923352 based on GCC, https://github.com/gcc-mirror/gcc/blob/e6a32c12b4ef87c084d29863c79503344126d101/gcc/config/rs6000/linux64.h#L300), `__ppc__` and `__ppc64__` were not defined while `__PPC__` and `__PPC64__` are defined.