### PR TITLE
docs: replaced deprecated python-clang with python3-clang for Linux

### DIFF
--- a/Docs/src/SettingUpOgre/SettingUpOgreLinux.md
+++ b/Docs/src/SettingUpOgre/SettingUpOgreLinux.md
@@ -7,7 +7,7 @@
     * Git
     * Clang >3.5 or GCC >4.0
     * [QtCreator](https://download.qt.io/official_releases/qtcreator/) recommended (Optional).
-    * Debian-based: `sudo apt-get install libfreetype6-dev libfreeimage-dev libzzip-dev libxrandr-dev libxaw7-dev freeglut3-dev libgl1-mesa-dev libglu1-mesa-dev libx11-xcb-dev libxcb-keysyms1-dev doxygen graphviz python-clang libsdl2-dev cmake ninja-build`
+    * Debian-based: `sudo apt-get install libfreetype6-dev libfreeimage-dev libzzip-dev libxrandr-dev libxaw7-dev freeglut3-dev libgl1-mesa-dev libglu1-mesa-dev libx11-xcb-dev libxcb-keysyms1-dev doxygen graphviz python3-clang libsdl2-dev cmake ninja-build`
     * Arch: `pacman -S freeimage freetype2 libxaw libxrandr mesa zziplib cmake gcc`
     * For HW & SW requirements, please visit http://www.ogre3d.org/developers/requirements
     * NVIDIA users: Proprietary drivers are recommended.


### PR DESCRIPTION
The current Linux setup instructions list the package `python-clang`, which is no longer available in Debian/Ubuntu/Mint repositories.  
Copy-pasting the install command produces:

  Package python-clang is not available, but is referred to by another package.
  This may mean that the package is missing, has been obsoleted, or is only available from another source
  However, the following packages replace it:
    python3-clang:i386 python3-clang

This PR updates the instructions to use `python3-clang`, which is available and resolves the installation issue.  