### PR TITLE
GL3Plus: If GL_ARB_copy_image is not available, use GL_NV_copy_image

### DIFF
--- a/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp
@@ -649,15 +649,23 @@ namespace Ogre
                                           dstBox.getZOrSlice() + dstGl->getInternalSliceStart(),
                                           srcBox.width, srcBox.height, srcBox.getDepthOrSlices() ) );
             }
-            /*TODO
             else if( support.checkExtension( "GL_NV_copy_image" ) )
-            {
-                OCGE( glCopyImageSubDataNV( this->mFinalTextureName, this->mGlTextureTarget,
-                                            srcMipLevel, srcBox.x, srcBox.y, srcBox.z,
-                                            dstGl->mFinalTextureName, dstGl->mGlTextureTarget,
-                                            dstMipLevel, dstBox.x, dstBox.y, dstBox.z,
-                                            srcBox.width, srcBox.height, srcBox.getDepthOrSlices() ) );
-            }*/
+            {                
+                 // Initialize the pointer only the first time
+                PFNGLCOPYIMAGESUBDATANVPROC local_glCopyImageSubDataNV = nullptr;
+                if (!local_glCopyImageSubDataNV)
+                {
+                    local_glCopyImageSubDataNV = (PFNGLCOPYIMAGESUBDATANVPROC)gl3wGetProcAddress("glCopyImageSubDataNV");
+                }
+
+                OCGE( local_glCopyImageSubDataNV( this->mFinalTextureName, this->mGlTextureTarget,
+                                                  srcMipLevel, srcBox.x, srcBox.y,
+                                                  srcBox.getZOrSlice() + this->getInternalSliceStart(),
+                                                  dstGl->mFinalTextureName, dstGl->mGlTextureTarget,
+                                                  dstMipLevel, dstBox.x, dstBox.y,
+                                                  dstBox.getZOrSlice() + dstGl->getInternalSliceStart(),
+                                                  srcBox.width, srcBox.height, srcBox.getDepthOrSlices() ) );
+            }
             /*TODO: These are for OpenGL ES 3.0+
             else if( support.checkExtension( "GL_OES_copy_image" ) )
             {


### PR DESCRIPTION
This fixes crashes like: 
~~~
terminate called after throwing an instance of 'Ogre::UnimplementedException'
  what():  OGRE EXCEPTION(9:UnimplementedException):  in GL3PlusTextureGpu::copyTo at /build/ogre-next-UFfg83/ogre-next-2.2.5+dfsg3/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp (line 677)
Stack trace (most recent call last) in thread 3740:
#10   Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in
#9    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f5543e699ff, in
#8    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f5543dd7b42, in
#7    Object "/lib/x86_64-linux-gnu/libQt5Core.so.5", at 0x7f553e22399d, in
#6    Object "/lib/x86_64-linux-gnu/libQt5Core.so.5", at 0x7f553e221f90, in qTerminate()
#5    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f553fe642f6, in std::terminate()
#4    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f553fe6428b, in
#3    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7f553fe58bfd, in
#2    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f5543d6b7f2, in abort
#1    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f5543d85475, in raise
#0    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7f5543dd9a7c, in pthread_kill
Aborted (Signal sent by tkill() 3665 1000)
~~~

when OgreNext runs on system that do not implement GL_ARB_copy_image, such as d3d12 mesa driver, that is used for hardware acceleration on WSLg (see https://github.com/gazebosim/gz-sim/issues/920).