### PR TITLE
Fix crash when FreeImage library has been compiled without support fo…

### DIFF
--- a/OgreMain/src/OgreFreeImageCodec2.cpp
+++ b/OgreMain/src/OgreFreeImageCodec2.cpp
@@ -113,7 +113,10 @@ namespace Ogre
             if( (FREE_IMAGE_FORMAT)i == FIF_DDS )
                 continue;
 
-            String exts( FreeImage_GetFIFExtensionList( (FREE_IMAGE_FORMAT)i ) );
+            const char *exts = FreeImage_GetFIFExtensionList( (FREE_IMAGE_FORMAT)i );
+            if( !exts )
+                continue;
+
             if( !first )
             {
                 strExt << ",";


### PR DESCRIPTION
…r some formats.

In the case of `FreeImageRe` there might also be gaps even if compiled with full support.