### PR TITLE
Main: move the adjacency flag to render operation where it belongs

### DIFF
--- a/Docs/src/manual.texi
+++ b/Docs/src/manual.texi
@@ -1985,12 +1985,6 @@ If your vertex program makes use of @ref{Vertex Texture Fetch}, you should decla
 	uses_vertex_texture_fetch true
 @end example
 	
-@subheading Adjacency information in Geometry Programs
-Some geometry programs require adjacency information from the geometry. It means that a geometry shader doesn't only get the information of the primitive it operates on, it also has access to its neighbours (in the case of lines or triangles). This directive will tell Ogre to send the information to the geometry shader.
-@example
-	uses_adjacency_information true
-@end example
-	
 @subheading Vertex Programs With Shadows
 When using shadows (@xref{Shadows}), the use of vertex programs can add some additional complexities, because Ogre can only automatically deal with everything when using the fixed-function pipeline. If you use vertex programs, and you are also using shadows, you may need to make some adjustments. @*@*
 

--- a/OgreMain/include/OgreCommon.h
+++ b/OgreMain/include/OgreCommon.h
@@ -127,7 +127,18 @@ namespace Ogre {
         OT_PATCH_29_CONTROL_POINT   = 35,
         OT_PATCH_30_CONTROL_POINT   = 36,
         OT_PATCH_31_CONTROL_POINT   = 37,
-        OT_PATCH_32_CONTROL_POINT   = 38
+        OT_PATCH_32_CONTROL_POINT   = 38,
+        // max valid base OT_ = (1 << 6) - 1
+        /// Mark that the index buffer contains adjacency information
+        OT_DETAIL_ADJACENCY_BIT = 1 << 6,
+        /// like OT_POINT_LIST but with adjacency information for the geometry shader
+        OT_LINE_LIST_ADJ = OT_LINE_LIST | OT_DETAIL_ADJACENCY_BIT,
+        /// like OT_LINE_STRIP but with adjacency information for the geometry shader
+        OT_LINE_STRIP_ADJ = OT_LINE_STRIP | OT_DETAIL_ADJACENCY_BIT,
+        /// like OT_TRIANGLE_LIST but with adjacency information for the geometry shader
+        OT_TRIANGLE_LIST_ADJ = OT_TRIANGLE_LIST | OT_DETAIL_ADJACENCY_BIT,
+        /// like OT_TRIANGLE_STRIP but with adjacency information for the geometry shader
+        OT_TRIANGLE_STRIP_ADJ = OT_TRIANGLE_STRIP | OT_DETAIL_ADJACENCY_BIT
     };
 
     /** Comparison functions used for the depth/stencil buffer operations and 

--- a/OgreMain/include/OgreGpuProgram.h
+++ b/OgreMain/include/OgreGpuProgram.h
@@ -478,13 +478,9 @@ namespace Ogre
             return mVpAndRtArrayIndexFromAnyShader;
         }
 
-        /** Sets whether this geometry program requires adjacency information
-            from the input primitives.
-        */
+        /// @deprecated
         virtual void setAdjacencyInfoRequired( bool r ) { mNeedsAdjacencyInfo = r; }
