### PR TITLE
Uniform cmake_min_Version into ogre_next

### DIFF
--- a/CMake/Templates/SDK_CMakeLists.txt.in
+++ b/CMake/Templates/SDK_CMakeLists.txt.in
@@ -11,15 +11,9 @@
 # OGRE SAMPLES BUILD SYSTEM
 ######################################################################
 
-cmake_minimum_required(VERSION 2.6.2)
+cmake_minimum_required(VERSION 3.5.1)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
 cmake_policy(SET CMP0003 NEW)
-
-# CMake 2.8.2 has a bug that creates unusable Xcode projects when using ARCHS_STANDARD_32_BIT
-# to specify both armv6 and armv7.
-if(OGRE_BUILD_PLATFORM_APPLE_IOS AND (CMAKE_VERSION VERSION_EQUAL 2.8.2) AND (CMAKE_GENERATOR STREQUAL "Xcode"))
-	message(FATAL_ERROR "CMake 2.8.2 cannot create compatible Xcode projects for iOS, please download the latest version or an older release from http://www.cmake.org/files/")
-endif()
 
 # Just debug / release since that's all that's included in SDK. Only release for iOS/OS X
 if(APPLE)

--- a/Samples/2.0/AndroidAppTemplate/Template/app/CMakeLists.txt
+++ b/Samples/2.0/AndroidAppTemplate/Template/app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.5.1)
 
 # build native_app_glue as a static lib
 set( APP_GLUE_DIR ${ANDROID_NDK}/sources/android/native_app_glue )

--- a/Samples/2.0/Tutorials/EmptyProject/CMakeLists.txt
+++ b/Samples/2.0/Tutorials/EmptyProject/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 #set( CMAKE_TOOLCHAIN_FILE CMake/iOS.cmake )
 
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.5.1 )
 project( EmptyProject )
 
 set( EXECUTABLE_OUTPUT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/bin/${CMAKE_BUILD_TYPE}" )


### PR DESCRIPTION
I standardized the cmake version using the highest one required by the project.
