### PR TITLE
Remove recursive calling of CompositorNode::notifyRecreated which cou…

### DIFF
--- a/OgreMain/include/Compositor/OgreCompositorNode.h
+++ b/OgreMain/include/Compositor/OgreCompositorNode.h
@@ -308,9 +308,12 @@ namespace Ogre
         @param finalTarget
             The Final Target (i.e. RenderWindow) from which we'll base our local textures'
             resolution.
+        @param notifyNodes
+            Array of nodes that may be using our textures and need to be notified.
         */
         virtual void finalTargetResized01( const TextureGpu *finalTarget );
-        virtual void finalTargetResized02( const TextureGpu *finalTarget );
+        virtual void finalTargetResized02( const TextureGpu        *finalTarget,
+                                           const CompositorNodeVec &notifyNodes );
 
         /// @copydoc CompositorWorkspace::resetAllNumPassesLeft
         void resetAllNumPassesLeft();

--- a/OgreMain/include/Compositor/OgreTextureDefinition.h
+++ b/OgreMain/include/Compositor/OgreTextureDefinition.h
@@ -413,7 +413,7 @@ namespace Ogre
                                                  const TextureGpu           *finalTarget );
         /** See recreateResizableTextures01
             Updates involved RenderPassDescriptors.
-        @param connectedNodes
+        @param notifyNodes
             Array of connected nodes that may be using our textures and need to be notified.
         @param passes
             Array of Compositor Passes which may contain the texture being recreated
@@ -421,7 +421,7 @@ namespace Ogre
         */
         static void recreateResizableTextures02( const TextureDefinitionVec &textureDefs,
                                                  CompositorChannelVec       &inOutTexContainer,
-                                                 const CompositorNodeVec    &connectedNodes,
+                                                 const CompositorNodeVec    &notifyNodes,
                                                  const CompositorPassVec    *passes );
 
         /////////////////////////////////////////////////////////////////////////////////
@@ -519,7 +519,7 @@ namespace Ogre
             (eg. when using auto width & height, or fsaa settings)
         @param renderSys
             The RenderSystem to use
-        @param connectedNodes
+        @param notifyNodes
             Array of connected nodes that may be using our buffers and need to be notified.
         @param passes
             Array of Compositor Passes which may contain the texture being recreated
@@ -528,7 +528,7 @@ namespace Ogre
         static void recreateResizableBuffers( const BufferDefinitionVec &bufferDefs,
                                               CompositorNamedBufferVec  &inOutBufContainer,
                                               const TextureGpu *finalTarget, RenderSystem *renderSys,
-                                              const CompositorNodeVec &connectedNodes,
+                                              const CompositorNodeVec &notifyNodes,
                                               const CompositorPassVec *passes );
     };
 

--- a/OgreMain/src/Compositor/OgreCompositorWorkspace.cpp
+++ b/OgreMain/src/Compositor/OgreCompositorWorkspace.cpp
@@ -845,6 +845,17 @@ namespace Ogre
 
                 while( itor != endt )
                 {
+                    if( !( *itor )->getEnabled() )
+                    {
+                        endt = itor;
+                        break;
+                    }
+                    ++itor;
+                }
+
+                itor = mNodeSequence.begin();
+                while( itor != endt )
+                {
                     CompositorNode *node = *itor;
                     node->finalTargetResized01( finalTarget );
                     ++itor;
@@ -854,7 +865,7 @@ namespace Ogre
                 while( itor != endt )
                 {
                     CompositorNode *node = *itor;
-                    node->finalTargetResized02( finalTarget );
+                    node->finalTargetResized02( finalTarget, mNodeSequence );
                     ++itor;
                 }
             }
@@ -874,7 +885,7 @@ namespace Ogre
                 while( itor != endt )
                 {
                     CompositorShadowNode *node = *itor;
-                    node->finalTargetResized02( finalTarget );
+                    node->finalTargetResized02( finalTarget, mNodeSequence );
                     ++itor;
                 }
             }

--- a/OgreMain/src/Compositor/OgreTextureDefinition.cpp
+++ b/OgreMain/src/Compositor/OgreTextureDefinition.cpp
@@ -448,7 +448,7 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     void TextureDefinitionBase::recreateResizableTextures02( const TextureDefinitionVec &textureDefs,
                                                              CompositorChannelVec &inOutTexContainer,
-                                                             const CompositorNodeVec &connectedNodes,
+                                                             const CompositorNodeVec &notifyNodes,
                                                              const CompositorPassVec *passes )
     {
         TextureDefinitionVec::const_iterator itor = textureDefs.begin();
@@ -471,8 +471,8 @@ namespace Ogre
                     }
                 }
 
-                CompositorNodeVec::const_iterator itNodes = connectedNodes.begin();
-                CompositorNodeVec::const_iterator enNodes = connectedNodes.end();
+                CompositorNodeVec::const_iterator itNodes = notifyNodes.begin();
+                CompositorNodeVec::const_iterator enNodes = notifyNodes.end();
 
                 while( itNodes != enNodes )
                 {
@@ -646,7 +646,7 @@ namespace Ogre
                                                           CompositorNamedBufferVec &inOutBufContainer,
                                                           const TextureGpu *finalTarget,
                                                           RenderSystem *renderSys,
-                                                          const CompositorNodeVec &connectedNodes,
+                                                          const CompositorNodeVec &notifyNodes,
                                                           const CompositorPassVec *passes )
     {
         CompositorNamedBuffer cmp;
@@ -675,8 +675,8 @@ namespace Ogre
                     }
                 }
 
-                CompositorNodeVec::const_iterator itNodes = connectedNodes.begin();
-                CompositorNodeVec::const_iterator enNodes = connectedNodes.end();
+                CompositorNodeVec::const_iterator itNodes = notifyNodes.begin();
+                CompositorNodeVec::const_iterator enNodes = notifyNodes.end();
 
                 while( itNodes != enNodes )
                 {


### PR DESCRIPTION
Fixes https://github.com/OGRECave/ogre-next/issues/539

This replaces recursively calling `CompositorNode::notifyRecreated` by following the `CompositorNode::mConnectedNodes` field with notifying a flat list of nodes (`CompositorWorkspace::mNodeSequence`).

Both regular nodes and shadow nodes notify all regular nodes and neither notify shadow nodes. I think this is correct based on this line from the compositor documentation:

> It is possible however, to connect the output from a Shadow Node to a regular Node for further postprocessing (i.e. reflective shadow maps for real time Global Illumination), but Shadow Nodes cannot have input.

`CompositorNode::notifyDestroyed` also recursively notifies other nodes but as it clears the output at the same time it doesn't suffer from the same issue. I've left that behaviour the same although it makes the notify methods a bit inconsistent.