### PR TITLE
bugfix: memory leak due to undeleted stereo driver bridge

### DIFF
--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -206,6 +206,12 @@ namespace Ogre
             mHLSLProgramFactory = 0;
         }
 
+#if OGRE_NO_QUAD_BUFFER_STEREO == 0
+        // Stereo driver must be freed after device is created
+        D3D11StereoDriverBridge* stereoBridge = D3D11StereoDriverBridge::getSingletonPtr();
+        OGRE_DELETE stereoBridge;
+#endif
+
         LogManager::getSingleton().logMessage( "D3D11: " + getName() + " destroyed." );
     }
     //---------------------------------------------------------------------


### PR DESCRIPTION
Stereo driver must be freed after device is created.

This bug is probably also included in Ogre1.