### PR TITLE
Fix miscellaneous formatting problems, typos etc. in some of the docs

### DIFF
--- a/OgreMain/include/Animation/OgreBone.h
+++ b/OgreMain/include/Animation/OgreBone.h
@@ -189,7 +189,7 @@ namespace Ogre
         */
         void _setNodeParent( Node *nodeParent );
 
-        /** Sets a given orientation in local space (ie. relative to its parent)
+        /** Sets a given orientation in local space (i.e., relative to its parent)
         @remarks
             Don't call this function too often, as we need to convert to SoA
         */
@@ -225,7 +225,7 @@ namespace Ogre
         */
         inline Vector3 getScale() const;
 
-        /** Tells the Bone whether it should inherit orientation from it's parent node.
+        /** Tells the Bone whether it should inherit orientation from its parent node.
         @remarks
             See Node::setInheritOrientation remarks.
             Note that Nodes and bones inherit scale and orientation differently, because
@@ -247,7 +247,7 @@ namespace Ogre
         */
         bool getInheritOrientation() const;
 
-        /** Tells the node whether it should inherit scaling factors from it's parent node.
+        /** Tells the node whether it should inherit scaling factors from its parent node.
         @remarks
             See setInheritOrientation().
         @param inherit If true, this node's scale will be affected by its parent's scale. If false,
@@ -270,7 +270,7 @@ namespace Ogre
         */
         Matrix4 _getDerivedTransform() const;
 
-        /** Gets the transformation matrix for this bone in local space (i.e. as if the
+        /** Gets the transformation matrix for this bone in local space (i.e., as if the
             skeleton wasn't attached to a SceneNode).
         @remarks
             This method returns the full transformation matrix

--- a/OgreMain/include/Compositor/OgreCompositorShadowNode.h
+++ b/OgreMain/include/Compositor/OgreCompositorShadowNode.h
@@ -66,21 +66,26 @@ namespace Ogre
         This is not needed anymore.
 
         To summarize: a normal rendering flow with shadow map looks like this:
-            shadowNode->setupShadowCamera( normal->getVisibleBoundsInfo() );
-            shadowNode->_cullPhase01();
-            shadowNode->_renderPhase02();
-            normal->_cullPhase01();
-            normal->_renderPhase02();
+
+        @code{.cpp}
+        shadowNode->setupShadowCamera( normal->getVisibleBoundsInfo() );
+        shadowNode->_cullPhase01();
+        shadowNode->_renderPhase02();
+        normal->_cullPhase01();
+        normal->_renderPhase02();
+        @endcode
     @par
     @par
         On forward lighting passes, shadow mapping is handled in the following way:
-            1) Build a list of all lights visible by all cameras (SceneManager does this)
-            2) Traverse the list to get the closest lights to the current camera.
-               These lights will cast shadows.
-            3) Build a list of the closest lights for each object (SceneManager does this)
-            4) Traverse this list and find those that are actually casting a shadow
-            5) Send to the GPU & engine the list in step 4, but shadow casting lights are
+
+        1. Build a list of all lights visible by all cameras (SceneManager does this)
+        2. Traverse the list to get the closest lights to the current camera.
+          These lights will cast shadows.
+        3. Build a list of the closest lights for each object (SceneManager does this)
+        4. Traverse this list and find those that are actually casting a shadow
+        5. Send to the GPU & engine the list in step 4, but shadow casting lights are
                put first, then sorted by proximity.
+
         See the comments inside the function setShadowMapsToPass for more information.
     @author
         Matias N. Goldberg

--- a/OgreMain/include/Compositor/OgreCompositorShadowNodeDef.h
+++ b/OgreMain/include/Compositor/OgreCompositorShadowNodeDef.h
@@ -133,7 +133,7 @@ namespace Ogre
         size_t getSharesSetupWith() const { return sharesSetupWith; }
     };
 
-    /** Shadow Nodes are special nodes (not to be confused with @see CompositorNode)
+    /** Shadow Nodes are special nodes (not to be confused with CompositorNode)
         that are only used for rendering shadow maps.
         Normal Compositor Nodes can share or own a ShadowNode. The ShadowNode will
         render the scene enough times to fill all shadow maps so the main scene pass

--- a/OgreMain/include/Compositor/OgreCompositorWorkspaceDef.h
+++ b/OgreMain/include/Compositor/OgreCompositorWorkspaceDef.h
@@ -181,7 +181,8 @@ namespace Ogre
 
         /** Clears all the connection between channels of the nodes @see connect
         @remarks
-            1. We don't clear the output connection (see CompositorNode::connectExternalRT, see clearOutputConnections())
+            1. We don't clear the output connection (see CompositorNode::connectExternalRT, see
+        clearOutputConnections())
             2. The node aliases (both implicit and explicit) will still exist. see clearAll.
             3. A node with incomplete inputs should be disabled before the workspace is instantiated
                (see CompositorNodeDef::setStartEnabled). If the workspace has already been instantiated,
@@ -194,7 +195,8 @@ namespace Ogre
         /** Clears the connection from the "final output RenderTarget" (i.e., usually the RenderWindow)
             that goes to the input channel of one of our nodes. See CompositorNode::connectExternalRT.
         @remarks
-            1. We don't clear other type of connections (see connect(), see clearAllInterNodeConnections())
+            1. We don't clear other type of connections (see connect(), see
+        clearAllInterNodeConnections())
             2. The node aliases (both implicit and explicit) will still exist. see clearAll.
             3. A node with incomplete inputs should be disabled before the workspace is instantiated
                (see CompositorNodeDef::setStartEnabled). If the workspace has already been instantiated,

--- a/OgreMain/include/Compositor/OgreCompositorWorkspaceDef.h
+++ b/OgreMain/include/Compositor/OgreCompositorWorkspaceDef.h
@@ -181,24 +181,24 @@ namespace Ogre
 
         /** Clears all the connection between channels of the nodes @see connect
         @remarks
-            1. We don't clear the output connection (@see connectOutput, @see clearOutputConnections)
-            2. The node aliases (both implicit and explicit) will still exist. @see clearAll.
+            1. We don't clear the output connection (see CompositorNode::connectExternalRT, see clearOutputConnections())
+            2. The node aliases (both implicit and explicit) will still exist. see clearAll.
             3. A node with incomplete inputs should be disabled before the workspace is instantiated
-               (@see CompositorNodeDef::setStartEnabled). If the workspace has already been instantiated,
-               the node instance should be disabled, @see CompositorNode::setEnabled)
+               (see CompositorNodeDef::setStartEnabled). If the workspace has already been instantiated,
+               the node instance should be disabled, see CompositorNode::setEnabled)
             4. It is safe to call this function while there are still workspaces, but you must call
                CompositorWorkspace::reconnectAllNodes after you're done setting the new node connections
         */
         void clearAllInterNodeConnections();
 
