### PR TITLE
Fix RGB channel swap in STBICodec RGB-to-RGBA conversion (v2-3)

### DIFF
--- a/OgreMain/src/OgreSTBICodec.cpp
+++ b/OgreMain/src/OgreSTBICodec.cpp
@@ -189,9 +189,9 @@ namespace Ogre {
                     const uint8 g = *pSrc++;
                     const uint8 r = *pSrc++;
 
-                    *pDst++ = r;
-                    *pDst++ = g;
                     *pDst++ = b;
+                    *pDst++ = g;
+                    *pDst++ = r;
                     *pDst++ = 0xFF;
                 }
             }


### PR DESCRIPTION
## Summary

- Fix red/blue channel swap when loading 3-channel RGB images through the STB codec
- The variable names `b, g, r` assume BGR input, but `stb_image` always returns RGB
- Writing `r, g, b` (actually B, G, R) into `PFG_RGBA8_UNORM` (R-first) swaps red and blue
- master (v3-0) already has the correct `b, g, r` write order — this backports the fix to v2-3

## Visual evidence

See the screenshots in https://github.com/osrf/homebrew-simulation/pull/3394#issuecomment-4101535199 — the "Rescue Randy" model has blue skin and teal jacket instead of brown skin and lime jacket when ogre 2.3 is built without FreeImage (STB codec active).

## Test plan

- Build ogre-next 2.3 without FreeImage (`OGRE_CONFIG_ENABLE_FREEIMAGE=OFF`, `OGRE_CONFIG_ENABLE_STBI=ON`)
- Load a scene with 3-channel RGB textures (e.g. `fuel_textured_mesh.sdf` in gz-sim)
- Verify that colors render correctly (no red/blue swap)