### PR TITLE
Fix NEON build on Linux (include order in the Math/Array NEON headers)

### DIFF
--- a/OgreMain/include/Math/Array/NEON/Single/OgreBooleanMaskNEON.h
+++ b/OgreMain/include/Math/Array/NEON/Single/OgreBooleanMaskNEON.h
@@ -33,6 +33,9 @@ THE SOFTWARE.
 #    error "Don't include this file directly. include Math/Array/OgreBooleanMask.h"
 #endif
 
+// For vmovemaskq_u32 (the _mm_movemask_ps emulation used by getScalarMask).
+#include "Math/Array/OgreMathlib.h"
+
 namespace Ogre
 {
     class _OgreExport BooleanMask4

--- a/OgreMain/src/Math/Array/NEON/Single/OgreMathlibNEON.cpp
+++ b/OgreMain/src/Math/Array/NEON/Single/OgreMathlibNEON.cpp
@@ -33,9 +33,12 @@ THE SOFTWARE.
 #if __OGRE_HAVE_NEON
 #    define __Mathlib_H__  // Needed to directly include OgreMathlibNEON
 
+// OgreArrayConfig.h must come first: it includes arm_neon.h and defines the
+// ArrayReal/ArrayInt/uint32x4_ct types OgreMathlibNEON.h relies on.
+#    include "Math/Array/OgreArrayConfig.h"
+
 #    include "Math/Array/NEON/Single/OgreMathlibNEON.h"
 #    include "Math/Array/NEON/Single/neon_mathfun.h"
-#    include "Math/Array/OgreArrayConfig.h"
 #    include "Math/Array/OgreBooleanMask.h"
 
 namespace Ogre


### PR DESCRIPTION
### What

Since the NEON Math/Array `.cpp` files were added (commit `5c9fcc3`), OgreMain
does not compile on AArch64 Linux with `OGRE_SIMD_NEON=ON`. Two independent
include-order problems, both masked on every platform where
`OgreStableHeaders.h` expands to the full header set - on Linux (and
Emscripten/FreeBSD) that umbrella is intentionally empty, so the NEON headers
get parsed without the types they rely on. Neither issue is compiler-specific
(reproduced with clang 18; the include order fails the same way under GCC).

- **`OgreMathlibNEON.cpp`**: the file defines `__Mathlib_H__` to include
  `OgreMathlibNEON.h` directly, but the alphabetically sorted include list
  puts the `Math/Array/NEON/...` headers before `Math/Array/OgreArrayConfig.h`
  - the header that pulls in `<arm_neon.h>` and defines
  `ArrayReal`/`ArrayInt`/`uint32x4_ct`:

  ```
  OgreMathlibNEON.h:46:42: error: unknown type name 'uint32x4_t'
  OgreMathlibNEON.h:48:22: error: unknown type name 'uint32x4_ct'
  OgreMathlibNEON.h:49:43: error: use of undeclared identifier 'vandq_u32'
  OgreMathlibNEON.h:63:19: error: unknown type name 'ArrayInt'
  ```

  Fix: move the `OgreArrayConfig.h` include into its own block ahead of the
  NEON headers (`IncludeBlocks: Preserve` in the project `.clang-format`
  keeps a separate block in place, so the format CI will not re-sort it
  back). The SSE2 twin `OgreMathlibSSE2.cpp` has the same structure but is
  unaffected only because `"OgreArrayConfig.h"` happens to sort before
  `"SSE2/..."`.

- **`OgreBooleanMaskNEON.h`**: `BooleanMask4::getScalarMask()` in the `.inl`
  calls `vmovemaskq_u32`, which is not an `<arm_neon.h>` intrinsic but the
  `_mm_movemask_ps` emulation helper defined in `OgreMathlibNEON.h` (the SSE2
  variant uses the real intrinsic, so only NEON has this hidden dependency).
  Any translation unit that includes `Math/Array/OgreBooleanMask.h` without
  having gone through `Math/Array/OgreMathlib.h` first fails to compile;
  `OgreVctCascadedVoxelizer.cpp` (HlmsPbs) is such a unit:

  ```
  OgreBooleanMaskNEON.inl:57:16: error: use of undeclared identifier 'vmovemaskq_u32'
  ```

  Fix: include `Math/Array/OgreMathlib.h` from `OgreBooleanMaskNEON.h` so the
  header is self-sufficient regardless of the includer's order.

No behaviour change on any platform - both commits only add/rearrange
includes; on platforms that already compiled, every header involved was
already reachable in these translation units.

### Why

AArch64 Linux is a real build target (CI runners, servers, Asahi, containers
on Apple hardware), and `OGRE_SIMD_NEON` defaults to ON. Without these two
includes, `OgreNextMain` and `OgreNextHlmsPbs` fail to build there while the
same sources build fine on macOS/iOS/Android, which makes the break easy to
miss on the platforms where NEON is usually exercised.

### How tested

Ubuntu 24.04 AArch64, clang 18.1.3, CMake + Ninja, `OGRE_SIMD_NEON=ON`
(`OGRE_SIMD_SSE2=OFF`), building OgreNextMain plus HlmsPbs, HlmsUnlit,
Atmosphere, PlanarReflections, ParticleFX2 and RenderSystem_NULL:

- before: `OgreMathlibNEON.cpp` fails with the unknown-type errors above;
  with the first commit applied, `OgreVctCascadedVoxelizer.cpp` fails on
  `vmovemaskq_u32` - each commit fixes its own failing TU;
- after both: clean build of all of the above (OgreMain in Debug and
  Release, the components in Release), all libraries link;
- macOS arm64 (where the stable-headers umbrella already masked the problem)
  builds unchanged before and after.
