### PR TITLE
pkgconfig: fix plugindir on macOS where plugins install to lib/ directly (v2-3)

### DIFF
--- a/CMake/Templates/OGRE.pc.in
+++ b/CMake/Templates/OGRE.pc.in
@@ -2,7 +2,7 @@ prefix=@OGRE_PREFIX_PATH@
 exec_prefix=${prefix}
 libdir=${prefix}/@OGRE_LIB_DIRECTORY@
 includedir=${prefix}/include
-plugindir=${libdir}/@OGRE_NEXT_PREFIX@
+plugindir=${libdir}@OGRE_PLUGIN_PATH@
 
 Name: @OGRE_NEXT_PREFIX@ 
 Description: Object-Oriented Graphics Rendering Engine


### PR DESCRIPTION
## Summary
`OGRE.pc.in` defines `plugindir=${libdir}/@OGRE_NEXT_PREFIX@`.

On Linux with `OGRE_USE_NEW_PROJECT_NAME=ON`, this expands correctly to `${libdir}/OgreNext`.

On macOS, `OGRE_PLUGIN_PATH` is `"/"` (plugins install directly into `lib/`), but `OGRE_NEXT_PREFIX` is `"OGRE"`, producing `plugindir=${libdir}/OGRE` — a path that doesn't exist. This causes downstream consumers using pkg-config (e.g. gz-rendering via FindGzOGRE2.cmake) to fail at runtime when looking for render-system plugins.

## Changes
Replace `@OGRE_NEXT_PREFIX@` with `@OGRE_PLUGIN_PATH@` in `OGRE.pc.in`. `OGRE_PLUGIN_PATH` already contains the correct platform-specific suffix:
- Linux: `/@OGRE_NEXT_PREFIX@` (e.g. `/OgreNext`) → plugindir unchanged
- macOS: `/` → plugindir correctly points to `${libdir}/`

`OGRE_PLUGIN_PATH` is set in `CMake/Utils/OgreConfigTargets.cmake` (line 83 of root `CMakeLists.txt`) before `ConfigureBuild.cmake` (line 625) runs `configure_file`, so the variable is in scope.

## Test plan
- Build on macOS, verify `pkg-config --variable=plugindir OGRE` returns `<prefix>/lib/` (not `<prefix>/lib/OGRE`)
- Build on Linux with `OGRE_USE_NEW_PROJECT_NAME=ON`, verify plugindir returns `<prefix>/lib/OgreNext` (unchanged)