### PR TITLE
Diffuse/specular parameters are mixed incorrectly. Or not?

### DIFF
--- a/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
+++ b/Samples/Media/Hlms/Pbs/Any/AmbientLighting_piece_ps.any
@@ -78,9 +78,9 @@
 			{
 		@end
 				pixelData.envColourS += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
-											  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
-				pixelData.envColourD += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
 											  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
+				pixelData.envColourD += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+											  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
 		@property( vct_num_probes )
 			}
 		@end

--- a/Samples/Media/Hlms/Pbs/GLSLES/PixelShader_ps.glsl
+++ b/Samples/Media/Hlms/Pbs/GLSLES/PixelShader_ps.glsl
@@ -494,11 +494,11 @@ void main()
 		float ambientWS = dot( passBuf.ambientHemisphereDir.xyz, reflDir ) * 0.5 + 0.5;
 
 		@property( use_envprobe_map || hlms_use_ssr || use_planar_reflections )
-			envColourS	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-			envColourD	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			envColourS	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			envColourD	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
 		@end @property( !use_envprobe_map && !hlms_use_ssr && !use_planar_reflections )
-			vec3 envColourS = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-			vec3 envColourD = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			vec3 envColourS = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			vec3 envColourD = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
 		@end
 	@end
 

--- a/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
+++ b/Samples/Media/Hlms/Terra/Any/800.PixelShader_piece_ps.any
@@ -374,17 +374,17 @@
 					{
 				@end
 						pixelData.envColourS += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
-													  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
-						pixelData.envColourD += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
 													  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
+						pixelData.envColourD += lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+													  midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
 				@property( vct_num_probes )
 					}
 				@end
 			@else
 				pixelData.envColourS = lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
-											 midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
-				pixelData.envColourD = lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
 											 midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWS );
+				pixelData.envColourD = lerp( midf3_c( passBuf.ambientLowerHemi.xyz ),
+											 midf3_c( passBuf.ambientUpperHemi.xyz ), ambientWD );
 			@end
 		@end
 		@property( ambient_fixed && vct_num_probes )

--- a/Samples/Media/Hlms/Terra/GLSLES/PixelShader_ps.glsl
+++ b/Samples/Media/Hlms/Terra/GLSLES/PixelShader_ps.glsl
@@ -299,11 +299,11 @@ void main()
 		float ambientWS = dot( passBuf.ambientHemisphereDir.xyz, reflDir ) * 0.5 + 0.5;
 
 		@property( envprobe_map )
-			envColourS	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-			envColourD	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			envColourS	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			envColourD	+= mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
 		@end @property( !envprobe_map )
-			vec3 envColourS = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
-			vec3 envColourD = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			vec3 envColourS = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWS );
+			vec3 envColourD = mix( passBuf.ambientLowerHemi.xyz, passBuf.ambientUpperHemi.xyz, ambientWD );
 		@end
 	@end
 


### PR DESCRIPTION
Diffuse/specular parameters are mixed incorrectly. Or not?
In any case, there are visible differences.
Left picture as it is. Right picture with my changes.

I have only set ambient light in the scene: 
`sceneManager->setAmbientLight( Ogre::ColourValue( 1.0f, 0.0f, 0.0f ), Ogre::ColourValue( 1.0f, 1.0f, 1.0f ), Ogre::Vector3::UNIT_Y);`

![example](https://github.com/OGRECave/ogre-next/assets/98119869/d2138ffc-5938-4e91-9627-3033c45d4a9e)
