### PR TITLE
NULL: create a GpuProgramManager, so material scripts can be parsed

### DIFF
--- a/RenderSystems/NULL/include/OgreNULLGpuProgramManager.h
+++ b/RenderSystems/NULL/include/OgreNULLGpuProgramManager.h
@@ -1,0 +1,62 @@
+/*
+-----------------------------------------------------------------------------
+This source file is part of OGRE-Next
+    (Object-oriented Graphics Rendering Engine)
+For the latest info, see http://www.ogre3d.org/
+
+Copyright (c) 2000-2017 Torus Knot Software Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------
+*/
+
+#ifndef _OgreNULLGpuProgramManager_H_
+#define _OgreNULLGpuProgramManager_H_
+
+#include "OgreNULLPrerequisites.h"
+
+#include "OgreGpuProgramManager.h"
+
+namespace Ogre
+{
+    /** Dummy GpuProgramManager, so that scripts declaring low level programs can be
+        parsed instead of asserting on a missing singleton.
+
+        Every program it hands out is inert: it holds no microcode, compiles nothing
+        and reports isSupported() == false, since there is no GPU to compile for.
+    */
+    class _OgreNULLExport NULLGpuProgramManager final : public GpuProgramManager
+    {
+    protected:
+        /// @copydoc ResourceManager::createImpl
+        Resource *createImpl( const String &name, ResourceHandle handle, const String &group,
+                              bool isManual, ManualResourceLoader *loader,
+                              const NameValuePairList *createParams ) override;
+        /// Specialised create method with specific parameters
+        Resource *createImpl( const String &name, ResourceHandle handle, const String &group,
+                              bool isManual, ManualResourceLoader *loader, GpuProgramType gptype,
+                              const String &syntaxCode ) override;
+
+    public:
+        NULLGpuProgramManager();
+        ~NULLGpuProgramManager() override;
+    };
+}  // namespace Ogre
+
+#endif

