### PR TITLE
NULL: fix uninitialised Window pointer read in getDepthBufferFor

### DIFF
--- a/RenderSystems/NULL/include/OgreNULLTextureGpu.h
+++ b/RenderSystems/NULL/include/OgreNULLTextureGpu.h
@@ -86,6 +86,22 @@ namespace Ogre
         PixelFormatGpu getDesiredDepthBufferFormat() const override;
     };
 
+    /// A RenderWindow-specific texture. Its only job over the base class is to
+    /// answer the "Window" custom attribute, which RenderSystem::getDepthBufferFor
+    /// relies on for every render-window-specific colour target.
+    class _OgreNULLExport NULLTextureGpuWindow final : public NULLTextureGpuRenderTarget
+    {
+        Window *mWindow;
+
+    public:
+        NULLTextureGpuWindow( GpuPageOutStrategy::GpuPageOutStrategy pageOutStrategy,
+                              VaoManager *vaoManager, IdString name, uint32 textureFlags,
+                              TextureTypes::TextureTypes initialType, TextureGpuManager *textureManager,
+                              Window *window );
+
+        void getCustomAttribute( IdString name, void *pData ) override;
+    };
+
     /** @} */
     /** @} */
 }  // namespace Ogre

--- a/RenderSystems/NULL/include/OgreNULLTextureGpuManager.h
+++ b/RenderSystems/NULL/include/OgreNULLTextureGpuManager.h
@@ -64,7 +64,7 @@ namespace Ogre
         NULLTextureGpuManager( VaoManager *vaoManager, RenderSystem *renderSystem );
         ~NULLTextureGpuManager() override;
 
-        TextureGpu *createTextureGpuWindow();
+        TextureGpu *createTextureGpuWindow( Window *window );
     };
 
     /** @} */

--- a/RenderSystems/NULL/src/OgreNULLTextureGpu.cpp
+++ b/RenderSystems/NULL/src/OgreNULLTextureGpu.cpp
@@ -102,4 +102,23 @@ namespace Ogre
     {
         return mDesiredDepthBufferFormat;
     }
+    //-----------------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------------
+    NULLTextureGpuWindow::NULLTextureGpuWindow( GpuPageOutStrategy::GpuPageOutStrategy pageOutStrategy,
+                                                VaoManager *vaoManager, IdString name,
+                                                uint32 textureFlags,
+                                                TextureTypes::TextureTypes initialType,
+                                                TextureGpuManager *textureManager, Window *window ) :
+        NULLTextureGpuRenderTarget( pageOutStrategy, vaoManager, name, textureFlags, initialType,
+                                    textureManager ),
+        mWindow( window )
+    {
+    }
+    //-----------------------------------------------------------------------------------
+    void NULLTextureGpuWindow::getCustomAttribute( IdString name, void *pData )
+    {
+        if( name == "Window" )
+            *static_cast<Window **>( pData ) = mWindow;
+    }
 }  // namespace Ogre

--- a/RenderSystems/NULL/src/OgreNULLTextureGpuManager.cpp
+++ b/RenderSystems/NULL/src/OgreNULLTextureGpuManager.cpp
@@ -45,13 +45,13 @@ namespace Ogre
     //-----------------------------------------------------------------------------------
     NULLTextureGpuManager::~NULLTextureGpuManager() { destroyAll(); }
     //-----------------------------------------------------------------------------------
