### PR TITLE
Remove contentScaleFactor property from the macOS OgreMetalView

### DIFF
--- a/RenderSystems/Metal/include/Windowing/OSX/OgreMetalView.h
+++ b/RenderSystems/Metal/include/Windowing/OSX/OgreMetalView.h
@@ -41,20 +41,12 @@ _OgreMetalExport @interface OgreMetalView : NSView
 
 @property( nonatomic, readwrite ) BOOL layerSizeDidUpdate;
 
-/// When true (default), we will try to set the contentScaleFactor to the native's.
 /// You can use 'nativeScaleFactor' for further control.
-/// Note: Changing contentScaleFactor directly will force this value to false.
 @property( nonatomic ) bool scaleToNative;
 
 /// When scaleToNative = true, instead of setting self.contentScaleFactor, you
 /// should change this setting. It's expressed in fractions of the nativeScale.
-///
-/// For example on an iPad Mini 3 the native factor is 2.0; thus if you set
-/// nativeScaleFactor = 1; then contentScaleFactor = 2.0
-/// If you set nativeScaleFactor = 0.5; we'll set contentScaleFactor = 1.0
 @property( nonatomic ) CGFloat nativeScaleFactor;
-
-@property( nonatomic ) CGFloat contentScaleFactor;
 
 /// The value of presentationTime will be passed to
 /// MTLCommandBuffer::presentDrawable atTime:presentationTime

--- a/RenderSystems/Metal/src/Windowing/OSX/OgreMetalView.mm
+++ b/RenderSystems/Metal/src/Windowing/OSX/OgreMetalView.mm
@@ -50,8 +50,6 @@ THE SOFTWARE.
 
 - (void)viewDidMoveToWindow
 {
-    // if(self.scaleToNative)
-    //    [setContentScaleFactor:self.window.screen.backingScaleFactor * self.nativeScaleFactor];
     _layerSizeDidUpdate = YES;
 }
 
@@ -92,13 +90,6 @@ THE SOFTWARE.
     {
         return [self.superview acceptsFirstMouse:theEvent];
     }
-}
-
-- (void)setContentScaleFactor:(CGFloat)contentScaleFactor
-{
-    self.scaleToNative = false;
-    //[super setContentScaleFactor:contentScaleFactor];
-    _layerSizeDidUpdate = YES;
 }
 
 - (void)setFrameSize:(NSSize)newSize


### PR DESCRIPTION
When compiling RenderSystem_Metal for macOS, I was getting a warning

```
Ivar '_contentScaleFactor' which backs the property is not referenced in this property's accessor
```

when compiling the method `setContentsScaleFactor:` of the `OgreMetalView` class.  That got me to look at what this property is used for, and I concluded that it is not needed at all.  This is in contrast to iOS, where `OgreMetalView` derives from `UIView`, which has a `contentScaleFactor` property.