--- a/RenderSystems/NULL/include/OgreNULLPrerequisites.h
+++ b/RenderSystems/NULL/include/OgreNULLPrerequisites.h
@@ -35,6 +35,7 @@ THE SOFTWARE.
 namespace Ogre
 {
     // Forward declarations
+    class NULLGpuProgramManager;
     class NULLStagingBuffer;
     class NULLRenderSystem;
     class NULLVaoManager;

--- a/RenderSystems/NULL/include/OgreNULLRenderSystem.h
+++ b/RenderSystems/NULL/include/OgreNULLRenderSystem.h
@@ -59,6 +59,7 @@ namespace Ogre
         bool mInitialized;
 
         v1::HardwareBufferManager *mHardwareBufferManager;
+        NULLGpuProgramManager     *mShaderManager;
 
         ConfigOptionMap mOptions;
 

--- a/RenderSystems/NULL/src/OgreNULLGpuProgramManager.cpp
+++ b/RenderSystems/NULL/src/OgreNULLGpuProgramManager.cpp
@@ -1,0 +1,97 @@
+/*
+-----------------------------------------------------------------------------
+This source file is part of OGRE-Next
+    (Object-oriented Graphics Rendering Engine)
+For the latest info, see http://www.ogre3d.org/
+
+Copyright (c) 2000-2017 Torus Knot Software Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-----------------------------------------------------------------------------
+*/
+
+#include "OgreNULLGpuProgramManager.h"
+
+#include "OgreGpuProgram.h"
+#include "OgreResourceGroupManager.h"
+
+namespace Ogre
+{
+    /// The low level counterpart of OgreMain's NullProgram: it exists so a script can
+    /// declare a program, and does nothing else.
+    class NULLGpuProgram final : public GpuProgram
+    {
+    protected:
+        void loadFromSource() override {}
+        void unloadImpl() override {}
+
+    public:
+        NULLGpuProgram( ResourceManager *creator, const String &name, ResourceHandle handle,
+                        const String &group, bool isManual, ManualResourceLoader *loader ) :
+            GpuProgram( creator, name, handle, group, isManual, loader )
+        {
+        }
+        ~NULLGpuProgram() override {}
+
+        /// Overridden from GpuProgram - never supported, nothing was compiled
+        bool isSupported() const override { return false; }
+
+        size_t calculateSize() const override { return 0; }
+
+        /// Overridden from StringInterface
+        bool setParameter( const String & /*name*/, const String & /*value*/ ) override
+        {
+            // always silently ignore all parameters so as not to report errors on
+            // unsupported platforms
+            return true;
+        }
+    };
+    //-----------------------------------------------------------------------------
+    NULLGpuProgramManager::NULLGpuProgramManager() : GpuProgramManager()
+    {
+        // Superclass sets up members
+
+        // Register with resource group manager
+        ResourceGroupManager::getSingleton()._registerResourceManager( mResourceType, this );
+    }
+    //-----------------------------------------------------------------------------
+    NULLGpuProgramManager::~NULLGpuProgramManager()
+    {
+        // Unregister with resource group manager
+        ResourceGroupManager::getSingleton()._unregisterResourceManager( mResourceType );
+    }
+    //-----------------------------------------------------------------------------
+    Resource *NULLGpuProgramManager::createImpl( const String &name, ResourceHandle handle,
+                                                 const String &group, bool isManual,
+                                                 ManualResourceLoader *loader,
+                                                 const NameValuePairList * )
+    {
+        // The declaration is accepted whatever it says: syntax and type only matter to a
+        // compiler, and there is none
+        return new NULLGpuProgram( this, name, handle, group, isManual, loader );
+    }
+    //-----------------------------------------------------------------------------
+    Resource *NULLGpuProgramManager::createImpl( const String &name, ResourceHandle handle,
+                                                 const String &group, bool isManual,
+                                                 ManualResourceLoader *loader, GpuProgramType,
+                                                 const String & )
+    {
+        return new NULLGpuProgram( this, name, handle, group, isManual, loader );
+    }
+}  // namespace Ogre

--- a/RenderSystems/NULL/src/OgreNULLRenderSystem.cpp
+++ b/RenderSystems/NULL/src/OgreNULLRenderSystem.cpp
@@ -29,6 +29,7 @@ Copyright (c) 2000-2014 Torus Knot Software Ltd
 #include "OgreNULLRenderSystem.h"
 
 #include "OgreDefaultHardwareBufferManager.h"
+#include "OgreNULLGpuProgramManager.h"
 #include "OgreNULLTextureGpuManager.h"
 #include "OgreNULLWindow.h"
 #include "OgreRenderPassDescriptor.h"
@@ -40,7 +41,8 @@ namespace Ogre
     NULLRenderSystem::NULLRenderSystem() :
         RenderSystem(),
         mInitialized( false ),
-        mHardwareBufferManager( 0 )
+        mHardwareBufferManager( 0 ),
+        mShaderManager( 0 )
     {
     }
     //-------------------------------------------------------------------------
@@ -50,6 +52,9 @@ namespace Ogre
     {
         OGRE_DELETE mHardwareBufferManager;
         mHardwareBufferManager = 0;
+
+        OGRE_DELETE mShaderManager;
+        mShaderManager = 0;
     }
     //-------------------------------------------------------------------------
     const String &NULLRenderSystem::getName() const
@@ -143,6 +148,7 @@ namespace Ogre
             mHardwareBufferManager = new v1::DefaultHardwareBufferManager();
             mVaoManager = OGRE_NEW NULLVaoManager();
             mTextureGpuManager = OGRE_NEW NULLTextureGpuManager( mVaoManager, this );
+            mShaderManager = OGRE_NEW NULLGpuProgramManager();
 
             mInitialized = true;
         }


### PR DESCRIPTION
Fixes #589. Under `RenderSystem_NULL` there is no `GpuProgramManager`, so parsing
any `.material` or `.program` script aborts:

```
Assertion failed: (msSingleton), function getSingleton,
  file OgreGpuProgramManager.cpp, line 52
```

`NULLRenderSystem::_createRenderWindow` creates the HardwareBuffer, Vao and
TextureGpu managers, and nothing creates a `GpuProgramManager`, so `msSingleton`
stays null for the whole process lifetime.

This is option 1 from the issue, held to the condition you set there: worth having
only if it stays small in RAM and in maintenance.

