### PR TITLE
Two portability / build fixes

### DIFF
--- a/Components/SceneFormat/src/OgreSceneFormatExporter.cpp
+++ b/Components/SceneFormat/src/OgreSceneFormatExporter.cpp
@@ -50,21 +50,9 @@ THE SOFTWARE.
 #include "OgreSceneManager.h"
 #include "OgreTextureGpuManager.h"
 
-#include "math.h"
-
+#include <cmath>
 #include <fstream>
 #include <queue>
-
-#if OGRE_COMPILER == OGRE_COMPILER_MSVC && OGRE_COMP_VER < 1800
-inline float isfinite( float x )
-{
-    return _finite( x ) == 0;
-}
-inline float isinf( float x )
-{
-    return x == std::numeric_limits<float>::infinity() || x == -std::numeric_limits<float>::infinity();
-}
-#endif
 
 #define SceneFormatExporterNumFloatBins \
     ( sizeof( mFloatBinTmpString ) / sizeof( mFloatBinTmpString[0] ) )
@@ -144,11 +132,11 @@ namespace Ogre
             strValue.a( encodeFloatBin( value ) );
         else
         {
-            if( isfinite( value ) )
+            if( std::isfinite( value ) )
                 strValue.a( LwString::Float( value, 9 ) );
             else
             {
-                if( isinf( value ) )
+                if( std::isinf( value ) )
                     strValue.a( value > 0 ? "\"inf\"" : "\"-inf\"" );
                 else
                     strValue.a( "\"nan\"" );
@@ -168,11 +156,11 @@ namespace Ogre
             strValue.a( encodeDoubleBin( value ) );
         else
         {
-            if( isfinite( value ) )
+            if( std::isfinite( value ) )
                 strValue.a( LwString::Float( (float)value, 18 ) );
             else
             {
-                if( isinf( value ) )
+                if( std::isinf( value ) )
                     strValue.a( value > 0 ? "\"inf\"" : "\"-inf\"" );
                 else
                     strValue.a( "\"nan\"" );

--- a/OgreMain/include/OgreBitwise.h
+++ b/OgreMain/include/OgreBitwise.h
@@ -37,10 +37,17 @@ THE SOFTWARE.
 #    define __has_builtin( x ) 0
 #endif
 
-#if OGRE_PLATFORM == OGRE_PLATFORM_FREEBSD
-/// Undefine in <sys/endian.h> defined bswap macros for FreeBSD
+/// bswapNN may be defined as macros in <sys/endian.h> or <sys/bswap.h>
+#ifdef bswap16
+#    define bswap16_sav bswap16
 #    undef bswap16
+#endif
+#ifdef bswap32
+#    define bswap32_sav bswap32
 #    undef bswap32
+#endif
+#ifdef bswap64
+#    define bswap64_sav bswap64
 #    undef bswap64
 #endif
 
@@ -554,12 +561,19 @@ namespace Ogre
 
 }  // namespace Ogre
 
-/** Redefine in <sys/endian.h> defined bswap macros for FreeBSD
+/** Redefine bswap macros temporarily undefined above
  */
-#if OGRE_PLATFORM == OGRE_PLATFORM_FREEBSD
-#    define bswap16( x ) __bswap16( x )
-#    define bswap32( x ) __bswap32( x )
-#    define bswap64( x ) __bswap64( x )
+#ifdef bswap16_sav
+#    define bswap16 bswap16_sav
+#    undef bswap16_sav
+#endif
+#ifdef bswap32_sav
+#    define bswap32 bswap32_sav
+#    undef bswap32_sav
+#endif
+#ifdef bswap64_sav
+#    define bswap64 bswap64_sav
+#    undef bswap64_sav
 #endif
 
 #endif

--- a/OgreMain/include/OgreSilentMemory.h
+++ b/OgreMain/include/OgreSilentMemory.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
 
 #include <string.h>
 
-#if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __MINGW32__ )
+#if defined( __GNUC__ ) && !defined( __clang__ ) && defined( __nonnull ) && defined( __fortify_function )
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wclass-memaccess"
 


### PR DESCRIPTION
1) OgreSilentMemory.h is in fact for glibc rather than just gcc
2) bswap16 and friends are not just defined on FreeBSD