### PR TITLE
fix v2-3 for GCC 15

### DIFF
--- a/OgreMain/include/OgreMemorySTLAllocator.h
+++ b/OgreMain/include/OgreMemorySTLAllocator.h
@@ -100,7 +100,7 @@ namespace Ogre
         };
 
         /// ctor
-        inline explicit STLAllocator()
+        inline STLAllocator()
         { }
 
         /// dtor


### PR DESCRIPTION
Hi,

upgrading to GCC 15 yield:

```cpp
[50/750] Building CXX object OgreMain/CMakeFiles/OgreNextMain.dir/src/OgreGpuProgramParams.cpp.o
FAILED: [code=1] OgreMain/CMakeFiles/OgreNextMain.dir/src/OgreGpuProgramParams.cpp.o
/nix/store/a245z3cvf9x9sn0xlk6k8j9xhxbhda1z-gcc-wrapper-15.2.0/bin/g++ -DFREEIMAGE_LIB -DOGRE_NONCLIENT_BUILD -DOgreNextMain_EXPORTS -D_MT -D_USRDLL -I/build/source/OgreMain/include -I/build/source/build/include -I/nix/store/d4i1vzn8wsna9rjcc2h55qcsnd8mg815-freetype-2.13.3-dev/include/freetype2 -I/build/source -I/build/source/OgreMain/include/GLX -I/build/source/OgreMain/src/nedmalloc -Wall -Winit-self -Wno-overloaded-virtual -Wcast-qual -Wwrite-strings -Wextra -Wno-unused-parameter -Wshadow -Wno-missing-field-initializers -Wno-long-long -Wno-unused-but-set-parameter  -msse -msse2 -O3 -DNDEBUG -fPIC   -fPIC -pthread -DOGRE_GCC_VISIBILITY -fvisibility=hidden -fvisibility-inlines-hidden -MD -MT OgreMain/CMakeFiles/OgreNextMain.dir/src/OgreGpuProgramParams.cpp.o -MF OgreMain/CMakeFiles/OgreNextMain.dir/src/OgreGpuProgramParams.cpp.o.d -o OgreMain/CMakeFiles/OgreNextMain.dir/src/OgreGpuProgramParams.cpp.o -c /build/source/OgreMain/src/OgreGpuProgramParams.cpp
In file included from /nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0/include/c++/15.2.0/bits/hashtable.h:37,
                 from /nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0/include/c++/15.2.0/bits/unordered_map.h:33,
                 from /nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0/include/c++/15.2.0/unordered_map:43,
                 from /nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0/include/c++/15.2.0/functional:65,
                 from /build/source/OgreMain/include/OgreStdHeaders.h:36,
                 from /build/source/OgreMain/include/OgrePrerequisites.h:461,
                 from /build/source/OgreMain/include/OgreGpuProgramParams.h:32,
                 from /build/source/OgreMain/src/OgreGpuProgramParams.cpp:29:
/nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0/include/c++/15.2.0/bits/hashtable_policy.h: In instantiation of 'constexpr std::__detail::_Hashtable_alloc<_NodeAlloc>::_Hashtable_alloc() [with _NodeAlloc = Ogre::STLAllocator<std::__detail::_Hash_node<std::pair<const unsigned int, std::__cxx11::basic_string<char> >, false>, Ogre::CategorisedAllocPolicy<Ogre::MEMCATEGORY_GENERAL> >]':
/build/source/OgreMain/src/OgreGpuProgramParams.cpp:939:71:   recursively required from 'std::unordered_map<_Key, _Tp, _Hash, _Pred, _Alloc>::unordered_map() [with _Key = unsigned int; _Tp = std::__cxx11::basic_string<char>; _Hash = std::hash<unsigned int>; _Pred = std::equal_to<unsigned int>; _Alloc = Ogre::STLAllocator<std::pair<const unsigned int, std::__cxx11::basic_string<char> >, Ogre::CategorisedAllocPolicy<Ogre::MEMCATEGORY_GENERAL> >]'
  939 |         , mActivePassIterationIndex(std::numeric_limits<size_t>::max())
      |                                                                       ^
/build/source/OgreMain/src/OgreGpuProgramParams.cpp:939:71:   required from here
/nix/store/mjf8jlq9grydcdvyw6hb063x5c34g5gf-gcc-15.2.0/include/c++/15.2.0/bits/hashtable_policy.h:1475:67: error: converting to 'Ogre::STLAllocator<std::__detail::_Hash_node<std::pair<const unsigned int, std::__cxx11::basic_string<char> >, false>, Ogre::CategorisedAllocPolicy<Ogre::MEMCATEGORY_GENERAL> >' from initializer list would use explicit constructor 'Ogre::STLAllocator<T, AllocPolicy>::STLAllocator() [with T = std::__detail::_Hash_node<std::pair<const unsigned int, std::__cxx11::basic_string<char> >, false>; AllocPolicy = Ogre::CategorisedAllocPolicy<Ogre::MEMCATEGORY_GENERAL>]'
 1475 |       [[__no_unique_address__]] _Hashtable_ebo_helper<_NodeAlloc> _M_alloc{};
      |                                                                   ^~~~~~~~
In file included from /build/source/OgreMain/include/OgreMemoryAllocatorConfig.h:188,
                 from /build/source/OgreMain/include/OgrePrerequisites.h:462:
/build/source/OgreMain/include/OgreMemorySTLAllocator.h:103:25: note: 'Ogre::STLAllocator<T, AllocPolicy>::STLAllocator() [with T = std::__detail::_Hash_node<std::pair<const unsigned int, std::__cxx11::basic_string<char> >, false>; AllocPolicy = Ogre::CategorisedAllocPolicy<Ogre::MEMCATEGORY_GENERAL>]' declared here
  103 |         inline explicit STLAllocator()
      |                         ^~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```