-    TextureGpu *NULLTextureGpuManager::createTextureGpuWindow()
+    TextureGpu *NULLTextureGpuManager::createTextureGpuWindow( Window *window )
     {
-        return OGRE_NEW NULLTextureGpuRenderTarget(
-            GpuPageOutStrategy::Discard, mVaoManager, "RenderWindow",
-            TextureFlags::NotTexture | TextureFlags::RenderToTexture |
-                TextureFlags::RenderWindowSpecific | TextureFlags::DiscardableContent,
-            TextureTypes::Type2D, this );
+        return OGRE_NEW NULLTextureGpuWindow( GpuPageOutStrategy::Discard, mVaoManager, "RenderWindow",
+                                              TextureFlags::NotTexture | TextureFlags::RenderToTexture |
+                                                  TextureFlags::RenderWindowSpecific |
+                                                  TextureFlags::DiscardableContent,
+                                              TextureTypes::Type2D, this, window );
     }
     //-----------------------------------------------------------------------------------
     TextureGpu *NULLTextureGpuManager::createTextureImpl(

--- a/RenderSystems/NULL/src/OgreNULLWindow.cpp
+++ b/RenderSystems/NULL/src/OgreNULLWindow.cpp
@@ -95,8 +95,8 @@ namespace Ogre
         NULLTextureGpuManager *textureManager =
             static_cast<NULLTextureGpuManager *>( textureGpuManager );
 
-        mTexture = textureManager->createTextureGpuWindow();
-        mDepthBuffer = textureManager->createTextureGpuWindow();
+        mTexture = textureManager->createTextureGpuWindow( this );
+        mDepthBuffer = textureManager->createTextureGpuWindow( this );
         mStencilBuffer = mDepthBuffer;
 
         setFinalResolution( mRequestedWidth, mRequestedHeight );


### PR DESCRIPTION
`RenderSystem::getDepthBufferFor()` reads an uninitialised `Window *` for every render-window pass under the NULL render system:

```cpp
if( colourTexture->isRenderWindowSpecific() )
{
    Window *window;                                       // uninitialised
    colourTexture->getCustomAttribute( "Window", &window );
    return window->getDepthBuffer();
}
```

`NULLWindow::_initialize` creates its colour texture with `TextureFlags::RenderWindowSpecific`, so the branch is taken — but no NULL texture class overrides `getCustomAttribute`, and `TextureGpu`'s base implementation is an empty no-op:

```cpp
virtual void getCustomAttribute( IdString name, void *pData ) {}
```

The call therefore writes nothing, `window` keeps whatever the stack slot held, and the next line dereferences it.

### Why it matters

This is not a cosmetic gap. Whether it crashes depends entirely on what happened to be on the stack: a Debug build can wander through and hand back a garbage `TextureGpu *` that a compositor pass then uses, and a Release build of the same code segfaults (`EXC_BAD_ACCESS`). Anyone using the NULL RS for a headless/CI run hits it at the first pass targeting the window, in a build configuration where they cannot see why.

Instrumented against master (the probe starts the local at a known poison value instead of relying on stack luck, and is otherwise a verbatim copy of what `getDepthBufferFor` does):

```
colour texture isRenderWindowSpecific = 1
getCustomAttribute("Window") -> 0xdeadbeef (window is 0x106640730)
getDepthBufferFor -> 0xd29f6f2a9a890149 (window->getDepthBuffer() is 0x10664bb90)
```

The returned "depth buffer" is a value read out of unrelated memory.

### The change

Add `NULLTextureGpuWindow`, whose only job is to answer that attribute — the NULL twin of `MetalTextureGpuWindow`, `VulkanTextureGpuWindow`, `D3D11TextureGpuWindow` and `GL3PlusTextureGpuWindow`, which all exist for exactly this — and pass the window to `createTextureGpuWindow()` the way the other render systems already do.

Nothing else needed changing: `NULLWindow::_initialize` has been creating a real `mDepthBuffer` all along, so once the attribute is answered the lookup returns the window's own depth buffer.

### Verification

macOS 15 / Apple Silicon, clang, `RenderSystem_NULL` + `OgreNextMain` built static in Debug (the same probe as above, now checking the results instead of just printing them):

* before — `getCustomAttribute` leaves the caller's pointer untouched, `getDepthBufferFor` returns a value read from an unrelated address;
* after — `getCustomAttribute("Window")` returns the window, and `getDepthBufferFor` returns exactly `window->getDepthBuffer()`.

Found while making the Ogre-Next backend of [orkige](https://github.com/orkitec/orkige) run window-less and GPU-less for CI, which is the first thing that asked the NULL RS to service a render-window pass. There the Debug build happened to survive on a dereferenceable stack slot and the Release build of the same scene segfaulted at `0x28` — which is how this was tracked down.
