### PR TITLE
Terra fix shader w/o metalness or roughness map(s)

### DIFF
--- a/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/Main/200.BRDFs_piece_ps.any
@@ -331,7 +331,7 @@ midf3 BRDF_IR( midf3 lightDir, midf3 lightDiffuse, PixelData pixelData )
 			midf3 clearCoatEnvBRDF = midf3_c( 1.0f, 0.0f, 1.0f );
 		@end
 
-		Rs += pixelData.clearCoatEnvColourS * pixelData.specular.xyz * ( _h ( 0.04 ) * clearCoatEnvBRDF.x + clearCoatEnvBRDF.y ) * pixelData.clearCoat;
+		Rs += pixelData.clearCoatEnvColourS * pixelData.specular.xyz * ( _h( 0.04 ) * clearCoatEnvBRDF.x + clearCoatEnvBRDF.y ) * pixelData.clearCoat;
 	@end
 
 	finalColour += Rd + Rs;

--- a/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
@@ -142,7 +142,7 @@
 												  material.detailOffsetScale[@n].xy,
 												  texIndex_detailMetalnessIdx@n ).x;
 		@else
-			midf metalness@n = _h( 0 );
+			midf metalness@n = _h( 1.0 );
 		@end
 	@end
 
@@ -167,7 +167,7 @@
 												  material.detailOffsetScale[@n].xy,
 												  texIndex_detailRoughnessIdx@n ).x;
 		@else
-			midf roughness@n = _h( 0 );
+			midf roughness@n = _h( 1.0 );
 		@end
 	@end
 


### PR DESCRIPTION
Just like I wrote here:
https://forums.ogre3d.org/viewtopic.php?p=554764#p554764
Now I can use values set by `terraDatablock->setRoughness` and `terraDatablock->setMetalness`, without maps.
BTW IDK why there's 3 commits here, previous are merged already.