### PR TITLE
HlmsPbs: prevent crash when Ocean is used without Terra

### DIFF
--- a/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
@@ -3128,6 +3128,8 @@ namespace Ogre
 
         if( OGRE_EXTRACT_HLMS_TYPE_FROM_CACHE_HASH( lastCacheHash ) != mType )
         {
+            if( mCurrentPassBuffer == 0 )
+                return 0;
             // layout(binding = 0) uniform PassBuffer {} pass
             ConstBufferPacked *passBuffer = mPassBuffers[mCurrentPassBuffer - 1];
             *commandBuffer->addCommand<CbShaderBuffer>() = CbShaderBuffer(


### PR DESCRIPTION
Guard against null mCurrentPassBuffer in fillBuffersFor. Prevents crash when using Ocean without Terra.

See forum: https://forums.ogre3d.org/viewtopic.php?t=97734