-        /** Clears the connection from the "final output RenderTarget" (i.e. usually the RenderWindow)
-            that goes to the input channel of one of our nodes. @see connectOutput.
+        /** Clears the connection from the "final output RenderTarget" (i.e., usually the RenderWindow)
+            that goes to the input channel of one of our nodes. See CompositorNode::connectExternalRT.
         @remarks
-            1. We don't clear other type of connections (@see connect, @see clearAllInterNodeConnections)
-            2. The node aliases (both implicit and explicit) will still exist. @see clearAll.
+            1. We don't clear other type of connections (see connect(), see clearAllInterNodeConnections())
+            2. The node aliases (both implicit and explicit) will still exist. see clearAll.
             3. A node with incomplete inputs should be disabled before the workspace is instantiated
-               (@see CompositorNodeDef::setStartEnabled). If the workspace has already been instantiated,
-               the node instance should be disabled, @see CompositorNode::setEnabled)
+               (see CompositorNodeDef::setStartEnabled). If the workspace has already been instantiated,
+               the node instance should be disabled, see CompositorNode::setEnabled)
             4. It is safe to call this function while there are still workspaces, but you must call
                CompositorWorkspace::reconnectAllNodes after you're done setting the new node connections
         */
@@ -214,7 +214,7 @@ namespace Ogre
 
         /** An alias is explicitly used when the user wants to use multiple, independent
             instances of the same node. Each alias equals one instance.
-            An implicit alias is when the name of the alias and it's node name match.
+            An implicit alias is when the name of the alias and its node name match.
         @remarks
             When the name of the node and its alias are the same, it is said to be called an
             "implicit" alias.

--- a/OgreMain/include/Compositor/OgreTextureDefinition.h
+++ b/OgreMain/include/Compositor/OgreTextureDefinition.h
@@ -394,7 +394,7 @@ namespace Ogre
         static void destroyTextures( CompositorChannelVec &inOutTexContainer, RenderSystem *renderSys );
 
         /** Destroys & recreates only the textures that depend on the main RT
-            (e.g. the Render Window) resolution.
+            (e.g., the Render Window) resolution.
         @remarks
             This is divided in two steps: recreateResizableTextures01 & recreateResizableTextures02
             since in some cases in RenderPassDescriptor, setting up MRT and depth textures
@@ -502,14 +502,14 @@ namespace Ogre
         /// We need the definition because, unlike textures, the container passed in may
         /// contain textures that were not created by us (i.e. global & input textures)
         /// that we shouldn't delete.
-        /// It is illegal for two buffers to have the same name, so it's invalid that a
+        /// It is illegal for two buffers to have the same name, so it's invalid that
         /// e.g. an input and a local texture would share the same name.
         static void destroyBuffers( const BufferDefinitionVec &bufferDefs,
                                     CompositorNamedBufferVec  &inOutBufContainer,
                                     RenderSystem              *renderSys );
 
         /** Destroys & recreates only the buffers that depend on the main RT
-            (i.e. the RenderWindow) resolution
+            (i.e., the RenderWindow) resolution
         @param textureDefs
             Array of texture definitions, so we know which ones depend on main RT's resolution
         @param inOutTexContainer

--- a/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
+++ b/OgreMain/include/Compositor/Pass/OgreCompositorPassDef.h
@@ -83,7 +83,7 @@ namespace Ogre
             + PASS_COMPUTE (see CompositorPassComputeDef)
             + PASS_SHADOWS (see CompositorPassShadowsDef)
             + PASS_MIPMAP (see CompositorPassMipmapDef)
-            
+
         This class doesn't do much on its own. See the derived types for more information
         A definition is shared by all pass instantiations (i.e. Five CompositorPassScene can
         share the same CompositorPassSceneDef) and are assumed to remain const throughout
@@ -160,8 +160,8 @@ namespace Ogre
         /** Will issue a warning (by raising an exception) if Ogre is forced to flush
             the RenderTarget, which is very bad for performance on mobile, and can
             cause serious performance problems in Desktop if using MSAA, and also
-            cause correctness problems (i.e. bad rendering) if store action is
-            StoreAction::Resolve.
+            cause correctness problems (i.e., bad rendering) if store action is
+            StoreAction::MultisampleResolve.
         @remarks
             Flushes are caused by splitting rendering to the same RenderTarget
             in multiple passes while rendering to a different RenderTarget in the middle.

--- a/OgreMain/include/OgreHlmsManager.h
+++ b/OgreMain/include/OgreHlmsManager.h
@@ -191,13 +191,18 @@ namespace Ogre
             on them, as we need to ensure caches of HlmsPso remain valid.
 
         @param baseParams
+        @parblock
             A macroblock reference to base the parameters. This reference may live on the stack,
-            on the heap, etc; it's RS-specific data does not have to be filled.
+            on the heap, etc; its RS-specific data does not have to be filled.
             e.g. this is fine:
+
+            @code{.cpp}
                 HlmsMacroblock myRef;
                 myRef.mDepthCheck = false;
                 HlmsMacroblock *finalBlock = manager->getMacroblock( myRef );
                 //myRef.mRsData == finalBlock.mRsData not necessarily true
+            @endcode
+        @endparblock
         @return
             Created or cached datablock with same parameters as baseParams
         */

