### PR TITLE
[Metal] Avoid NSWindow for hidden offscreen windows

### DIFF
--- a/RenderSystems/Metal/src/OgreMetalWindow.mm
+++ b/RenderSystems/Metal/src/OgreMetalWindow.mm
@@ -416,8 +416,7 @@ namespace Ogre
                     frame.size.width = frame.size.height = 500.0;
                 }
                 NSWindowStyleMask style =
-                    NSWindowStyleMaskResizable | NSWindowStyleMaskTitled |
-                    NSWindowStyleMaskClosable;
+                    NSWindowStyleMaskResizable | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
                 if( mRequestedFullscreenMode )
                 {
                     frame.size = NSScreen.mainScreen.visibleFrame.size;

--- a/RenderSystems/Metal/src/OgreMetalWindow.mm
+++ b/RenderSystems/Metal/src/OgreMetalWindow.mm
@@ -399,57 +399,69 @@ namespace Ogre
         // create window if nothing was provided
         if( !externalWindowHandle )
         {
-            NSRect frame = NSMakeRect( 0.0, 0.0, mRequestedWidth, mRequestedHeight );
-            if( mRequestedWidth == 1 )
+            if( mHidden )
             {
-                // just make it big enough to see
-                frame.size.width = frame.size.height = 500.0;
+                // Hidden offscreen window: create a Metal view without an NSWindow.
+                // NSWindow must be created on the main thread on macOS; skipping it
+                // makes hidden windows safe to create from any thread.
+                NSRect frame = NSMakeRect( 0.0, 0.0, mRequestedWidth, mRequestedHeight );
+                mMetalView = [[OgreMetalView alloc] initWithFrame:frame];
             }
-            NSWindowStyleMask style =
-                NSWindowStyleMaskResizable | NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
-            if( mRequestedFullscreenMode )
+            else
             {
-                frame.size = NSScreen.mainScreen.visibleFrame.size;
-                style = NSWindowStyleMaskBorderless;
-            }
-            NSWindow *window = [[NSWindow alloc] initWithContentRect:frame
-                                                           styleMask:style
-                                                             backing:NSBackingStoreBuffered
-                                                               defer:YES];
-            window.title = @( mTitle.c_str() );
-            window.contentView = [[OgreMetalView alloc] initWithFrame:frame];
-
-            externalWindowHandle = window;
-            SetupMetalWindowListeners( this, window );
-            if( !mHidden )
+                NSRect frame = NSMakeRect( 0.0, 0.0, mRequestedWidth, mRequestedHeight );
+                if( mRequestedWidth == 1 )
+                {
+                    // just make it big enough to see
+                    frame.size.width = frame.size.height = 500.0;
+                }
+                NSWindowStyleMask style =
+                    NSWindowStyleMaskResizable | NSWindowStyleMaskTitled |
+                    NSWindowStyleMaskClosable;
+                if( mRequestedFullscreenMode )
+                {
+                    frame.size = NSScreen.mainScreen.visibleFrame.size;
+                    style = NSWindowStyleMaskBorderless;
+                }
+                NSWindow *window = [[NSWindow alloc] initWithContentRect:frame
+                                                               styleMask:style
+                                                                 backing:NSBackingStoreBuffered
+                                                                   defer:YES];
+                window.title = @( mTitle.c_str() );
+                window.contentView = [[OgreMetalView alloc] initWithFrame:frame];
+                externalWindowHandle = window;
+                SetupMetalWindowListeners( this, window );
                 [window orderFront:nil];
+            }
         }
         else
         {
             mIsExternal = true;
         }
 
-        NSView *externalView;
-        if( [externalWindowHandle isKindOfClass:[NSWindow class]] )
+        if( !mMetalView )
         {
-            mWindow = (NSWindow *)externalWindowHandle;
-            externalView = mWindow.contentView;
-        }
-        else
-        {
-            assert( [externalWindowHandle isKindOfClass:[NSView class]] );
-            externalView = (NSView *)externalWindowHandle;
-            mWindow = externalView.window;
-        }
-
-        if( [externalView isKindOfClass:[OgreMetalView class]] )
-            mMetalView = (OgreMetalView *)externalView;
-        else
-        {
-            NSRect frame = externalView.bounds;
-            mMetalView = [[OgreMetalView alloc] initWithFrame:frame];
-            mMetalView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
-            [externalView addSubview:mMetalView];
+            NSView *externalView;
+            if( [externalWindowHandle isKindOfClass:[NSWindow class]] )
+            {
+                mWindow = (NSWindow *)externalWindowHandle;
+                externalView = mWindow.contentView;
+            }
+            else
+            {
+                assert( [externalWindowHandle isKindOfClass:[NSView class]] );
+                externalView = (NSView *)externalWindowHandle;
+                mWindow = externalView.window;
+            }
+            if( [externalView isKindOfClass:[OgreMetalView class]] )
+                mMetalView = (OgreMetalView *)externalView;
+            else
+            {
+                NSRect frame = externalView.bounds;
+                mMetalView = [[OgreMetalView alloc] initWithFrame:frame];
+                mMetalView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+                [externalView addSubview:mMetalView];
+            }
         }
 #endif
 


### PR DESCRIPTION
## Summary

When `mHidden` is true and no external window handle is provided, the Metal backend creates an `NSWindow` anyway (just without calling `[window orderFront:]`). Since `NSWindow` must be created and manipulated on the main thread on macOS, this makes it unsafe to create hidden/offscreen rendering windows from background threads — a common pattern for headless server-side rendering.

### Changes

When `mHidden` is true and no external handle is provided, create a standalone `OgreMetalView` without wrapping it in an `NSWindow`. This mirrors the spirit of `VulkanWindowNull` in the Vulkan backend, which similarly avoids platform window creation for headless rendering.

The `externalWindowHandle` / `NSView` / `NSWindow` resolution path is wrapped in `if( !mMetalView )` so it is only executed when a view was not already created by the hidden-window path.