### PR TITLE
PBS: honour non-sRGB colour targets in the pass hash

### DIFF
--- a/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
@@ -1848,7 +1848,21 @@ namespace Ogre
 
         const RenderSystemCapabilities *capabilities = mRenderSystem->getCapabilities();
         setProperty( kNoTid, PbsProperty::HwGammaRead, capabilities->hasCapability( RSC_HW_GAMMA ) );
-        setProperty( kNoTid, PbsProperty::HwGammaWrite, 1 );
+        {
+            // Honour non-sRGB colour targets: without hardware gamma on write the
+            // shader must gamma-encode the linear lighting result itself (the
+            // !hw_gamma_write template path), otherwise PBS output lands raw in a
+            // UNORM target and displays crushed/dark.
+            bool hwGammaWrite = true;
+            const RenderPassDescriptor *colourPassDesc = mRenderSystem->getCurrentPassDescriptor();
+            if( colourPassDesc && colourPassDesc->getNumColourEntries() > 0u &&
+                colourPassDesc->mColour[0].texture )
+            {
+                hwGammaWrite = PixelFormatGpuUtils::isSRgb(
+                    colourPassDesc->mColour[0].texture->getPixelFormat() );
+            }
+            setProperty( kNoTid, PbsProperty::HwGammaWrite, hwGammaWrite ? 1 : 0 );
+        }
         retVal.setProperties = mT[kNoTid].setProperties;
 
         CamerasInProgress cameras = sceneManager->getCamerasInProgress();

--- a/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
+++ b/Components/Hlms/Pbs/src/OgreHlmsPbs.cpp
@@ -1858,8 +1858,8 @@ namespace Ogre
             if( colourPassDesc && colourPassDesc->getNumColourEntries() > 0u &&
                 colourPassDesc->mColour[0].texture )
             {
-                hwGammaWrite = PixelFormatGpuUtils::isSRgb(
-                    colourPassDesc->mColour[0].texture->getPixelFormat() );
+                hwGammaWrite =
+                    PixelFormatGpuUtils::isSRgb( colourPassDesc->mColour[0].texture->getPixelFormat() );
             }
             setProperty( kNoTid, PbsProperty::HwGammaWrite, hwGammaWrite ? 1 : 0 );
         }


### PR DESCRIPTION
### What

`HlmsPbs::preparePassHash` hardcodes `hw_gamma_write=1`, assuming the colour target is always sRGB. When an app renders to a **UNORM (non-sRGB) swapchain**, PBS writes its linear lighting result raw into the target, and the image displays gamma-crushed — a mid-albedo surface under the zenith sun reads ~0.03 instead of ~0.5, and night/indoor scenes collapse to black.

This PR derives the property from the live pass descriptor instead: if the first colour target's format is sRGB, hardware conversion is used exactly as today; otherwise `hw_gamma_write` is 0 and the **existing** `!hw_gamma_write` template path gamma-encodes in the shader — that path was already written for this case but was unreachable with the hardcoded property.

### Why not just use an sRGB swapchain?

Engines mixing PBS 3D with byte-exact 2D/UI pipelines (or matching a legacy renderer pixel-for-pixel) legitimately run UNORM swapchains. The template code says this configuration was meant to work; only the pass-hash property disagreed.

### How tested

macOS 15 / Apple Silicon, Metal RS, static build via vcpkg at master ef2e8f35c: measured readback of a mid-grey PBS reference under a known directional light on a UNORM swapchain — ~0.19 before, ~0.43 after (the sqrt-encode expectation); sRGB-target rendering byte-identical before/after (property still 1 there). Soaked through an engine's full desktop suite (789 green) including an Hlms-Unlit 2D parity pixel test that stays byte-identical.