### PR TITLE
Fix Compile Warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ if(CMAKE_VS_PLATFORM_NAME STREQUAL "Tegra-Android")
 	set(CMAKE_LINK_LIBRARY_FLAG "")
 endif()
 
+#fix Policy CMP0072 is not set
+set(OpenGL_GL_PREFERENCE LEGACY)
 
 # Use relative paths
 # This is mostly to reduce path size for command-line limits on windows


### PR DESCRIPTION
when i compile ogre, i have this warning: OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for  compatibility with CMake 3.10 and below the legacy GL library will be used.
To solve the warning:
Policy CMP0072 says that I need to set OpenGL_GL_PREFERENCE to LEGACY.