### PR TITLE
fix GLES2PixelUtil::getClosestGLImageInternalFormat

### DIFF
--- a/RenderSystems/GLES2/src/OgreGLES2PixelFormat.cpp
+++ b/RenderSystems/GLES2/src/OgreGLES2PixelFormat.cpp
@@ -762,7 +762,7 @@ namespace Ogre {
     GLenum GLES2PixelUtil::getClosestGLImageInternalFormat(PixelFormat format)
     {
         GLenum GLformat = getGLImageInternalFormat(format);
-        return (format == GL_NONE ? GL_RGBA8 : GLformat);
+        return (GLformat == GL_NONE ? GL_RGBA8 : GLformat);
     }
     //-----------------------------------------------------------------------------
     PixelFormat GLES2PixelUtil::getClosestOGREFormat(GLenum fmt, GLenum dataType)


### PR DESCRIPTION
## Issue: Incorrect Variable Type Comparison

The original code incorrectly compares variables of different types:

- It checks `format == GL_NONE`.
    - `format` is of type `PixelFormat` (an application-defined enum or type).
    - `GL_NONE` is an OpenGL constant of type `GLenum`.

**This is not elegant.**