### PR TITLE
Fix CompositorNode::connectBufferTo

### DIFF
--- a/OgreMain/src/Compositor/OgreCompositorNode.cpp
+++ b/OgreMain/src/Compositor/OgreCompositorNode.cpp
@@ -517,7 +517,8 @@ namespace Ogre
         else
         {
             nodeB->mBuffers.insert( inBuf, 1, *outBuf );
-            ++mNumConnectedBufferInputs;
+            ++nodeB->mNumConnectedBufferInputs;
+            this->mConnectedNodes.push_back( nodeB );
         }
     }
     //-----------------------------------------------------------------------------------


### PR DESCRIPTION
This seemed to not work at all.

For reference, I edited Sample_TutorialCompute02_UavBuffer to use a buffer connection by editing
https://github.com/OGRECave/ogre-next/blob/master/Samples/Media/2.0/scripts/materials/TutorialCompute02_UavBuffer/Compute.compositor like this:
```
compositor_node UavBuffer
{
	buffer testBuffer 1 4 target_width target_height

	out_buffer 0 testBuffer
}

compositor_node TutorialComputeTest02_UavBufferRenderingNode
{
	in 0 rt_renderwindow
	in_buffer 0 testBuffer

	//buffer name size bytesPerElement [target_width] [target_height] bind_flags
	//buffer testBuffer 1 4 target_width target_height
	
	...
}

workspace TutorialComputeTest02_UavBufferWorkspace
{
	connect_buffer UavBuffer 0 TutorialComputeTest02_UavBufferRenderingNode 0
	connect_output TutorialComputeTest02_UavBufferRenderingNode 0
}
```