### PR TITLE
Fix STLAllocator compatibility with GCC 15 and modern C++ standards

### DIFF
--- a/OgreMain/include/OgreMemorySTLAllocator.h
+++ b/OgreMain/include/OgreMemorySTLAllocator.h
@@ -100,25 +100,29 @@ namespace Ogre
         };
 
         /// ctor
-        inline explicit STLAllocator()
+        inline constexpr STLAllocator()
         { }
 
         /// dtor
+#if __cplusplus >= 202002L
+        constexpr ~STLAllocator()
+#else
         ~STLAllocator()
+#endif
         { }
 
         /// copy ctor - done component wise
-        inline STLAllocator( STLAllocator const& )
+        inline constexpr STLAllocator( STLAllocator const& )
         { }
 
         /// cast
         template <typename U>
-        inline STLAllocator( STLAllocator<U, AllocPolicy> const& )
+        inline constexpr STLAllocator( STLAllocator<U, AllocPolicy> const& )
         { }
 
         /// cast
         template <typename U, typename P>
-        inline STLAllocator( STLAllocator<U, P> const& )
+        inline constexpr STLAllocator( STLAllocator<U, P> const& )
         { }
 
         /// memory allocation (elements, used by STL)


### PR DESCRIPTION
Updated STLAllocator constructors to be compatible with modern C++ standard library containers:

1. Made constructors constexpr: Added constexpr keyword to all constructors to make them compatible with modern C++ standard library containers that require constexpr allocators.

2. Removed explicit from default constructor: The default constructor was marked as explicit, which prevented it from being used in implicit initialization contexts (like {}-initialization). Standard library containers expect allocators to have non-explicit default constructors.

3. Conditionally made destructor constexpr: Added a preprocessor check to only make the destructor constexpr in C++20 and later, since constexpr destructors are not available in earlier C++ standards.

These changes fix compilation errors with GCC 15 where the hashtable implementation tries to use {} initialization on the allocator member, which requires a non-explicit constexpr default constructor.

---

Note: this fixes the same problem as #564, but was entirely AI generated. I'm not sure whether you have some AI policy so feel free to disregard it if it violates your policy.