### PR TITLE
Fix Vulkan crash on creating or resizing Ogre created window.

### DIFF
--- a/RenderSystems/Vulkan/src/OgreVulkanWindow.cpp
+++ b/RenderSystems/Vulkan/src/OgreVulkanWindow.cpp
@@ -540,7 +540,7 @@ namespace Ogre
 
         acquireNextSwapchain();
 
-        if( mDepthBuffer )
+        if( mDepthBuffer && mDepthBuffer->getResidencyStatus() != GpuResidency::Resident )
             mDepthBuffer->_transitionTo( GpuResidency::Resident, (uint8 *)0 );
         if( mStencilBuffer && mStencilBuffer != mDepthBuffer )
             mStencilBuffer->_transitionTo( GpuResidency::Resident, (uint8 *)0 );


### PR DESCRIPTION
Fixes https://github.com/OGRECave/ogre-next/issues/530

I notice that `mStencilBuffer` just below looks like it also might need a check but I didn't encounter any error there and I don't know under what conditions the stencil buffer is separate from the depth buffer.