### PR TITLE
Missing init of mTexture pointer in OgreFont.

### DIFF
--- a/Components/Overlay/src/OgreFont.cpp
+++ b/Components/Overlay/src/OgreFont.cpp
@@ -72,6 +72,7 @@ namespace Ogre
         mTtfResolution( 0 ),
         mTtfMaxBearingY( 0 ),
         mHlmsDatablock( 0 ),
+        mTexture( 0 ),
         mTextureLoadingInProgress( false ),
         mAntialiasColour( false )
     {


### PR DESCRIPTION
If calling loadImpl() it will call guiDatablock->setTexture( 0, mTexture, &samplerblock ); with unit mTexture pointer instead of NULL. In unloadImpl() it will call textureManager->destroyTexture( mTexture ); with random pointer.