--- a/OgreMain/include/OgreItem.h
+++ b/OgreMain/include/OgreItem.h
@@ -108,7 +108,7 @@ namespace Ogre
         SubItemVec                    mSubItems;
 
         /** A set of all the entities which shares a single OldSkeletonInstance.
-            This is only created if the Item is in fact sharing it's OldSkeletonInstance with
+            This is only created if the Item is in fact sharing its OldSkeletonInstance with
             other Entities.
         */
         // ItemSet* mSharedSkeletonEntities;
@@ -209,7 +209,7 @@ namespace Ogre
         /// Stops sharing the SkeletonInstance with other Items. @see useSkeletonInstanceFrom
         void stopUsingSkeletonInstanceFromMaster();
 
-        /** Returns whether this Item shares it's SkeltonInstance with other Item instances.
+        /** Returns whether this Item shares its SkeltonInstance with other Item instances.
          */
         bool sharesSkeletonInstance() const;
 
@@ -242,7 +242,7 @@ namespace Ogre
         // bool hasVertexAnimation() const;
 
         /** Returns a pointer to the set of entities which share a OldSkeletonInstance.
-            If this instance does not share it's OldSkeletonInstance with other instances @c NULL will be
+            If this instance does not share its OldSkeletonInstance with other instances @c NULL will be
            returned
         */
         // const ItemSet* getSkeletonInstanceSharingSet() const    { return mSharedSkeletonEntities; }
@@ -264,7 +264,7 @@ namespace Ogre
             resources it references have been earmarked for background loading,
             so you should check isInitialised afterwards to see if it was successful.
         @param forceReinitialise
-            If @c true, this forces the Item to tear down it's
+            If @c true, this forces the Item to tear down its
             internal structures and try to rebuild them. Useful if you changed the
             content of a Mesh or Skeleton at runtime.
         */
