### PR TITLE
Fix C++20 compile errors in Xcode 14.3

### DIFF
--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -1507,7 +1507,7 @@ namespace Ogre
 
     public:
         GpuProgramParameters();
-        ~GpuProgramParameters() {}
+        ~GpuProgramParameters() = default;
 
         /// Copy constructor
         GpuProgramParameters( const GpuProgramParameters &oth );
@@ -1983,7 +1983,7 @@ namespace Ogre
         /** Gets an iterator over the automatic constant bindings currently in place. */
         AutoConstantIterator getAutoConstantIterator() const;
         /// Gets the number of int constants that have been set
-        size_t getAutoConstantCount() const { return mAutoConstants.size(); }
+        size_t getAutoConstantCount() const;
         /** Gets a specific Auto Constant entry if index is in valid range
             otherwise returns a NULL
             @param index which entry is to be retrieved
@@ -2516,6 +2516,8 @@ namespace Ogre
         {
         }
     };
+
+	inline size_t GpuProgramParameters::getAutoConstantCount() const { return mAutoConstants.size(); }
 
     /** @} */
     /** @} */

--- a/OgreMain/include/OgreGpuProgramParams.h
+++ b/OgreMain/include/OgreGpuProgramParams.h
@@ -2517,7 +2517,7 @@ namespace Ogre
         }
     };
 
-	inline size_t GpuProgramParameters::getAutoConstantCount() const { return mAutoConstants.size(); }
+    inline size_t GpuProgramParameters::getAutoConstantCount() const { return mAutoConstants.size(); }
 
     /** @} */
     /** @} */

--- a/OgreMain/src/OgreTextureGpuManager.cpp
+++ b/OgreMain/src/OgreTextureGpuManager.cpp
@@ -2701,7 +2701,7 @@ namespace Ogre
             }
             bStillHasWork = !mMultiLoads.empty();
             // We use memory_order_relaxed because the mutex already guarantees ordering.
-            bUseMultiload = mUseMultiload.load( std::memory_order::memory_order_relaxed );
+            bUseMultiload = mUseMultiload.load( std::memory_order_relaxed );
             mMultiLoadsMutex.unlock();
 
             if( bWorkGrabbed )


### PR DESCRIPTION
The changes in OgreGpuProgramParams.h fix cryptic compile errors in recent versions of Clang when compiling as C++20.  See issue #370.  It's not clear at this point whether the bug really belongs to Ogre or Clang, but the changes seem innocuous enough.

The change in OgreTextureGpuManager.cpp is more clearly a bug in Ogre:  As of C++20, `std::memory_order` is an enum class, but `memory_order_relaxed` is not one of its members.