### PR TITLE
Fix include path error when compiling Ogre as a subproject

### DIFF
--- a/Components/SceneFormat/CMakeLists.txt
+++ b/Components/SceneFormat/CMakeLists.txt
@@ -21,7 +21,7 @@ file(
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-include_directories(${CMAKE_SOURCE_DIR}/Components/Hlms/Common/include)
+include_directories(${OGRE_SOURCE_DIR}/Components/Hlms/Common/include)
 ogre_add_component_include_dir(Hlms/Pbs)
 
 add_definitions( -DOgreSceneFormat_EXPORTS )


### PR DESCRIPTION
Fixes a compile error when compiling Ogre as a subproject (using FetchContent) in a different master project.