### PR TITLE
getMemoryStats was reporting used staging texture bytes as available, and vice versa

### DIFF
--- a/OgreMain/src/OgreTextureGpuManager.cpp
+++ b/OgreMain/src/OgreTextureGpuManager.cpp
@@ -1164,7 +1164,8 @@ namespace Ogre
                                             size_t &outUsedStagingTextureBytes,
                                             size_t &outAvailableStagingTextureBytes )
     {
-        outAvailableStagingTextureBytes = getConsumedMemoryByStagingTextures( mAvailableStagingTextures );
+        outAvailableStagingTextureBytes =
+            getConsumedMemoryByStagingTextures( mAvailableStagingTextures );
         outUsedStagingTextureBytes = getConsumedMemoryByStagingTextures( mUsedStagingTextures );
 
         size_t textureBytesCpu = 0;

--- a/OgreMain/src/OgreTextureGpuManager.cpp
+++ b/OgreMain/src/OgreTextureGpuManager.cpp
@@ -1164,8 +1164,8 @@ namespace Ogre
                                             size_t &outUsedStagingTextureBytes,
                                             size_t &outAvailableStagingTextureBytes )
     {
-        outUsedStagingTextureBytes = getConsumedMemoryByStagingTextures( mAvailableStagingTextures );
-        outAvailableStagingTextureBytes = getConsumedMemoryByStagingTextures( mUsedStagingTextures );
+        outAvailableStagingTextureBytes = getConsumedMemoryByStagingTextures( mAvailableStagingTextures );
+        outUsedStagingTextureBytes = getConsumedMemoryByStagingTextures( mUsedStagingTextures );
 
         size_t textureBytesCpu = 0;
         size_t textureBytesGpu = 0;


### PR DESCRIPTION
TextureGpuManager::getMemoryStats was reporting used staging texture bytes as available, and vice versa