@@ -278,7 +278,7 @@ namespace Ogre
         void _notifyParentNodeMemoryChanged() override;
     };
 
-    /** FItemy object for creating Item instances */
+    /** Factory object for creating Item instances */
     class _OgreExport ItemFactory final : public MovableObjectFactory
     {
     protected:

--- a/OgreMain/include/OgreLight.h
+++ b/OgreMain/include/OgreLight.h
@@ -60,13 +60,6 @@ namespace Ogre
         and direction.
         Light::setDirection and Light::getDirection will redirect to the SceneNode and assert
         or crash if not attached to one.
-    @par
-        Remember also that dynamic lights rely on modifying the colour of vertices based on the position
-    of the light compared to an object's vertex normals. Dynamic lighting will only look good if the
-        object being lit has a fair level of tessellation and the normals are properly set. This is
-    particularly true for the spotlight which will only look right on highly tessellated models. In the
-    future OGRE may be extended for certain scene types so an alternative to the standard dynamic
-    lighting may be used, such as dynamic lightmaps.
     */
     class _OgreExport Light : public MovableObject, public TextureGpuListener
     {
@@ -184,14 +177,19 @@ namespace Ogre
          */
         const ColourValue &getSpecularColour() const { return mSpecular; }
 
-        /** Sets the attenuation parameters (range, constant, linear & quadratic, @see setAttenuation)
+        /** Sets the attenuation parameters (range, constant, linear & quadratic, see #setAttenuation)
             based on a given radius.
         @remarks
-            The actual attenuation formula is:
-                            1
-            --------------------------------
-            (distance / radius)² * 0.5 + 0.5
-
+            The actual attenuation formula is:<br/>
+            <table style="text-align: center;">
+              <tr>
+                <td style="border-bottom: 1px solid black;">1</td>
+              </tr>
+              <tr>
+                <td>(distance / radius)<sup>2</sup> * 0.5 + 0.5</td>
+              </tr>
+            </table>
+        @remarks
             The original formula never ends, that is the range is infinity. This function calculates
             a range based on "lumThreshold": When the luminosity past certain distance is below the
             established threshold, the light calculations are cut.
@@ -414,7 +412,6 @@ namespace Ogre
         */
         Vector4 getAs4DVector() const;
 
-
         /// @copydoc AnimableObject::createAnimableValue
         AnimableValuePtr createAnimableValue( const String &valueName ) override;
 
@@ -427,7 +424,7 @@ namespace Ogre
             This method allows you to set the distance at which shadows will no
             longer be rendered.
         @note
-            Each shadow technique can interpret this subtely differently.
+            Each shadow technique can interpret this subtly differently.
             For example, one technique may use this to eliminate casters,
             another might use it to attenuate the shadows themselves.
             You should tweak this value to suit your chosen shadow technique
@@ -455,7 +452,7 @@ namespace Ogre
         /** Get the near clip plane distance to be used by the shadow camera, if
             this light casts texture shadows.
         @remarks
-            May be zero if the light doesn't have it's own near distance set;
+            May be zero if the light doesn't have its own near distance set;
             use _deriveShadowNearDistance for a version guaranteed to give a result.
         */
         Real getShadowNearClipDistance() const { return mShadowNearClipDist; }
@@ -479,7 +476,7 @@ namespace Ogre
         /** Get the far clip plane distance to be used by the shadow camera, if
             this light casts texture shadows.
         @remarks
-            May be zero if the light doesn't have it's own far distance set;
+            May be zero if the light doesn't have its own far distance set;
             use _deriveShadowfarDistance for a version guaranteed to give a result.
         */
         Real getShadowFarClipDistance() const { return mShadowFarClipDist; }
@@ -551,7 +548,7 @@ namespace Ogre
             information only this Light knows.
         @remarks
             This method allows a Light to map in a custom GPU program parameter
-            based on it's own data. This is represented by a GPU auto parameter
+            based on its own data. This is represented by a GPU auto parameter
             of ACT_LIGHT_CUSTOM, and to allow there to be more than one of these per
             Light, the 'data' field on the auto parameter will identify
             which parameter is being updated and on which light. The implementation

--- a/OgreMain/include/OgreNode.h
+++ b/OgreMain/include/OgreNode.h
@@ -46,11 +46,11 @@ namespace Ogre
     /** \addtogroup Scene
      *  @{
      */
-    /** Class representing a general-purpose node an articulated scene graph.
+    /** Class representing a general-purpose node in an articulated scene graph.
     @remarks
         A node in the scene graph is a node in a structured tree. A node contains
         information about the transformation which will apply to
-        it and all of it's children. Child nodes can have transforms of their own, which
+        it and all of its children. Child nodes can have transforms of their own, which
         are combined with their parent's transformations.
     @par
         This is an abstract class - concrete classes are based on this for specific purposes,
@@ -86,7 +86,7 @@ namespace Ogre
             /** Called when a node gets updated.
             @remarks
                 Note that this happens when the node's derived update happens,
-                not every time a method altering it's state occurs. There may
+                not every time a method altering its state occurs. There may
                 be several state-changing calls but only one of these calls,
                 when the node graph is fully updated.
             */
@@ -143,10 +143,10 @@ namespace Ogre
         /// Notification from parent that we need to migrate to a different depth level
         void parentDepthLevelChanged();
 
-        /** Triggers the node to update it's combined transforms.
+        /** Triggers the node to update its combined transforms.
         @par
             This method is called internally by Ogre to ask the node
-            to update it's complete transformation based on it's parents
+            to update its complete transformation based on its parents
             derived transform.
         */
         void _updateFromParent();
@@ -272,7 +272,7 @@ namespace Ogre
             of a parent node to apply to a child node (e.g. where the child node is a part of
             the same object, so you want it to be the same relative orientation based on the
             parent's orientation), but not in other cases (e.g. where the child node is just
-            for positioning another object, you want it to maintain it's own orientation).
+            for positioning another object, you want it to maintain its own orientation).
             The default is to inherit as with other transforms.
             Don't call this function too often, as we need to convert to SoA
         @par
@@ -288,7 +288,7 @@ namespace Ogre
             of a parent node to apply to a child node (e.g. where the child node is a part of
             the same object, so you want it to be the same relative orientation based on the
             parent's orientation), but not in other cases (e.g. where the child node is just
-            for positioning another object, you want it to maintain it's own orientation).
+            for positioning another object, you want it to maintain its own orientation).
             The default is to inherit as with other transforms.
             Don't call this function too often, as we need to convert to SoA
         @par
@@ -304,26 +304,26 @@ namespace Ogre
             of a parent node to apply to a child node (e.g. where the child node is a part of
             the same object, so you want it to be the same relative orientation based on the
             parent's orientation), but not in other cases (e.g. where the child node is just
-            for positioning another object, you want it to maintain it's own orientation).
+            for positioning another object, you want it to maintain its own orientation).
             The default is to inherit as with other transforms.
         @par
             Note that rotations are oriented around the node's origin.
         */
         virtual_l1 void resetOrientation();
 
-        /** Sets the position of the node relative to it's parent.
+        /** Sets the position of the node relative to its parent.
         @remarks
             Don't call this function too often, as we need to convert to SoA
         */
         virtual_l1 void setPosition( const Vector3 &pos );
 
-        /** Sets the position of the node relative to it's parent.
+        /** Sets the position of the node relative to its parent.
         @remarks
             Don't call this function too often, as we need to convert to SoA
         */
         virtual_l1 void setPosition( Real x, Real y, Real z );
 
-        /** Gets the position of the node relative to it's parent.
+        /** Gets the position of the node relative to its parent.
             @remarks
                 Don't call this function too often, as we need to convert from SoA
         */
@@ -336,7 +336,7 @@ namespace Ogre
             option of the child. In some cases you want a scaling factor of a parent node to apply to
             a child node (e.g. where the child node is a part of the same object, so you want it to be
             the same relative size based on the parent's size), but not in other cases (e.g. where the
-            child node is just for positioning another object, you want it to maintain it's own size).
+            child node is just for positioning another object, you want it to maintain its own size).
             The default is to inherit as with other transforms.
             Don't call this function too often, as we need to convert to SoA
         @par
@@ -351,7 +351,7 @@ namespace Ogre
             option of the child. In some cases you want a scaling factor of a parent node to apply to
             a child node (e.g. where the child node is a part of the same object, so you want it to be
             the same relative size based on the parent's size), but not in other cases (e.g. where the
-            child node is just for positioning another object, you want it to maintain it's own size).
+            child node is just for positioning another object, you want it to maintain its own size).
             The default is to inherit as with other transforms.
             Don't call this function too often, as we need to convert to SoA
         @par
@@ -365,7 +365,7 @@ namespace Ogre
         */
         virtual_l2 Vector3 getScale() const;
 
-        /** Tells the node whether it should inherit orientation from it's parent node.
+        /** Tells the node whether it should inherit orientation from its parent node.
         @remarks
             Orientations, unlike other transforms, are not always inherited by child nodes.
             Whether or not orientations affect the orientation of the child nodes depends on
@@ -373,7 +373,7 @@ namespace Ogre
             of a parent node to apply to a child node (e.g. where the child node is a part of
             the same object, so you want it to be the same relative orientation based on the
             parent's orientation), but not in other cases (e.g. where the child node is just
-            for positioning another object, you want it to maintain it's own orientation).
+            for positioning another object, you want it to maintain its own orientation).
             The default is to inherit as with other transforms.
         @param inherit If true, this node's orientation will be affected by its parent's orientation.
             If false, it will not be affected.
@@ -388,21 +388,21 @@ namespace Ogre
             of a parent node to apply to a child node (e.g. where the child node is a part of
             the same object, so you want it to be the same relative orientation based on the
             parent's orientation), but not in other cases (e.g. where the child node is just
-            for positioning another object, you want it to maintain it's own orientation).
+            for positioning another object, you want it to maintain its own orientation).
             The default is to inherit as with other transforms.
         @remarks
             See setInheritOrientation for more info.
         */
         virtual_l2 bool getInheritOrientation() const;
 
-        /** Tells the node whether it should inherit scaling factors from it's parent node.
+        /** Tells the node whether it should inherit scaling factors from its parent node.
         @remarks
             Scaling factors, unlike other transforms, are not always inherited by child nodes.
             Whether or not scalings affect the size of the child nodes depends on the setInheritScale
             option of the child. In some cases you want a scaling factor of a parent node to apply to
             a child node (e.g. where the child node is a part of the same object, so you want it to be
             the same relative size based on the parent's size), but not in other cases (e.g. where the
-            child node is just for positioning another object, you want it to maintain it's own size).
+            child node is just for positioning another object, you want it to maintain its own size).
             The default is to inherit as with other transforms.
         @param inherit If true, this node's scale will be affected by its parent's scale. If false,
             it will not be affected.
@@ -415,10 +415,10 @@ namespace Ogre
         */
         virtual_l2 bool getInheritScale() const;
 
-        /** Scales the node, combining it's current scale with the passed in scaling factor.
+        /** Scales the node, combining its current scale with the passed in scaling factor.
         @remarks
             This method applies an extra scaling factor to the node's existing scale, (unlike setScale
-            which overwrites it) combining it's current scale with the new one. E.g. calling this
+            which overwrites it) combining its current scale with the new one. E.g. calling this
             method twice with Vector3(2,2,2) would have the same effect as setScale(Vector3(4,4,4)) if
             the existing scale was 1.
         @par
@@ -426,10 +426,10 @@ namespace Ogre
         */
         virtual_l2 void scale( const Vector3 &scale );
 
-        /** Scales the node, combining it's current scale with the passed in scaling factor.
+        /** Scales the node, combining its current scale with the passed in scaling factor.
         @remarks
             This method applies an extra scaling factor to the node's existing scale, (unlike setScale
-            which overwrites it) combining it's current scale with the new one. E.g. calling this
+            which overwrites it) combining its current scale with the new one. E.g. calling this
             method twice with Vector3(2,2,2) would have the same effect as setScale(Vector3(4,4,4)) if
             the existing scale was 1.
         @par
@@ -530,7 +530,7 @@ namespace Ogre
         virtual_l2 void rotate( const Quaternion &q, TransformSpace relativeTo = TS_LOCAL );
 
         /** Gets a matrix whose columns are the local axes based on
-            the nodes orientation relative to it's parent. */
+            the nodes orientation relative to its parent. */
         virtual_l2 Matrix3 getLocalAxes() const;
 
         /** Creates an unnamed new Node as a child of this node.
@@ -805,7 +805,7 @@ namespace Ogre
         void _setNullNodeMemoryManager() { mNodeMemoryManager = 0; }
 
         /** Internal use, notifies all attached objects that our memory pointers
-            (i.e. Transform) may have changed (e.g. during cleanups, change of parent, etc)
+            (i.e., Transform) may have changed (e.g., during cleanups, change of parent, etc)
         */
         virtual void _callMemoryChangeListeners() = 0;
 

--- a/OgreMain/include/OgreParticleSystem.h
+++ b/OgreMain/include/OgreParticleSystem.h
@@ -182,7 +182,7 @@ namespace Ogre
         */
         ParticleEmitter *addEmitter( const String &emitterType );
 
-        /** Retrieves an emitter by it's index (zero-based).
+        /** Retrieves an emitter by its index (zero-based).
         @remarks
             Used to retrieve a pointer to an emitter for a particle system to procedurally change
             emission parameters etc.
@@ -228,7 +228,7 @@ namespace Ogre
         */
         ParticleAffector *addAffector( const String &affectorType );
 
-        /** Retrieves an affector by it's index (zero-based).
+        /** Retrieves an affector by its index (zero-based).
         @remarks
             Used to retrieve a pointer to an affector for a particle system to procedurally change
             affector parameters etc.
@@ -276,7 +276,7 @@ namespace Ogre
         @note
             There is no corresponding 'destroyParticle' method - if you want to dispose of a
             particle manually (say, if you've used setSpeedFactor(0) to make particles live forever)
-            you should use getParticle() and modify it's timeToLive to zero, meaning that it will
+            you should use getParticle() and modify its timeToLive to zero, meaning that it will
             get cleaned up in the next update.
         */
         Particle *createParticle();
@@ -311,7 +311,7 @@ namespace Ogre
             Particle systems all have a particle quota, i.e. a maximum number of particles they are
             allowed to have active at a time. This allows the application to set a keep particle systems
             under control should they be affected by complex parameters which alter their emission rates
-            etc. If a particle system reaches it's particle quota, none of the emitters will be able to
+            etc. If a particle system reaches its particle quota, none of the emitters will be able to
             emit any more particles. As existing particles die, the spare capacity will be allocated
             equally across all emitters to be as consistent to the original particle system style as
         possible. The quota can be increased but not decreased after the system has been created.
@@ -517,7 +517,7 @@ namespace Ogre
             set (maybe one set per section of landscape), which will be culled coarsely, but you also
             want to cull the particles individually because they are spread out. Whilst you could have
             lots of single-tree sets which are culled separately, this would be inefficient to render
-            because each tree would be issued as it's own rendering operation.
+            because each tree would be issued as its own rendering operation.
         @par
             By calling this method with a parameter of true, you can have large particle sets which
             are spaced out and so get the benefit of batch rendering and coarse culling, but also have
@@ -528,14 +528,14 @@ namespace Ogre
         virtual void setCullIndividually( bool cullIndividual );
         /// Return the resource group to be used to load dependent resources
         virtual const String &getResourceGroupName() const { return mResourceGroupName; }
-        /** Get the origin of this particle system, e.g. a script file name.
+        /** Get the origin of this particle system, e.g., a script file name.
         @remarks
             This property will only contain something if the creator of
             this particle system chose to populate it. Script loaders are advised
             to populate it.
         */
         const String &getOrigin() const { return mOrigin; }
-        /// Notify this particle system of it's origin
+        /// Notify this particle system of its origin
         void _notifyOrigin( const String &origin ) { mOrigin = origin; }
 
         /** @copydoc MovableObject::setRenderQueueGroup */
@@ -564,7 +564,7 @@ namespace Ogre
             number of seconds, so that the bounds are calculated for a few
             seconds and then frozen.
         @param autoUpdate If true (the default), the particle system will
-            update it's bounds every frame. If false, the bounds update will
+            update its bounds every frame. If false, the bounds update will
             cease after the 'stopIn' number of seconds have passed.
         @param stopIn Only applicable if the first parameter is true, this is the
             number of seconds after which the automatic update will cease.

--- a/OgreMain/include/OgreRenderable.h
+++ b/OgreMain/include/OgreRenderable.h
@@ -335,7 +335,7 @@ namespace Ogre
             information only this Renderable knows.
         @remarks
             This method allows a Renderable to map in a custom GPU program parameter
-            based on it's own data. This is represented by a GPU auto parameter
+            based on its own data. This is represented by a GPU auto parameter
             of ACT_CUSTOM, and to allow there to be more than one of these per
             Renderable, the 'data' field on the auto parameter will identify
             which parameter is being updated. The implementation of this method
@@ -419,13 +419,13 @@ namespace Ogre
         */
         void setDatablockOrMaterialName( String materialName, String groupName );
 
-        /** Assigns a datablock (i.e. HLMS material) based on its unique name.
+        /** Assigns a datablock (i.e., HLMS material) based on its unique name.
         @remarks
-            An null IdString() is valid, it will use the default material
+            A null IdString() is valid, it will use the default material
         */
         void setDatablock( IdString datablockName );
 
-        /// Assigns a datablock (i.e. HLMS Material) to this renderable
+        /// Assigns a datablock (i.e., HLMS Material) to this renderable
         virtual void setDatablock( HlmsDatablock *datablock );
 
         /** Sets the datablock to a null pointer. Use case: If you will be destroying an
@@ -511,7 +511,7 @@ namespace Ogre
         uint32 mHlmsGlobalIndex;
 
     public:
-        /** Control visibility at Renderable (e.g. SubMesh) level
+        /** Control visibility at Renderable (e.g., SubMesh) level
 
             Note that if our MovableObject owner called MovableObject::setVisible( false )
             we won't get rendered. Both must be true in order to render.

--- a/OgreMain/include/OgreSceneManager.h
+++ b/OgreMain/include/OgreSceneManager.h
@@ -203,7 +203,7 @@ namespace Ogre
         }
     };
 
-    /** Manages the organisation and rendering of a 'scene' i.e. a collection
+    /** Manages the organisation and rendering of a 'scene', i.e., a collection
         of objects and potentially world geometry.
     @remarks
         This class defines the interface and the basic behaviour of a
@@ -945,7 +945,7 @@ namespace Ogre
 
         /** Builds a list of all lights that are visible by all queued cameras (this should be fed by
             Compositor). Then calls MovableObject::buildLightList with that list so that each
-            MovableObject gets it's own sorted list of the closest lights.
+            MovableObject gets its own sorted list of the closest lights.
         @remarks
             @see MovableObject::buildLightList()
         */
@@ -1055,7 +1055,7 @@ namespace Ogre
             @remarks
                 This method removes a previously added camera from the scene.
                 The camera is deleted so the caller must ensure no references
-                to it's previous instance (e.g. in a SceneNode) are used.
+                to its previous instance (e.g. in a SceneNode) are used.
             @param cam
                 Pointer to the camera to remove
         */
@@ -1129,7 +1129,7 @@ namespace Ogre
                 scenes.
             @par
                 To include the returned SceneNode in the scene, use the addChild
-                method of the SceneNode which is to be it's parent.
+                method of the SceneNode which is to be its parent.
             @par
                 Note that this method takes no parameters, and the node created is unnamed (it is
                 actually given a generated name, which you can retrieve if you want).
@@ -1220,7 +1220,7 @@ namespace Ogre
         /// we guarantee the dummy won't change its transform.
         SceneNode *getDummySceneNode() const { return mSceneDummy; }
 
-        /** Retrieves a SceneNode based on it's ID from the scene graph.
+        /** Retrieves a SceneNode based on its ID from the scene graph.
         @remarks
             @note Returns null if the ID does not exist
             @note It is a linear search O(N), retrieves the first node found
@@ -1601,7 +1601,7 @@ namespace Ogre
             be released earlier using the destroyParticleSystem method.
         @par
             The instance returned from this method won't actually do anything because on creation a
-            particle system has no emitters. The caller should manipulate the instance through it's
+            particle system has no emitters. The caller should manipulate the instance through its
             ParticleSystem methods to actually create a real particle effect.
         @par
             Creating a particle system does not make it a part of the scene. As with other MovableObject
@@ -1870,7 +1870,7 @@ namespace Ogre
         /// @see mTmpVisibleObjects
         VisibleObjectsPerThreadArray &_getTmpVisibleObjectsList() { return mTmpVisibleObjects; }
 
-        /** Notifies that the given MovableObject is dirty (i.e. the AABBs have changed).
+        /** Notifies that the given MovableObject is dirty (i.e., the AABBs have changed).
             Note that the parent SceneNodes of this/these objects are not updated and you will
             have to call @see notifyStaticDirty on the SceneNode if the position/rotation/scale
             have changed.
@@ -2030,7 +2030,7 @@ namespace Ogre
             @remarks
                 This method sets up the scene-wide fogging effect. These settings
                 apply to all geometry rendered, UNLESS the material with which it
-                is rendered has it's own fog settings (see Material::setFog).
+                is rendered has its own fog settings (see Material::setFog).
             @param
                 mode Set up the mode of fog as described in the FogMode
                 enum, or set to FOG_NONE to turn off.
@@ -2180,9 +2180,9 @@ namespace Ogre
             Remember, AnimationState objects are disabled by default at creation time.
             Turn them on when you want them using their setEnabled method.
         @par
-            Note that any SceneNode affected by this automatic animation will have it's state
-            reset to it's initial position before application of the animation. Unless specifically
-            modified using Node::setInitialState the Node assumes it's initial state is at the
+            Note that any SceneNode affected by this automatic animation will have its state
+            reset to its initial position before application of the animation. Unless specifically
+            modified using Node::setInitialState the Node assumes its initial state is at the
             origin. If you want the base state of the SceneNode to be elsewhere, make your changes
             to the node using the standard transform methods, then call setInitialState to
             'bake' this reference position into the node.


### PR DESCRIPTION
A few specifics:

It is sometimes necessary to add a comma after "i.e." or "e.g." to prevent an unintended paragraph break, due to Ogre's use of the `JAVADOC_AUTOBRIEF` Doxygen setting.

`@see` should not be used inside a paragraph, only as a freestanding item, because it starts a new paragraph.

I resorted to HTML to get a decent rendering of the formula in `Light::setAttenuationBasedOnRadius`.

When I was modifying a file for other reasons, I also fixed incorrect usage of "it's".  The rule is that "it's" is a contraction for "it is" or "it has", while "its" is used for the possessive, "belonging to it".  Yes, this is inconsistent with other English possessives.