### PR TITLE
Fix Xcode compile error caused by header confusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ if (APPLE AND NOT ANDROID)
   set(CMAKE_XCODE_ATTRIBUTE_GCC_VERSION "com.apple.compilers.llvm.clang.1_0")
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+  set(CMAKE_XCODE_ATTRIBUTE_USE_HEADERMAP NO)
 endif ()
 
 # This option needs to be set now


### PR DESCRIPTION
Without this change, Xcode 14.2 gives compile errors in src/OgreTagPoint.cpp.  It seems that when it says #include "OgreTagPoint.h", it's reading Animation/OgreTagPoint.h.