### PR TITLE
CMake: guard macOS framework post-build commands with OGRE_BUILD_LIBS_AS_FRAMEWORKS (v2-3)

### DIFF
--- a/OgreMain/CMakeLists.txt
+++ b/OgreMain/CMakeLists.txt
@@ -439,33 +439,35 @@ if (APPLE)
         LINK_FLAGS "-framework IOKit -framework Cocoa -framework Carbon -framework OpenGL -framework CoreVideo"
     )
 
-    set(OGRE_OSX_BUILD_CONFIGURATION "$(PLATFORM_NAME)/$(CONFIGURATION)")
-  
-	add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
-		COMMAND mkdir ARGS -p ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/Threading
-        COMMAND ditto 
-		${OGRE_SOURCE_DIR}/OgreMain/include/Threading/*.h ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/Threading
-		COMMAND mkdir ARGS -p ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/OSX
-        COMMAND ditto 
-		${OGRE_SOURCE_DIR}/OgreMain/include/OSX/*.h ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/OSX
-		COMMAND cd ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers
-		)
+    if (OGRE_BUILD_LIBS_AS_FRAMEWORKS)
+      set(OGRE_OSX_BUILD_CONFIGURATION "$(PLATFORM_NAME)/$(CONFIGURATION)")
 
-    foreach(HEADER_PATH ${THREAD_HEADER_FILES})
-        get_filename_component(HEADER_FILE ${HEADER_PATH} NAME)
-        set(FWK_HEADER_PATH ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/${HEADER_FILE})
-        add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
-            COMMAND rm -f ${FWK_HEADER_PATH}
-            )
-    endforeach()
+      add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
+          COMMAND mkdir ARGS -p ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/Threading
+          COMMAND ditto
+          ${OGRE_SOURCE_DIR}/OgreMain/include/Threading/*.h ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/Threading
+          COMMAND mkdir ARGS -p ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/OSX
+          COMMAND ditto
+          ${OGRE_SOURCE_DIR}/OgreMain/include/OSX/*.h ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/OSX
+          COMMAND cd ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers
+          )
 
-    foreach(HEADER_PATH ${PLATFORM_HEADERS})
-        get_filename_component(HEADER_FILE ${HEADER_PATH} NAME)
-        set(FWK_HEADER_PATH ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/${HEADER_FILE})
-        add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
-            COMMAND rm -f ${FWK_HEADER_PATH}
-            )
-    endforeach()
+      foreach(HEADER_PATH ${THREAD_HEADER_FILES})
+          get_filename_component(HEADER_FILE ${HEADER_PATH} NAME)
+          set(FWK_HEADER_PATH ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/${HEADER_FILE})
+          add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
+              COMMAND rm -f ${FWK_HEADER_PATH}
+              )
+      endforeach()
+
+      foreach(HEADER_PATH ${PLATFORM_HEADERS})
+          get_filename_component(HEADER_FILE ${HEADER_PATH} NAME)
+          set(FWK_HEADER_PATH ${OGRE_BINARY_DIR}/lib/${OGRE_OSX_BUILD_CONFIGURATION}/Ogre.framework/Headers/${HEADER_FILE})
+          add_custom_command(TARGET ${OGRE_NEXT}Main POST_BUILD
+              COMMAND rm -f ${FWK_HEADER_PATH}
+              )
+      endforeach()
+    endif ()
 
     ogre_config_framework(${OGRE_NEXT}Main)
   endif ()


### PR DESCRIPTION
## Summary
On macOS (non-iOS), `OgreMain/CMakeLists.txt` unconditionally runs `ditto` and `mkdir` to create an `Ogre.framework` bundle structure, even when `OGRE_BUILD_LIBS_AS_FRAMEWORKS=OFF`.

This causes build failures in environments that don't have `ditto` (e.g. minimal toolchain setups, package manager sandboxes) and creates unnecessary framework directory structures.

## Changes
Wrap the framework-specific post-build block (from `set(OGRE_OSX_BUILD_CONFIGURATION ...)` through the header cleanup loop) in `if(OGRE_BUILD_LIBS_AS_FRAMEWORKS)` / `endif()`.

`ogre_config_framework()` is left outside the guard since it already has its own internal framework check.

## Test plan
- Build on macOS with `-DOGRE_BUILD_LIBS_AS_FRAMEWORKS=OFF` — no `ditto` errors
- Build on macOS with `-DOGRE_BUILD_LIBS_AS_FRAMEWORKS=ON` — framework bundle created as before