-        /** Returns whether this geometry program requires adjacency information
-            from the input primitives.
-        */
+        /// @deprecated
         virtual bool isAdjacencyInfoRequired( void ) const { return mNeedsAdjacencyInfo; }
         /** Sets the number of process groups dispatched by this compute
             program.

--- a/OgreMain/src/OgreGpuProgram.cpp
+++ b/OgreMain/src/OgreGpuProgram.cpp
@@ -652,12 +652,14 @@ namespace Ogre
     String GpuProgram::CmdAdjacency::doGet(const void* target) const
     {
         const GpuProgram* t = static_cast<const GpuProgram*>(target);
-        return StringConverter::toString(t->isAdjacencyInfoRequired());
+        return StringConverter::toString(t->mNeedsAdjacencyInfo);
     }
     void GpuProgram::CmdAdjacency::doSet(void* target, const String& val)
     {
+        LogManager::getSingleton().logMessage("'uses_adjacency_information' is deprecated. "
+            "Set the respective RenderOperation::OpertionType instead.");
         GpuProgram* t = static_cast<GpuProgram*>(target);
-        t->setAdjacencyInfoRequired(StringConverter::parseBool(val));
+        t->mNeedsAdjacencyInfo = StringConverter::parseBool(val);
     }
     //-----------------------------------------------------------------------
     String GpuProgram::CmdComputeGroupDims::doGet(const void* target) const

--- a/OgreMain/src/OgreRenderSystem.cpp
+++ b/OgreMain/src/OgreRenderSystem.cpp
@@ -1122,6 +1122,12 @@ namespace Ogre {
         case OT_TRIANGLE_LIST:
             mMetrics.mFaceCount += (primCount / 3u);
             break;
+        case OT_TRIANGLE_LIST_ADJ:
+            mMetrics.mFaceCount += (primCount / 6 );
+            break;
+        case OT_TRIANGLE_STRIP_ADJ:
+            mMetrics.mFaceCount += (primCount / 2 - 2);
+            break;
         case OT_TRIANGLE_STRIP:
         case OT_TRIANGLE_FAN:
             mMetrics.mFaceCount += (primCount - 2u);

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -2951,8 +2951,11 @@ namespace Ogre
         else
         {
             //rendering without tessellation.
-            bool useAdjacency = (mGeometryProgramBound && mPso->geometryShader && mPso->geometryShader->isAdjacencyInfoRequired());
-            switch( op.operationType )
+            int operationType = op.operationType;
+            if (mGeometryProgramBound && mPso->geometryShader && mPso->geometryShader->isAdjacencyInfoRequired())
+                operationType |= OT_DETAIL_ADJACENCY_BIT;
+
+            switch( operationType )
             {
             case OT_POINT_LIST:
                 primType = D3D11_PRIMITIVE_TOPOLOGY_POINTLIST;
@@ -2960,23 +2963,43 @@ namespace Ogre
                 break;
 
             case OT_LINE_LIST:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_LINELIST_ADJ : D3D11_PRIMITIVE_TOPOLOGY_LINELIST;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINELIST;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 2;
                 break;
 
+            case OT_LINE_LIST_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINELIST_ADJ;
+                primCount = (DWORD)( op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount ) / 4;
+                break;
+
             case OT_LINE_STRIP:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ : D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) - 1;
                 break;
 
+            case OT_LINE_STRIP_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_LINESTRIP_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) - 2;
+                break;
+
             case OT_TRIANGLE_LIST:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST_ADJ : D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 3;
                 break;
 
+            case OT_TRIANGLE_LIST_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 6;
+                break;
+
             case OT_TRIANGLE_STRIP:
-                primType = useAdjacency ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ : D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
                 primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) - 2;
+                break;
+
+            case OT_TRIANGLE_STRIP_ADJ:
+                primType = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ;
+                primCount = (DWORD)(op.useIndexes ? op.indexData->indexCount : op.vertexData->vertexCount) / 2 - 2;
                 break;
 
             case OT_TRIANGLE_FAN:

--- a/RenderSystems/GL3Plus/src/GLSL/OgreGLSLShader.cpp
+++ b/RenderSystems/GL3Plus/src/GLSL/OgreGLSLShader.cpp
@@ -710,17 +710,33 @@ namespace Ogre {
         {
             return OT_LINE_LIST;
         }
+        else if (val == "line_list_adj" )
+        {
+            return OT_LINE_LIST_ADJ;
+        }
         else if (val == "line_strip")
         {
             return OT_LINE_STRIP;
+        }
+        else if (val == "line_strip_adj" )
+        {
+            return OT_LINE_STRIP_ADJ;
         }
         else if (val == "triangle_strip")
         {
             return OT_TRIANGLE_STRIP;
         }
+        else if (val == "triangle_strip_adj")
+        {
+            return OT_TRIANGLE_STRIP_ADJ;
+        }
         else if (val == "triangle_fan")
         {
             return OT_TRIANGLE_FAN;
+        }
+        else if (val == "triangle_list_adj")
+        {
+            return OT_TRIANGLE_LIST_ADJ;
         }
         else
         {
@@ -740,14 +756,26 @@ namespace Ogre {
         case OT_LINE_LIST:
             return "line_list";
             break;
+        case OT_LINE_LIST_ADJ:
+            return "line_list_adj";
+            break;
         case OT_LINE_STRIP:
             return "line_strip";
+            break;
+        case OT_LINE_STRIP_ADJ:
+            return "line_strip_adj";
             break;
         case OT_TRIANGLE_STRIP:
             return "triangle_strip";
             break;
+        case OT_TRIANGLE_STRIP_ADJ:
+            return "triangle_strip_adj";
+            break;
         case OT_TRIANGLE_FAN:
             return "triangle_fan";
+            break;
+        case OT_TRIANGLE_LIST_ADJ:
+            return "triangle_list_adj";
             break;
         case OT_TRIANGLE_LIST:
         default:

--- a/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
+++ b/RenderSystems/GL3Plus/src/OgreGL3PlusRenderSystem.cpp
@@ -2699,27 +2699,42 @@ namespace Ogre {
 
         activateGLTextureUnit(0);
 
+        int operationType = op.operationType;
+        // Use adjacency if there is a geometry program and it requested adjacency info
+        if (mGeometryProgramBound && mPso->geometryShader && mPso->geometryShader->isAdjacencyInfoRequired())
+            operationType |= OT_DETAIL_ADJACENCY_BIT;
+
         // Determine the correct primitive type to render.
         GLint primType;
-        // Use adjacency if there is a geometry program and it requested adjacency info.
-        bool useAdjacency = (mGeometryProgramBound && mPso->geometryShader && mPso->geometryShader->isAdjacencyInfoRequired());
-        switch (op.operationType)
+        switch (operationType)
         {
         case OT_POINT_LIST:
             primType = GL_POINTS;
             break;
         case OT_LINE_LIST:
-            primType = useAdjacency ? GL_LINES_ADJACENCY : GL_LINES;
+            primType = GL_LINES;
+            break;
+        case OT_LINE_LIST_ADJ:
+            primType = GL_LINES_ADJACENCY;
             break;
         case OT_LINE_STRIP:
-            primType = useAdjacency ? GL_LINE_STRIP_ADJACENCY : GL_LINE_STRIP;
+            primType = GL_LINE_STRIP;
+            break;
+        case OT_LINE_STRIP_ADJ:
+            primType = GL_LINE_STRIP_ADJACENCY;
             break;
         default:
         case OT_TRIANGLE_LIST:
-            primType = useAdjacency ? GL_TRIANGLES_ADJACENCY : GL_TRIANGLES;
+            primType = GL_TRIANGLES;
+            break;
+        case OT_TRIANGLE_LIST_ADJ:
+            primType = GL_TRIANGLES_ADJACENCY;
             break;
         case OT_TRIANGLE_STRIP:
-            primType = useAdjacency ? GL_TRIANGLE_STRIP_ADJACENCY : GL_TRIANGLE_STRIP;
+            primType = GL_TRIANGLE_STRIP;
+            break;
+        case OT_TRIANGLE_STRIP_ADJ:
+            primType = GL_TRIANGLE_STRIP_ADJACENCY;
             break;
         case OT_TRIANGLE_FAN:
             primType = GL_TRIANGLE_FAN;

--- a/Samples/Media/materials/scripts/Compute.material
+++ b/Samples/Media/materials/scripts/Compute.material
@@ -38,7 +38,6 @@ shared_params more_switches
 //         source Compute.hlsl
 //         entry_point mainGS
 //         target gs_4_0
-//         uses_adjacency_information true
 
 //         default_params
 //         {
@@ -76,7 +75,6 @@ shared_params more_switches
 //         source Compute.cg
 //         entry_point mainGS
 //         profiles gpu_gp gp4_gp
-//         uses_adjacency_information true
 
 //         default_params
 //         {

--- a/Samples/Media/materials/scripts/IsoSurf.material
+++ b/Samples/Media/materials/scripts/IsoSurf.material
@@ -20,7 +20,6 @@ geometry_program Ogre/Isosurf/TessellateTetrahedraGS_HLSL hlsl
 	source isosurf.hlsl
 	entry_point mainGS
 	target gs_4_0
-	uses_adjacency_information true
 
 	default_params
 	{
@@ -57,7 +56,6 @@ geometry_program Ogre/Isosurf/TessellateTetrahedraGS_CG cg
 	source isosurf.cg
 	entry_point mainGS
 	profiles gpu_gp gp4_gp
-	uses_adjacency_information true
 
 	default_params
 	{
@@ -92,7 +90,6 @@ geometry_program Ogre/Isosurf/TessellateTetrahedraGS_GLSL glsl
 {
 	source IsosurfGS.glsl
 	syntax glsl150
-	uses_adjacency_information true
 
 	default_params
 	{

--- a/Tools/MeshTool/docs/ogremeshxml.dtd
+++ b/Tools/MeshTool/docs/ogremeshxml.dtd
@@ -9,7 +9,7 @@
 	material 			CDATA 			#REQUIRED
 	usesharedvertices	(true|false)	"true"
 	use32bitindexes		(true|false)	"false"
-	operationtype       (triangle_list|triangle_strip|triangle_fan)	"triangle_list">
+	operationtype       (line_list|line_strip|point_list|triangle_list|triangle_strip|triangle_fan|line_list_adj|line_strip_adj|triangle_list_adj|triangle_strip_adj)	"triangle_list">
 <!ELEMENT textures (texture+)>
 <!ELEMENT texture EMPTY>
 <!ATTLIST texture

--- a/Tools/MeshTool/src/XML/OgreXMLMeshSerializer.cpp
+++ b/Tools/MeshTool/src/XML/OgreXMLMeshSerializer.cpp
@@ -266,6 +266,18 @@ namespace v1 {
         case OT_TRIANGLE_STRIP:
             subMeshNode->SetAttribute("operationtype", "triangle_strip");
             break;
+        case OT_TRIANGLE_LIST_ADJ:
+            subMeshNode->SetAttribute("operationtype", "triangle_list_adj");
+            break;
+        case OT_TRIANGLE_STRIP_ADJ:
+            subMeshNode->SetAttribute("operationtype", "triangle_strip_adj");
+            break;
+        case OT_LINE_LIST_ADJ:
+            subMeshNode->SetAttribute("operationtype", "line_list_adj");
+            break;
+        case OT_LINE_STRIP_ADJ:
+            subMeshNode->SetAttribute("operationtype", "line_strip_adj");
+            break;
         }
 
         if (s->indexData[VpNormal]->indexCount > 0)
@@ -719,7 +731,24 @@ namespace v1 {
                     sm->operationType = OT_POINT_LIST;
                     readFaces = false;
                 }
-
+                else if (!strcmp(optype, "triangle_list_adj"))
+                {
+                    sm->operationType = OT_TRIANGLE_LIST_ADJ;
+                }
+                else if (!strcmp(optype, "triangle_strip_adj"))
+                {
+                    sm->operationType = OT_TRIANGLE_STRIP_ADJ;
+                }
+                else if (!strcmp(optype, "line_strip_adj"))
+                {
+                    sm->operationType = OT_LINE_STRIP_ADJ;
+                    readFaces = false;
+                }
+                else if (!strcmp(optype, "line_list_adj"))
+                {
+                    sm->operationType = OT_LINE_LIST_ADJ;
+                    readFaces = false;
+                }
             }
 
             const char* tmp = smElem->Attribute("usesharedvertices");


### PR DESCRIPTION
instead of the geometry shader - for e.g. rendering adjacency buffers without an geometry shader attached.

patch based on
https://forums.ogre3d.org/viewtopic.php?f=4&t=94417#p542277 https://github.com/OGRECave/ogre/pull/830/commits/ae9da1ba6f869846d5e46dcc80c55d23fbdd4708