### PR TITLE
NULL: never name a Vao 0 (RenderQueue's reserved value)

### DIFF
--- a/RenderSystems/NULL/include/Vao/OgreNULLVaoManager.h
+++ b/RenderSystems/NULL/include/Vao/OgreNULLVaoManager.h
@@ -129,6 +129,10 @@ namespace Ogre
 
         VaoVec mVaos;
 
+        /// 0 is reserved by RenderQueue as "no Vao bound", so names start at 1.
+        /// Monotonic: a name is never reused, not even after the Vao is destroyed.
+        uint32 mVaoNames;
+
         VertexBufferPacked *mDrawId;
 
     protected:

--- a/RenderSystems/NULL/src/Vao/OgreNULLVaoManager.cpp
+++ b/RenderSystems/NULL/src/Vao/OgreNULLVaoManager.cpp
@@ -45,7 +45,7 @@ THE SOFTWARE.
 
 namespace Ogre
 {
-    NULLVaoManager::NULLVaoManager() : VaoManager( 0 ), mDrawId( 0 )
+    NULLVaoManager::NULLVaoManager() : VaoManager( 0 ), mVaoNames( 1u ), mDrawId( 0 )
     {
         mConstBufferAlignment = 256;
         mTexBufferAlignment = 256;
@@ -290,7 +290,7 @@ namespace Ogre
         const VertexBufferPackedVec &vertexBuffers, IndexBufferPacked *indexBuffer,
         OperationType opType )
     {
-        uint32 idx = (uint32)mVertexArrayObjects.size();
+        uint32 idx = mVaoNames++;
 
         const uint32 bitsOpType = 3;
         const uint32 bitsVaoGl = 2;


### PR DESCRIPTION
`NULLVaoManager::createVertexArrayObjectImpl` names each new Vao after the size of the base class's live-Vao set:

```cpp
uint32 idx = (uint32)mVertexArrayObjects.size();
```

Two things follow from that.

**The first Vao is named 0**, which is `RenderQueue`'s reserved "no Vao bound yet" value, so the first draw call trips

```cpp
OGRE_ASSERT_MEDIUM( vao->getVaoName() != 0u &&
                    "Invalid Vao name! This can happen if a BT_IMMUTABLE buffer was "
                    "recently created and VaoManager::_beginFrame() wasn't called" );
```

in `RenderQueue::renderGL3`/`renderES2` and aborts every Debug build — with a message that points at an unrelated cause.

**Names are reused.** `mVertexArrayObjects` holds the *live* Vaos, so destroying one and creating another hands the new one a name a still-live Vao already holds. `RenderQueue`'s `lastVaoName` check then skips the `CbVao` command between two different Vaos, which is exactly the batching decision a NULL-RS run is usually there to measure.

Both are visible on master:

```
vao[0] name = 0
vao[1] name = 1
vao[2] name = 2
vao after a destroy = 2 (still-live vao[2] = 2)
```

### The change

Use a monotonic counter starting at 1, which is what `MetalVaoManager` and `VulkanVaoManager` already do (`mVaoNames( 1 )` in both constructors).

### Verification

macOS 15 / Apple Silicon, clang, `RenderSystem_NULL` + `OgreNextMain` built static in Debug:

```
vao[0] name = 1
vao[1] name = 2
vao[2] name = 3
vao after a destroy = 4 (still-live vao[2] = 3)
```

No Vao is named 0, and no two live Vaos share a name.

Found while making the Ogre-Next backend of [orkige](https://github.com/orkitec/orkige) run window-less and GPU-less for CI: the Debug run aborted on the assert above at the first draw call (SIGTRAP, exit 133). The workaround there was to park one Vao alive from boot so every real one landed at 1 or above — which is the shape of this fix, done properly.
