### PR TITLE
Fixing the D3D11RenderSystem::createBlendState and Hlms::applyStrongBlendblockRules

### DIFF
--- a/OgreMain/src/OgreHlms.cpp
+++ b/OgreMain/src/OgreHlms.cpp
@@ -2453,6 +2453,8 @@ namespace Ogre
             blendblock.mBlendOperationAlpha =
                 static_cast<SceneBlendOperation>( ( blendOperationAlpha >> 20u ) - 1u );
         }
+
+        blendblock.calculateSeparateBlendMode();
     }
     //-----------------------------------------------------------------------------------
     HighLevelGpuProgramPtr Hlms::compileShaderCode( const String &source,

--- a/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
+++ b/RenderSystems/Direct3D11/src/OgreD3D11RenderSystem.cpp
@@ -2517,8 +2517,9 @@ namespace Ogre
                     D3D11Mappings::get( newBlock->mSourceBlendFactorAlpha, true );
                 blendDesc.RenderTarget[0].DestBlendAlpha =
                     D3D11Mappings::get( newBlock->mDestBlendFactorAlpha, true );
-                blendDesc.RenderTarget[0].BlendOp = blendDesc.RenderTarget[0].BlendOpAlpha =
-                    D3D11Mappings::get( newBlock->mBlendOperation );
+                blendDesc.RenderTarget[0].BlendOp = D3D11Mappings::get( newBlock->mBlendOperation );
+                blendDesc.RenderTarget[0].BlendOpAlpha =
+                    D3D11Mappings::get( newBlock->mBlendOperationAlpha );
 
                 blendDesc.RenderTarget[0].RenderTargetWriteMask =
                     newBlock->mBlendChannelMask & HlmsBlendblock::BlendChannelAll;
@@ -2541,9 +2542,8 @@ namespace Ogre
                     D3D11Mappings::get( newBlock->mSourceBlendFactor, true );
                 blendDesc.RenderTarget[0].DestBlendAlpha =
                     D3D11Mappings::get( newBlock->mDestBlendFactor, true );
-                blendDesc.RenderTarget[0].BlendOp = D3D11Mappings::get( newBlock->mBlendOperation );
-                blendDesc.RenderTarget[0].BlendOpAlpha =
-                    D3D11Mappings::get( newBlock->mBlendOperationAlpha );
+                blendDesc.RenderTarget[0].BlendOp = blendDesc.RenderTarget[0].BlendOpAlpha =
+                    D3D11Mappings::get( newBlock->mBlendOperation );
 
                 blendDesc.RenderTarget[0].RenderTargetWriteMask =
                     newBlock->mBlendChannelMask & HlmsBlendblock::BlendChannelAll;


### PR DESCRIPTION
There seems to be a problen D3D11 that the blendblock's blend operations were not properly setup according to mSeparateBlend and in HLMS implementation the flag was not udpated after applying the strong blendblock rules.