### PR TITLE
Fix OpenGL Win32 window ignoring "hidden" parameter

### DIFF
--- a/RenderSystems/GL3Plus/src/windowing/win32/OgreWin32Window.cpp
+++ b/RenderSystems/GL3Plus/src/windowing/win32/OgreWin32Window.cpp
@@ -143,7 +143,6 @@ namespace Ogre
         int left = -1;  // Defaults to screen center
         int top = -1;   // Defaults to screen center
         HWND parentHwnd = 0;
-        bool hidden = false;
         String border;
         bool outerSize = false;
         mHwGamma = false;
@@ -171,7 +170,7 @@ namespace Ogre
                 mVSync = StringConverter::parseBool( opt->second );
             opt = miscParams->find( "hidden" );
             if( opt != end )
-                hidden = StringConverter::parseBool( opt->second );
+                mHidden = StringConverter::parseBool( opt->second );
             opt = miscParams->find( "vsyncInterval" );
             if( opt != end )
                 mVSyncInterval = StringConverter::parseUnsignedInt( opt->second );
@@ -320,8 +319,8 @@ namespace Ogre
             strcpy( mDeviceName, monitorInfoEx.szDevice );
 
             // Update window style flags.
-            mFullscreenWinStyle = ( hidden ? 0 : WS_VISIBLE ) | WS_CLIPCHILDREN | WS_POPUP;
-            mWindowedWinStyle = ( hidden ? 0 : WS_VISIBLE ) | WS_CLIPCHILDREN;
+            mFullscreenWinStyle = ( mHidden ? 0 : WS_VISIBLE ) | WS_CLIPCHILDREN | WS_POPUP;
+            mWindowedWinStyle = ( mHidden ? 0 : WS_VISIBLE ) | WS_CLIPCHILDREN;
 
             if( parentHwnd )
             {
@@ -679,8 +678,6 @@ namespace Ogre
         mTexture->_transitionTo( GpuResidency::Resident, (uint8 *)0 );
         if( mDepthBuffer )
             mDepthBuffer->_transitionTo( GpuResidency::Resident, (uint8 *)0 );
-
-        setHidden( mHidden );
     }
     //-----------------------------------------------------------------------------------
     void Win32Window::destroy()


### PR DESCRIPTION
Currently, when creating a render window on OpenGL Win32 with the "hidden" parameter set to true the window remains visible.
This is because `mHidden` is never set correctly and while the window is correctly created invisible, it immediately gets updated afterwards based on the (wrong) value of `mHidden`.

This fix sets `mHidden` to the correct value and also removes the redundant call to `SetHidden()`.