### PR TITLE
Fixed OgreRectangle2D2 create VertexData Length ERROR

### DIFF
--- a/OgreMain/src/OgreRectangle2D2.cpp
+++ b/OgreMain/src/OgreRectangle2D2.cpp
@@ -142,7 +142,7 @@ namespace Ogre
         const BufferType bufferType = getBufferType();
 
         float *vertexData = reinterpret_cast<float *>( OGRE_MALLOC_SIMD(
-            sizeof( float ) * bytesPerVertex * numVertices, Ogre::MEMCATEGORY_GEOMETRY ) );
+            bytesPerVertex * numVertices, Ogre::MEMCATEGORY_GEOMETRY ) );
         FreeOnDestructor dataPtr( vertexData );
         if( !isHollowFullscreenRect() )
             fillBuffer( vertexData, numVertices );


### PR DESCRIPTION
size_t totalBytes = bytesPerVertex * numVertices;
totalBytes shold be bytesPerVertex * numVertices;