### The change

`NULLGpuProgramManager` is created beside the other managers in
`_createRenderWindow` and destroyed in `shutdown()`. Metal and Vulkan create
theirs in `initialiseFromRenderSystemCapabilities`; NULL's implementation of that
hook is empty and nothing calls it, so the managers' own creation site is the
equivalent place.

It has no members. Both `createImpl` overloads return a `NULLGpuProgram` with no
branch in between, because type and syntax code only matter to a compiler and
there is none. `NULLGpuProgram` is the low level counterpart of the `NullProgram`
OgreMain already carries for high level programs in an unregistered language, and
it is the same handful of lines:

```cpp
void   loadFromSource() override {}
void   unloadImpl() override {}
bool   isSupported() const override { return false; }
size_t calculateSize() const override { return 0; }
bool   setParameter( const String &, const String & ) override { return true; }
```

That is the entire implementation. The two new files are 62 and 97 lines
including the license header; wiring them into the render system is 7 lines.

### Why it stays small

- **No state.** No program factory map, no microcode, no device handle, no
  syntax registry. `D3D11GpuProgramManager` has exactly this shape today
  (`D3D11UnsupportedGpuProgram`, "D3D11 doesn't support assembly shaders").
- **Nothing to keep in sync.** It holds no opinion about shader stages, root
  layouts, syntax codes or capabilities, so a change anywhere else cannot make it
  stale or wrong. There is no code path in it that a future feature has to teach.
- **RAM.** One small `GpuProgram` per declared program, and nothing else. NULL
  advertises no shader profiles, so `isSyntaxSupported()` is false, the compiler
  takes the road it already takes for a program meant for another render system,
  and the program is never loaded: its source is not read from disk, and
  `calculateSize()` reports 0.

### Nothing starts pretending to work

Each declaration is reported as unsupported by the render system, the same way a
D3D11 program is reported under GL:

```
Compiler error: object unsupported by render system in probe.program(1): , Shader name: ProbeVertexProgram
```

and a material built on such programs is honest about what it became:

```
WARNING: material ProbeMaterial has no supportable Techniques and will be blank. Explanation:
Pass 0: Vertex program ProbeVertexProgram cannot be used - not supported.
```

`isSupported()` is overridden rather than left to the syntax lookup, so that
answer does not depend on what the NULL capabilities happen to advertise later.

If you would rather have the honest refusal (option 2 in the issue) instead, say
so and I will send that one; which of the two to carry is your call.

### Verification

macOS 15 / Apple Silicon, clang, Ninja. `RenderSystem_NULL` and `OgreNextMain`
built static in Debug from this branch, and a standalone probe linked against them
booted `Root` with `NULLPlugin`, created a render window through
`Root::createRenderWindow`, added a resource location holding one `.program` (two
`asm` declarations) and one `.material` referencing both, and called
`initialiseAllResourceGroups`.

Baseline master, same probe, same media:

```
GpuProgramManager::getSingletonPtr() = 0x0
Parsing script probe.program
Assertion failed: (msSingleton), function getSingleton, file OgreGpuProgramManager.cpp, line 52.
```

SIGABRT, exit 134. With this branch:

```
GpuProgramManager::getSingletonPtr() = 0x101a95ff0
Compiler error: object unsupported by render system in probe.program(1): , Shader name: ProbeVertexProgram
Compiler error: object unsupported by render system in probe.program(7): , Shader name: ProbeFragmentProgram
scripts parsed
ProbeVertexProgram = 0x101a9d820
  isSupported = 0, calculateSize = 0, hasCompileError = 0
ProbeMaterial = 0x101a9cf60
  supported techniques = 0
PROBE PASSED (0)
```

Exit 0, and the shutdown is clean.

Not covered: the Ogre-Next sample and test suites were not run, and this was built
for macOS with clang only. Nothing outside `RenderSystems/NULL` is touched.

Encountered while making the Ogre-Next backend of
[orkige](https://github.com/orkitec/orkige) run window-less and GPU-less for CI;
the media that triggered it was the AtmosphereNpr sky's own `.material`/`.program`
pair, which the engine now skips registering when it boots deviceless.
