### PR TITLE
Add sortByName to HlmsJson::saveMaterials

### DIFF
--- a/OgreMain/include/OgreHlmsJson.h
+++ b/OgreMain/include/OgreHlmsJson.h
@@ -170,7 +170,8 @@ namespace Ogre
             Leave it blank if you don't know what to put
         */
         void saveMaterials( const Hlms *hlms, String &outString,
-                            const String &additionalTextureExtension );
+                            const String &additionalTextureExtension,
+                            bool sortByName = false);
 
         /** Saves a single datablock to a string
         @param datablock

--- a/OgreMain/src/OgreHlmsJson.cpp
+++ b/OgreMain/src/OgreHlmsJson.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 */
 
 #include "OgreStableHeaders.h"
+#include "OgreIdString.h"
 
 #if !OGRE_NO_JSON
 
@@ -1012,7 +1013,8 @@ namespace Ogre
     }
     //-----------------------------------------------------------------------------------
     void HlmsJson::saveMaterials( const Hlms *hlms, String &outString,
-                                  const String &additionalTextureExtension )
+                                  const String &additionalTextureExtension,
+                                  bool sortByName )
     {
         outString += "{";
 
@@ -1113,14 +1115,42 @@ namespace Ogre
 
             Hlms::HlmsDatablockMap::const_iterator itor = datablockMap.begin();
             Hlms::HlmsDatablockMap::const_iterator endt = datablockMap.end();
-
-            while( itor != endt )
+        
+            if (sortByName)
             {
-                const HlmsDatablock *datablock = itor->second.datablock;
+                std::map<std::string, IdString> sortedMap;
+                while( itor != endt )
+                {
+                    sortedMap[itor->second.name] = itor->first;
+                    ++itor;
+                }
 
-                if( datablock != defaultDatablock )
-                    saveDatablock( itor->second.name, datablock, outString, additionalTextureExtension );
-                ++itor;
+                std::map<std::string, IdString>::const_iterator itor2 = sortedMap.begin();
+                std::map<std::string, IdString>::const_iterator endt2 = sortedMap.end();
+
+                while( itor2 != endt2 )
+                {
+                    Hlms::HlmsDatablockMap::const_iterator itorFind = datablockMap.find(itor2->second);
+                    if (itorFind != endt)
+                    {
+                        const HlmsDatablock *datablock = itorFind->second.datablock;
+
+                        if( datablock != defaultDatablock )
+                            saveDatablock( itorFind->second.name, datablock, outString, additionalTextureExtension );
+                    }
+                    ++itor2;
+                }
+            }
+            else
+            {
+                while( itor != endt )
+                {
+                    const HlmsDatablock *datablock = itor->second.datablock;
+
+                    if( datablock != defaultDatablock )
+                        saveDatablock( itor->second.name, datablock, outString, additionalTextureExtension );
+                    ++itor;
+                }
             }
 
             if( numDatablocks > 1u )


### PR DESCRIPTION
So by default as before. But with true, we can have sorted materials by name saved.